### PR TITLE
Refine annotation-based commands

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -17,3 +17,17 @@
 16. Улучшенная работа с файлами и медиапотоками
 17. Поддерживаются базы данных: H2, PostgreSQL, MySQL, Oracle (без JDBC-драйвера)
 18. Токен бота хранится в зашифрованном виде (ключ для шифрования передаётся в `TokenCipher`)
+
+This project is licensed under the MIT License.
+
+### Пример аннотационного хендлера
+```java
+public class MyHandlers {
+    @BotCommandHandler(type = BotRequestType.MESSAGE)
+    @TextMatch("/start")
+    public BotResponse start(BotRequest<Message> req) {
+        // логика команды
+        return null;
+    }
+}
+```

--- a/core/src/main/java/io/lonmstalker/core/annotation/AnnotatedBotCommand.java
+++ b/core/src/main/java/io/lonmstalker/core/annotation/AnnotatedBotCommand.java
@@ -1,0 +1,73 @@
+package io.lonmstalker.core.annotation;
+
+import io.lonmstalker.core.BotCommand;
+import io.lonmstalker.core.BotInfo;
+import io.lonmstalker.core.BotRequest;
+import io.lonmstalker.core.BotRequestType;
+import io.lonmstalker.core.BotResponse;
+import io.lonmstalker.core.BotRequestConverter;
+import io.lonmstalker.core.storage.BotRequestHolder;
+import io.lonmstalker.core.user.BotUserInfo;
+import io.lonmstalker.core.user.BotUserProvider;
+import io.lonmstalker.core.matching.CommandMatch;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import io.lonmstalker.core.exception.BotApiException;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * Command created from annotated method.
+ */
+@Slf4j
+@Builder
+public class AnnotatedBotCommand implements BotCommand<BotApiObject> {
+
+    private final Object handler;
+    private final Method method;
+    private final BotRequestConverter<?> converter;
+    private final CommandMatch<BotApiObject> matcher;
+    private final BotRequestType type;
+    private final int order;
+    private final BotUserProvider userProvider;
+
+
+    @Override
+    public @NonNull BotResponse handle(@NonNull BotRequest<BotApiObject> request) {
+        try {
+            Update update = BotRequestHolder.getUpdate();
+            Object data = converter.convert(update, type);
+            BotUserInfo user = userProvider.resolve(update);
+            BotInfo info = new BotInfo(request.botInfo().botId(), BotRequestHolder.getSender());
+            BotRequest<Object> newReq = new BotRequest<>(update.getUpdateId(), data, info, user);
+            BotResponse resp = (BotResponse) method.invoke(handler, newReq);
+            if (resp == null) {
+                log.debug("Handler {} returned null", method.getName());
+                return new BotResponse();
+            }
+            return resp;
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            log.error("Failed to invoke handler method", e);
+            throw new BotApiException(e);
+        }
+    }
+
+    @Override
+    public @NonNull BotRequestType type() {
+        return type;
+    }
+
+    @Override
+    public @NonNull CommandMatch<BotApiObject> matcher() {
+        return matcher;
+    }
+
+    @Override
+    public int order() {
+        return order;
+    }
+}

--- a/core/src/main/java/io/lonmstalker/core/annotation/AnnotationCommandLoader.java
+++ b/core/src/main/java/io/lonmstalker/core/annotation/AnnotationCommandLoader.java
@@ -1,0 +1,137 @@
+package io.lonmstalker.core.annotation;
+
+import io.lonmstalker.core.BotCommand;
+import io.lonmstalker.core.BotRequestType;
+import io.lonmstalker.core.BotRequestConverter;
+import io.lonmstalker.core.bot.BotCommandRegistry;
+import io.lonmstalker.core.matching.AndMatch;
+import io.lonmstalker.core.matching.CommandMatch;
+import io.lonmstalker.core.matching.MessageContainsMatch;
+import io.lonmstalker.core.matching.MessageRegexMatch;
+import io.lonmstalker.core.matching.MessageTextMatch;
+import io.lonmstalker.core.matching.UserRoleMatch;
+import io.lonmstalker.core.user.BotUserProvider;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import lombok.NonNull;
+import io.lonmstalker.core.exception.BotApiException;
+import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
+import io.lonmstalker.core.annotation.EnumValueConverter;
+import io.lonmstalker.core.annotation.AnnotatedBotCommand;
+
+/**
+ * Loader that registers commands defined via annotations.
+ */
+public class AnnotationCommandLoader {
+    private final BotCommandRegistry registry;
+    private final BotUserProvider userProvider;
+
+    public AnnotationCommandLoader(@NonNull BotCommandRegistry registry,
+                                   @NonNull BotUserProvider userProvider) {
+        this.registry = registry;
+        this.userProvider = userProvider;
+    }
+
+    /**
+     * Scan and register annotated methods of the given handler instance.
+     */
+    public void load(@NonNull Object handler) {
+        for (Method method : handler.getClass().getDeclaredMethods()) {
+            BotCommandHandler ann = method.getAnnotation(BotCommandHandler.class);
+            if (ann == null) {
+                continue;
+            }
+            method.setAccessible(true);
+            registry.add(createCommand(handler, method, ann));
+        }
+    }
+
+    private BotCommand<BotApiObject> createCommand(Object handler, Method method, BotCommandHandler ann) {
+        CommandMatch<BotApiObject> matcher = buildMatcher(method, ann);
+        BotRequestConverter<?> converter = determineConverter(method, ann);
+        BotRequestType type = ann.type();
+        int order = ann.order();
+        return AnnotatedBotCommand.builder()
+                .handler(handler)
+                .method(method)
+                .converter(converter)
+                .matcher(matcher)
+                .type(type)
+                .order(order)
+                .userProvider(userProvider)
+                .build();
+    }
+
+    private CommandMatch<BotApiObject> buildMatcher(Method method, BotCommandHandler ann) {
+        List<CommandMatch<BotApiObject>> matches = new ArrayList<>();
+        TextMatch text = method.getAnnotation(TextMatch.class);
+        if (text != null) {
+            matches.add((CommandMatch) new MessageTextMatch(text.value(), text.ignoreCase()));
+        }
+        RegexMatch regex = method.getAnnotation(RegexMatch.class);
+        if (regex != null) {
+            matches.add((CommandMatch) new MessageRegexMatch(regex.value()));
+        }
+        ContainsMatch contains = method.getAnnotation(ContainsMatch.class);
+        if (contains != null) {
+            matches.add((CommandMatch) new MessageContainsMatch(contains.value(), contains.ignoreCase()));
+        }
+        UserRoleMatch roles = method.getAnnotation(UserRoleMatch.class);
+        if (roles != null) {
+            matches.add((CommandMatch) new UserRoleMatch(userProvider, Set.of(roles.value())));
+        }
+        for (Class<? extends CommandMatch<?>> cls : ann.customMatchers()) {
+            matches.add(instantiateMatcher(cls));
+        }
+        if (matches.isEmpty()) {
+            throw new BotApiException("No matchers defined for method " + method.getName());
+        }
+        return new AndMatch<>(matches);
+    }
+
+    private CommandMatch<BotApiObject> instantiateMatcher(Class<? extends CommandMatch<?>> cls) {
+        try {
+            return (CommandMatch<BotApiObject>) cls.getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            throw new BotApiException("Cannot instantiate matcher: " + cls, e);
+        }
+    }
+
+    private BotRequestConverter<?> determineConverter(Method method, BotCommandHandler ann) {
+        Class<? extends BotRequestConverter<?>> cls = ann.converter();
+        if (cls == BotRequestConverterImpl.class) {
+            Class<?> dataClass = extractDataClass(method);
+            if (dataClass.isEnum()) {
+                return new EnumValueConverter(dataClass.asSubclass(Enum.class));
+            }
+            return new BotRequestConverterImpl();
+        }
+        return instantiateConverter(cls);
+    }
+
+    private BotRequestConverter<?> instantiateConverter(Class<? extends BotRequestConverter<?>> cls) {
+        try {
+            return cls.getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            throw new BotApiException("Cannot instantiate converter: " + cls, e);
+        }
+    }
+
+    private Class<?> extractDataClass(Method method) {
+        if (method.getParameterCount() == 0) {
+            return BotApiObject.class;
+        }
+        Type type = method.getGenericParameterTypes()[0];
+        if (type instanceof ParameterizedType pt) {
+            Type arg = pt.getActualTypeArguments()[0];
+            if (arg instanceof Class<?> c) {
+                return c;
+            }
+        }
+        return BotApiObject.class;
+    }
+}

--- a/core/src/main/java/io/lonmstalker/core/annotation/BotCommandHandler.java
+++ b/core/src/main/java/io/lonmstalker/core/annotation/BotCommandHandler.java
@@ -1,0 +1,20 @@
+package io.lonmstalker.core.annotation;
+
+import io.lonmstalker.core.BotCommandOrder;
+import io.lonmstalker.core.BotRequestType;
+import io.lonmstalker.core.BotRequestConverter;
+import io.lonmstalker.core.bot.BotRequestConverterImpl;
+import io.lonmstalker.core.matching.CommandMatch;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface BotCommandHandler {
+    BotRequestType type();
+    int order() default BotCommandOrder.LAST;
+    Class<? extends CommandMatch<?>>[] customMatchers() default {};
+    Class<? extends BotRequestConverter<?>> converter() default BotRequestConverterImpl.class;
+}

--- a/core/src/main/java/io/lonmstalker/core/annotation/ContainsMatch.java
+++ b/core/src/main/java/io/lonmstalker/core/annotation/ContainsMatch.java
@@ -1,0 +1,13 @@
+package io.lonmstalker.core.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface ContainsMatch {
+    String value();
+    boolean ignoreCase() default false;
+}

--- a/core/src/main/java/io/lonmstalker/core/annotation/EnumValueConverter.java
+++ b/core/src/main/java/io/lonmstalker/core/annotation/EnumValueConverter.java
@@ -1,0 +1,28 @@
+package io.lonmstalker.core.annotation;
+
+import io.lonmstalker.core.BotRequestConverter;
+import io.lonmstalker.core.BotRequestType;
+import io.lonmstalker.core.exception.BotApiException;
+import lombok.NonNull;
+import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+/**
+ * Converts message text to an enum value.
+ */
+public class EnumValueConverter<E extends Enum<E>> implements BotRequestConverter<E> {
+    private final Class<E> enumType;
+
+    public EnumValueConverter(@NonNull Class<E> enumType) {
+        this.enumType = enumType;
+    }
+
+    @Override
+    public @NonNull E convert(@NonNull Update update, @NonNull BotRequestType type) {
+        Message msg = update.getMessage();
+        if (msg == null || msg.getText() == null) {
+            throw new BotApiException("No message text to convert to enum " + enumType.getSimpleName());
+        }
+        return Enum.valueOf(enumType, msg.getText());
+    }
+}

--- a/core/src/main/java/io/lonmstalker/core/annotation/RegexMatch.java
+++ b/core/src/main/java/io/lonmstalker/core/annotation/RegexMatch.java
@@ -1,0 +1,12 @@
+package io.lonmstalker.core.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface RegexMatch {
+    String value();
+}

--- a/core/src/main/java/io/lonmstalker/core/annotation/TextMatch.java
+++ b/core/src/main/java/io/lonmstalker/core/annotation/TextMatch.java
@@ -1,0 +1,13 @@
+package io.lonmstalker.core.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface TextMatch {
+    String value();
+    boolean ignoreCase() default false;
+}

--- a/core/src/main/java/io/lonmstalker/core/annotation/UserRoleMatch.java
+++ b/core/src/main/java/io/lonmstalker/core/annotation/UserRoleMatch.java
@@ -1,0 +1,12 @@
+package io.lonmstalker.core.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface UserRoleMatch {
+    String[] value();
+}

--- a/core/src/main/java/io/lonmstalker/core/bot/ImprovedBotSession.java
+++ b/core/src/main/java/io/lonmstalker/core/bot/ImprovedBotSession.java
@@ -1,4 +1,5 @@
-package io.lonmstalker.core.bot;import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+package io.lonmstalker.core.bot;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/core/src/main/java/io/lonmstalker/core/matching/AndMatch.java
+++ b/core/src/main/java/io/lonmstalker/core/matching/AndMatch.java
@@ -1,0 +1,35 @@
+package io.lonmstalker.core.matching;
+
+import java.util.List;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Combines several matchers using logical AND.
+ */
+public class AndMatch<T extends BotApiObject> implements CommandMatch<T> {
+    private static final Logger log = LoggerFactory.getLogger(AndMatch.class);
+    private final List<CommandMatch<T>> matchers;
+
+    public AndMatch(@NonNull List<CommandMatch<T>> matchers) {
+        this.matchers = List.copyOf(matchers);
+    }
+
+    @SafeVarargs
+    public AndMatch(@NonNull CommandMatch<T>... matchers) {
+        this.matchers = List.of(matchers);
+    }
+
+    @Override
+    public boolean match(@NonNull T data) {
+        for (CommandMatch<T> m : matchers) {
+            if (!m.match(data)) {
+                log.debug("AndMatch: {} failed", m.getClass().getSimpleName());
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/core/src/main/java/io/lonmstalker/core/matching/OrMatch.java
+++ b/core/src/main/java/io/lonmstalker/core/matching/OrMatch.java
@@ -1,0 +1,36 @@
+package io.lonmstalker.core.matching;
+
+import java.util.List;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Combines several matchers using logical OR.
+ */
+public class OrMatch<T extends BotApiObject> implements CommandMatch<T> {
+    private static final Logger log = LoggerFactory.getLogger(OrMatch.class);
+    private final List<CommandMatch<T>> matchers;
+
+    public OrMatch(@NonNull List<CommandMatch<T>> matchers) {
+        this.matchers = List.copyOf(matchers);
+    }
+
+    @SafeVarargs
+    public OrMatch(@NonNull CommandMatch<T>... matchers) {
+        this.matchers = List.of(matchers);
+    }
+
+    @Override
+    public boolean match(@NonNull T data) {
+        for (CommandMatch<T> m : matchers) {
+            if (m.match(data)) {
+                return true;
+            } else {
+                log.debug("OrMatch: {} failed", m.getClass().getSimpleName());
+            }
+        }
+        return false;
+    }
+}

--- a/core/src/test/java/io/lonmstalker/core/bot/CommandMatchersTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/CommandMatchersTest.java
@@ -60,6 +60,18 @@ class CommandMatchersTest {
     }
 
     @Test
+    @DisplayName("AndMatch/OrMatch")
+    void compositeMatch() {
+        Message msg = new Message();
+        msg.setText("hello");
+        CommandMatch<Message> t1 = new MessageTextMatch("hello");
+        CommandMatch<Message> t2 = new MessageContainsMatch("hell");
+        assertTrue(new AndMatch<>(t1, t2).match(msg));
+        assertTrue(new OrMatch<>(t1, new MessageTextMatch("bye")).match(msg));
+        assertFalse(new AndMatch<>(t1, new MessageTextMatch("bye")).match(msg));
+    }
+
+    @Test
     @DisplayName("UserRoleMatch")
     void userRoleMatch() {
         Update update = new Update();


### PR DESCRIPTION
## Summary
- use Lombok builder and logging in `AnnotatedBotCommand`
- throw `BotApiException` instead of `RuntimeException`
- log null handler results
- build annotated commands via builder

## Testing
- `mvn -q test` *(failed: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d9d8eb8bc8325865c45dd15ce94d5