### PR TITLE
Fix BotHandlerProcessor path and update example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@
 ...
 <annotationProcessors>
     <annotationProcessor>
-        io.lonmstalker.core.processor.BotHandlerProcessor
+        io.lonmstalker.tgkit.core.processor.BotHandlerProcessor
     </annotationProcessor>
 ...
 </plugin>
@@ -87,10 +87,11 @@ public class EchoCommands {
     }
 }
 
+BotAdapter adapter = update -> null; // логику выполняют аннотированные методы
 Bot bot = BotFactory.INSTANCE.from(
         token,
         BotConfig.builder().build(),
-        new BotAdapterImpl(bot, converter, provider),
+        adapter,
         "com.example.bot");
 bot.start();          // smart Webhook ↔︎ Polling
 

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
                             org.checkerframework.checker.nullness.NullnessChecker
                         </annotationProcessor>
                         <annotationProcessor>
-                            io.lonmstalker.core.processor.BotHandlerProcessor
+                            io.lonmstalker.tgkit.core.processor.BotHandlerProcessor
                         </annotationProcessor>
                     </annotationProcessors>
                     <compilerArgs combine.children="append">


### PR DESCRIPTION
## Summary
- use fully-qualified io.lonmstalker.tgkit.core.processor.BotHandlerProcessor
- update example in README to a working snippet

## Testing
- `mvn -q test` *(fails: Could not transfer artifact com.diffplug.spotless:spotless-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_684ec32e81c08325824e034668b593cd