### PR TITLE
Add pluggable rendering layer and security bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@
 ...
 <annotationProcessors>
     <annotationProcessor>
-        io.lonmstalker.core.processor.BotHandlerProcessor
+        io.lonmstalker.tgkit.core.processor.BotHandlerProcessor
     </annotationProcessor>
 ...
 </plugin>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -30,6 +30,11 @@
             <artifactId>reflections</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.lonmstalker.tgkit</groupId>
+            <artifactId>render-spi</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>

--- a/core/src/main/java/io/lonmstalker/tgkit/core/loader/InternalCommandAdapter.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/loader/InternalCommandAdapter.java
@@ -10,6 +10,9 @@ import io.lonmstalker.tgkit.core.annotation.Arg;
 import io.lonmstalker.tgkit.core.args.BotArgumentConverter;
 import io.lonmstalker.tgkit.core.args.Context;
 import io.lonmstalker.tgkit.core.args.RouteContextHolder;
+import io.lonmstalker.tgkit.core.storage.BotRequestHolder;
+import io.craftbot.security.SecurityBundleHolder;
+import io.craftbot.security.SecurityInterceptor;
 import io.lonmstalker.tgkit.core.matching.CommandMatch;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -36,6 +39,10 @@ class InternalCommandAdapter implements BotCommand<BotApiObject> {
     @SuppressWarnings("argument")
     public @Nullable BotResponse handle(@NonNull BotRequest<BotApiObject> request) {
         try {
+            SecurityInterceptor sec = SecurityBundleHolder.get();
+            if (sec != null) {
+                sec.handle(BotRequestHolder.getUpdateNotNull(), method);
+            }
             Object converted = converter.convert(request);
             Object[] args = new Object[params.length];
             for (int i = 0; i < params.length; i++) {

--- a/core/src/main/java/io/lonmstalker/tgkit/core/processor/BotHandlerProcessor.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/processor/BotHandlerProcessor.java
@@ -21,7 +21,7 @@ import javax.tools.Diagnostic;
 import java.util.Set;
 
 @SupportedSourceVersion(SourceVersion.RELEASE_21)
-@SupportedAnnotationTypes("io.lonmstalker.core.annotation.BotHandler")
+@SupportedAnnotationTypes("io.lonmstalker.tgkit.core.annotation.BotHandler")
 public class BotHandlerProcessor extends AbstractProcessor {
 
     @Override

--- a/observability/src/main/java/io/lonmstalker/observability/ObservabilityInterceptor.java
+++ b/observability/src/main/java/io/lonmstalker/observability/ObservabilityInterceptor.java
@@ -60,7 +60,8 @@ public class ObservabilityInterceptor implements BotInterceptor {
      * @param ex       ошибка, если возникла
      */
     public void afterCompletion(@NonNull Update update, @Nullable BotResponse response, @Nullable Exception ex) {
-        Tags tags = Tags.of(Tag.of("type", String.valueOf(update.hasMessage())));
+        String updateType = io.lonmstalker.tgkit.core.utils.UpdateUtils.getType(update).name();
+        Tags tags = Tags.of(Tag.of("type", updateType));
         Timer.Sample s = SAMPLE.get();
         if (s != null) {
             s.stop(metrics.timer("update_latency_ms", tags));

--- a/observability/src/test/java/io/lonmstaler/observability/ObservabilityInterceptorTest.java
+++ b/observability/src/test/java/io/lonmstaler/observability/ObservabilityInterceptorTest.java
@@ -18,6 +18,7 @@ import org.telegram.telegrambots.meta.api.objects.Update;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.argThat;
 
 public class ObservabilityInterceptorTest {
     private final MeterRegistry registry = new SimpleMeterRegistry();
@@ -63,8 +64,8 @@ public class ObservabilityInterceptorTest {
         interceptor.afterCompletion(update, null, null);
         verify(tracer).start(eq("update"), any(Attributes.class));
         verify(span).close();
-        verify(metrics, atLeastOnce()).counter(eq("updates_total"), any());
-        verify(metrics).timer(eq("update_latency_ms"), any());
+        verify(metrics, atLeastOnce()).counter(eq("updates_total"), argThat(t -> t.items()[0].getValue().equals("MESSAGE")));
+        verify(metrics).timer(eq("update_latency_ms"), argThat(t -> t.items()[0].getValue().equals("MESSAGE")));
         assertNull(MDC.get("updateId"));
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,9 @@
     <modules>
         <module>core</module>
         <module>observability</module>
+        <module>render-spi</module>
+        <module>tgkit-renderers-telegram</module>
+        <module>security</module>
         <module>examples</module>
     </modules>
 
@@ -175,7 +178,7 @@
                             org.checkerframework.checker.nullness.NullnessChecker
                         </annotationProcessor>
                         <annotationProcessor>
-                            io.lonmstalker.core.processor.BotHandlerProcessor
+                            io.lonmstalker.tgkit.core.processor.BotHandlerProcessor
                         </annotationProcessor>
                     </annotationProcessors>
                     <compilerArgs combine.children="append">

--- a/render-spi/pom.xml
+++ b/render-spi/pom.xml
@@ -1,0 +1,10 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.lonmstalker.tgkit</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+    <artifactId>render-spi</artifactId>
+</project>

--- a/render-spi/src/main/java/io/craftbot/render/spi/ResponseDispatcher.java
+++ b/render-spi/src/main/java/io/craftbot/render/spi/ResponseDispatcher.java
@@ -1,0 +1,37 @@
+package io.craftbot.render.spi;
+
+import io.lonmstalker.tgkit.core.BotResponse;
+import io.lonmstalker.tgkit.core.args.Context;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.ServiceLoader;
+
+public class ResponseDispatcher {
+    private final List<ResponseRenderer<?>> renderers;
+
+    public ResponseDispatcher(ClassLoader cl) {
+        this.renderers = ServiceLoader.load(ResponseRenderer.class, cl)
+                .stream()
+                .map(ServiceLoader.Provider::get)
+                .sorted(Comparator.comparingInt(ResponseRenderer::order))
+                .toList();
+    }
+
+    public BotResponse toResponse(Object obj, Context ctx) throws Exception {
+        if (obj instanceof BotResponse br) {
+            return br;
+        }
+        for (ResponseRenderer<?> r : renderers) {
+            if (r.supports(obj)) {
+                return renderUnchecked(r, obj, ctx);
+            }
+        }
+        throw new IllegalArgumentException("No renderer for " + obj.getClass());
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static BotResponse renderUnchecked(ResponseRenderer renderer, Object obj, Context ctx) throws Exception {
+        return renderer.render(obj, ctx);
+    }
+}

--- a/render-spi/src/main/java/io/craftbot/render/spi/ResponseRenderer.java
+++ b/render-spi/src/main/java/io/craftbot/render/spi/ResponseRenderer.java
@@ -1,0 +1,10 @@
+package io.craftbot.render.spi;
+
+import io.lonmstalker.tgkit.core.BotResponse;
+import io.lonmstalker.tgkit.core.args.Context;
+
+public interface ResponseRenderer<T> {
+    boolean supports(Object obj);
+    BotResponse render(T obj, Context ctx) throws Exception;
+    default int order() { return 50; }
+}

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -1,0 +1,17 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.lonmstalker.tgkit</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+    <artifactId>security-bundle</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>io.lonmstalker.tgkit</groupId>
+            <artifactId>core</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/security/src/main/java/io/craftbot/security/CaptchaGuard.java
+++ b/security/src/main/java/io/craftbot/security/CaptchaGuard.java
@@ -1,0 +1,33 @@
+package io.craftbot.security;
+
+import io.craftbot.security.spi.CaptchaChallenge;
+import io.craftbot.security.spi.CaptchaProvider;
+import io.craftbot.security.spi.StateStore;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+/** Simple guard wrapping captcha provider. */
+public class CaptchaGuard {
+    private final CaptchaProvider provider;
+    private final StateStore store;
+
+    public CaptchaGuard(CaptchaProvider provider, StateStore store) {
+        this.provider = provider;
+        this.store = store;
+    }
+
+    public void challengeOrThrow(Update update) {
+        long chat = update.getMessage().getChatId();
+        if (store.get(chat, "captchaOK") != null) {
+            return;
+        }
+        CaptchaChallenge c = provider.create(chat);
+        // Usually you would send a message; here we just throw exception
+        throw new CaptchaRequired(c);
+    }
+
+    public void onCallback(long chat, String data) {
+        if (provider.verify(chat, data)) {
+            store.set(chat, "captchaOK", "yes", 60);
+        }
+    }
+}

--- a/security/src/main/java/io/craftbot/security/CaptchaRequired.java
+++ b/security/src/main/java/io/craftbot/security/CaptchaRequired.java
@@ -1,0 +1,15 @@
+package io.craftbot.security;
+
+import io.craftbot.security.spi.CaptchaChallenge;
+
+public class CaptchaRequired extends RuntimeException {
+    private final CaptchaChallenge challenge;
+
+    public CaptchaRequired(CaptchaChallenge challenge) {
+        this.challenge = challenge;
+    }
+
+    public CaptchaChallenge challenge() {
+        return challenge;
+    }
+}

--- a/security/src/main/java/io/craftbot/security/ForbiddenException.java
+++ b/security/src/main/java/io/craftbot/security/ForbiddenException.java
@@ -1,0 +1,7 @@
+package io.craftbot.security;
+
+public class ForbiddenException extends RuntimeException {
+    public ForbiddenException(String msg) {
+        super(msg);
+    }
+}

--- a/security/src/main/java/io/craftbot/security/LimiterKey.java
+++ b/security/src/main/java/io/craftbot/security/LimiterKey.java
@@ -1,0 +1,8 @@
+package io.craftbot.security;
+
+public enum LimiterKey {
+    USER,
+    CHAT,
+    GLOBAL,
+    COMBO
+}

--- a/security/src/main/java/io/craftbot/security/RateLimit.java
+++ b/security/src/main/java/io/craftbot/security/RateLimit.java
@@ -1,0 +1,23 @@
+package io.craftbot.security;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(METHOD)
+@Repeatable(RateLimits.class)
+public @interface RateLimit {
+    LimiterKey key();
+    int permits();
+    int seconds();
+}
+
+@Retention(RUNTIME)
+@Target(METHOD)
+@interface RateLimits {
+    RateLimit[] value();
+}

--- a/security/src/main/java/io/craftbot/security/RateLimiter.java
+++ b/security/src/main/java/io/craftbot/security/RateLimiter.java
@@ -1,0 +1,16 @@
+package io.craftbot.security;
+
+import io.craftbot.security.spi.Key;
+import io.craftbot.security.spi.RateLimitBackend;
+
+public class RateLimiter {
+    private final RateLimitBackend backend;
+
+    public RateLimiter(RateLimitBackend backend) {
+        this.backend = backend;
+    }
+
+    public boolean tryAcquire(Key key, int permits, int seconds) {
+        return backend.tryAcquire(key, permits, java.time.Duration.ofSeconds(seconds));
+    }
+}

--- a/security/src/main/java/io/craftbot/security/Roles.java
+++ b/security/src/main/java/io/craftbot/security/Roles.java
@@ -1,0 +1,13 @@
+package io.craftbot.security;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface Roles {
+    String[] value();
+}

--- a/security/src/main/java/io/craftbot/security/SecurityBundle.java
+++ b/security/src/main/java/io/craftbot/security/SecurityBundle.java
@@ -1,0 +1,28 @@
+package io.craftbot.security;
+
+import io.craftbot.security.spi.CaptchaProvider;
+import io.craftbot.security.spi.RateLimitBackend;
+import io.craftbot.security.spi.RoleResolver;
+import io.craftbot.security.spi.StateStore;
+
+public record SecurityBundle(SecurityInterceptor interceptor) {
+    public static Builder builder() { return new Builder(); }
+
+    public static class Builder {
+        private RoleResolver roles;
+        private RateLimitBackend backend;
+        private CaptchaProvider captcha;
+        private StateStore store;
+
+        public Builder roles(RoleResolver r) { this.roles = r; return this; }
+        public Builder backend(RateLimitBackend b) { this.backend = b; return this; }
+        public Builder captcha(CaptchaProvider c) { this.captcha = c; return this; }
+        public Builder store(StateStore s) { this.store = s; return this; }
+
+        public SecurityBundle build() {
+            SecurityInterceptor i = new SecurityInterceptor(roles, backend, captcha, store);
+            SecurityBundleHolder.set(i);
+            return new SecurityBundle(i);
+        }
+    }
+}

--- a/security/src/main/java/io/craftbot/security/SecurityBundleHolder.java
+++ b/security/src/main/java/io/craftbot/security/SecurityBundleHolder.java
@@ -1,0 +1,15 @@
+package io.craftbot.security;
+
+public final class SecurityBundleHolder {
+    private static SecurityInterceptor interceptor;
+
+    private SecurityBundleHolder() {}
+
+    public static void set(SecurityInterceptor i) {
+        interceptor = i;
+    }
+
+    public static SecurityInterceptor get() {
+        return interceptor;
+    }
+}

--- a/security/src/main/java/io/craftbot/security/SecurityInterceptor.java
+++ b/security/src/main/java/io/craftbot/security/SecurityInterceptor.java
@@ -1,0 +1,63 @@
+package io.craftbot.security;
+
+import io.craftbot.security.spi.Key;
+import io.craftbot.security.spi.RoleResolver;
+import io.craftbot.security.spi.RateLimitBackend;
+import io.craftbot.security.spi.CaptchaProvider;
+import io.craftbot.security.spi.StateStore;
+import io.lonmstalker.tgkit.core.BotResponse;
+import io.lonmstalker.tgkit.core.interceptor.BotInterceptor;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+public class SecurityInterceptor implements BotInterceptor {
+    private final RoleResolver roles;
+    private final RateLimiter limiter;
+    private final CaptchaGuard captcha;
+
+    public SecurityInterceptor(RoleResolver roles,
+                               RateLimitBackend backend,
+                               CaptchaProvider provider,
+                               StateStore store) {
+        this.roles = roles;
+        this.limiter = new RateLimiter(backend);
+        this.captcha = new CaptchaGuard(provider, store);
+    }
+
+    @Override
+    public void preHandle(@NonNull Update update) {
+        // nothing
+    }
+
+    @Override
+    public void postHandle(@NonNull Update update) {
+        // nothing
+    }
+
+    @Override
+    public void afterCompletion(@NonNull Update update, @Nullable BotResponse response, @Nullable Exception ex) throws Exception {
+        // nothing
+    }
+
+    public void handle(Update update, java.lang.reflect.Method method) {
+        Roles rolesAnn = method.getAnnotation(Roles.class);
+        if (rolesAnn != null) {
+            long userId = update.getMessage().getFrom().getId();
+            for (String role : rolesAnn.value()) {
+                if (!roles.hasRole(userId, role)) {
+                    throw new ForbiddenException("role");
+                }
+            }
+        }
+
+        RateLimit[] rlAnn = method.getAnnotationsByType(RateLimit.class);
+        for (RateLimit rl : rlAnn) {
+            Key key = new Key(rl.key().name()+":"+update.getMessage().getFrom().getId());
+            if (!limiter.tryAcquire(key, rl.permits(), rl.seconds())) {
+                captcha.challengeOrThrow(update);
+                return;
+            }
+        }
+    }
+}

--- a/security/src/main/java/io/craftbot/security/backend/InMemoryBackend.java
+++ b/security/src/main/java/io/craftbot/security/backend/InMemoryBackend.java
@@ -1,0 +1,18 @@
+package io.craftbot.security.backend;
+
+import io.craftbot.security.spi.Key;
+import io.craftbot.security.spi.RateLimitBackend;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class InMemoryBackend implements RateLimitBackend {
+    private final Map<String, Integer> counters = new ConcurrentHashMap<>();
+
+    @Override
+    public boolean tryAcquire(Key key, int permits, Duration window) {
+        counters.merge(key.value(), 1, Integer::sum);
+        return counters.get(key.value()) <= permits;
+    }
+}

--- a/security/src/main/java/io/craftbot/security/captcha/MathCaptchaProvider.java
+++ b/security/src/main/java/io/craftbot/security/captcha/MathCaptchaProvider.java
@@ -1,0 +1,16 @@
+package io.craftbot.security.captcha;
+
+import io.craftbot.security.spi.CaptchaChallenge;
+import io.craftbot.security.spi.CaptchaProvider;
+
+public class MathCaptchaProvider implements CaptchaProvider {
+    @Override
+    public CaptchaChallenge create(long chatId) {
+        return new CaptchaChallenge("2+2?", null, null, 60);
+    }
+
+    @Override
+    public boolean verify(long chatId, String answer) {
+        return "4".equals(answer);
+    }
+}

--- a/security/src/main/java/io/craftbot/security/roles/InMemoryRoleResolver.java
+++ b/security/src/main/java/io/craftbot/security/roles/InMemoryRoleResolver.java
@@ -1,0 +1,18 @@
+package io.craftbot.security.roles;
+
+import io.craftbot.security.spi.RoleResolver;
+
+import java.util.Map;
+
+public class InMemoryRoleResolver implements RoleResolver {
+    private final Map<Long, String> roles;
+
+    public InMemoryRoleResolver(Map<Long, String> roles) {
+        this.roles = roles;
+    }
+
+    @Override
+    public boolean hasRole(long userId, String role) {
+        return role.equals(roles.get(userId));
+    }
+}

--- a/security/src/main/java/io/craftbot/security/spi/CaptchaChallenge.java
+++ b/security/src/main/java/io/craftbot/security/spi/CaptchaChallenge.java
@@ -1,0 +1,9 @@
+package io.craftbot.security.spi;
+
+import org.telegram.telegrambots.meta.api.objects.InputFile;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
+
+public record CaptchaChallenge(String message,
+                               InputFile photo,
+                               ReplyKeyboard keyboard,
+                               int ttlSeconds) {}

--- a/security/src/main/java/io/craftbot/security/spi/CaptchaProvider.java
+++ b/security/src/main/java/io/craftbot/security/spi/CaptchaProvider.java
@@ -1,0 +1,6 @@
+package io.craftbot.security.spi;
+
+public interface CaptchaProvider {
+    CaptchaChallenge create(long chatId);
+    boolean verify(long chatId, String answer);
+}

--- a/security/src/main/java/io/craftbot/security/spi/Key.java
+++ b/security/src/main/java/io/craftbot/security/spi/Key.java
@@ -1,0 +1,3 @@
+package io.craftbot.security.spi;
+
+public record Key(String value) {}

--- a/security/src/main/java/io/craftbot/security/spi/RateLimitBackend.java
+++ b/security/src/main/java/io/craftbot/security/spi/RateLimitBackend.java
@@ -1,0 +1,7 @@
+package io.craftbot.security.spi;
+
+import java.time.Duration;
+
+public interface RateLimitBackend {
+    boolean tryAcquire(Key key, int permits, Duration window);
+}

--- a/security/src/main/java/io/craftbot/security/spi/RoleResolver.java
+++ b/security/src/main/java/io/craftbot/security/spi/RoleResolver.java
@@ -1,0 +1,5 @@
+package io.craftbot.security.spi;
+
+public interface RoleResolver {
+    boolean hasRole(long userId, String role);
+}

--- a/security/src/main/java/io/craftbot/security/spi/StateStore.java
+++ b/security/src/main/java/io/craftbot/security/spi/StateStore.java
@@ -1,0 +1,6 @@
+package io.craftbot.security.spi;
+
+public interface StateStore {
+    String get(long chat, String key);
+    void set(long chat, String key, String value, int ttlSeconds);
+}

--- a/tgkit-renderers-telegram/pom.xml
+++ b/tgkit-renderers-telegram/pom.xml
@@ -1,0 +1,33 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.lonmstalker.tgkit</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+    <artifactId>tgkit-renderers-telegram</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>io.lonmstalker.tgkit</groupId>
+            <artifactId>render-spi</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tgkit-renderers-telegram/src/main/java/io/lonmstalker/tgkit/render/telegram/CaptchaRenderer.java
+++ b/tgkit-renderers-telegram/src/main/java/io/lonmstalker/tgkit/render/telegram/CaptchaRenderer.java
@@ -1,0 +1,33 @@
+package io.lonmstalker.tgkit.render.telegram;
+
+import io.craftbot.render.spi.ResponseRenderer;
+import io.craftbot.security.spi.CaptchaChallenge;
+import io.lonmstalker.tgkit.core.BotResponse;
+import io.lonmstalker.tgkit.core.args.Context;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.methods.send.SendPhoto;
+
+public class CaptchaRenderer implements ResponseRenderer<CaptchaChallenge> {
+    @Override
+    public boolean supports(Object o) {
+        return o instanceof CaptchaChallenge;
+    }
+
+    @Override
+    public BotResponse render(CaptchaChallenge c, Context ctx) {
+        if (c.photo() != null) {
+            SendPhoto p = new SendPhoto(ctx.request().botInfo().internalId()+"", c.photo());
+            p.setCaption(c.message());
+            p.setReplyMarkup(c.keyboard());
+            return BotResponse.builder().method(p).build();
+        }
+        SendMessage m = new SendMessage(ctx.request().botInfo().internalId()+"", c.message());
+        m.setReplyMarkup(c.keyboard());
+        return BotResponse.builder().method(m).build();
+    }
+
+    @Override
+    public int order() {
+        return 10;
+    }
+}

--- a/tgkit-renderers-telegram/src/main/java/io/lonmstalker/tgkit/render/telegram/MarkdownMsg.java
+++ b/tgkit-renderers-telegram/src/main/java/io/lonmstalker/tgkit/render/telegram/MarkdownMsg.java
@@ -1,0 +1,3 @@
+package io.lonmstalker.tgkit.render.telegram;
+
+public record MarkdownMsg(String text) {}

--- a/tgkit-renderers-telegram/src/main/java/io/lonmstalker/tgkit/render/telegram/PhotoMsg.java
+++ b/tgkit-renderers-telegram/src/main/java/io/lonmstalker/tgkit/render/telegram/PhotoMsg.java
@@ -1,0 +1,5 @@
+package io.lonmstalker.tgkit.render.telegram;
+
+import org.telegram.telegrambots.meta.api.objects.InputFile;
+
+public record PhotoMsg(InputFile file, String caption) {}

--- a/tgkit-renderers-telegram/src/main/java/io/lonmstalker/tgkit/render/telegram/PhotoRenderer.java
+++ b/tgkit-renderers-telegram/src/main/java/io/lonmstalker/tgkit/render/telegram/PhotoRenderer.java
@@ -1,0 +1,20 @@
+package io.lonmstalker.tgkit.render.telegram;
+
+import io.craftbot.render.spi.ResponseRenderer;
+import io.lonmstalker.tgkit.core.BotResponse;
+import io.lonmstalker.tgkit.core.args.Context;
+import org.telegram.telegrambots.meta.api.methods.send.SendPhoto;
+
+public class PhotoRenderer implements ResponseRenderer<PhotoMsg> {
+    @Override
+    public boolean supports(Object o) {
+        return o instanceof PhotoMsg;
+    }
+
+    @Override
+    public BotResponse render(PhotoMsg msg, Context ctx) {
+        SendPhoto p = new SendPhoto(ctx.request().botInfo().internalId()+"", msg.file());
+        p.setCaption(msg.caption());
+        return BotResponse.builder().method(p).build();
+    }
+}

--- a/tgkit-renderers-telegram/src/main/java/io/lonmstalker/tgkit/render/telegram/TextRenderer.java
+++ b/tgkit-renderers-telegram/src/main/java/io/lonmstalker/tgkit/render/telegram/TextRenderer.java
@@ -1,0 +1,20 @@
+package io.lonmstalker.tgkit.render.telegram;
+
+import io.craftbot.render.spi.ResponseRenderer;
+import io.lonmstalker.tgkit.core.BotResponse;
+import io.lonmstalker.tgkit.core.args.Context;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+
+public class TextRenderer implements ResponseRenderer<MarkdownMsg> {
+    @Override
+    public boolean supports(Object o) {
+        return o instanceof MarkdownMsg;
+    }
+
+    @Override
+    public BotResponse render(MarkdownMsg msg, Context ctx) {
+        SendMessage m = new SendMessage(ctx.request().botInfo().internalId()+"", msg.text());
+        m.enableMarkdownV2(true);
+        return BotResponse.builder().method(m).build();
+    }
+}

--- a/tgkit-renderers-telegram/src/main/resources/META-INF/services/io.craftbot.render.spi.ResponseRenderer
+++ b/tgkit-renderers-telegram/src/main/resources/META-INF/services/io.craftbot.render.spi.ResponseRenderer
@@ -1,0 +1,3 @@
+io.lonmstalker.tgkit.render.telegram.TextRenderer
+io.lonmstalker.tgkit.render.telegram.CaptchaRenderer
+io.lonmstalker.tgkit.render.telegram.PhotoRenderer

--- a/tgkit-renderers-telegram/src/test/java/io/lonmstalker/tgkit/render/telegram/ResponseDispatcherTest.java
+++ b/tgkit-renderers-telegram/src/test/java/io/lonmstalker/tgkit/render/telegram/ResponseDispatcherTest.java
@@ -1,0 +1,60 @@
+package io.lonmstalker.tgkit.render.telegram;
+
+import io.craftbot.render.spi.ResponseDispatcher;
+import io.lonmstalker.tgkit.core.BotInfo;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import io.lonmstalker.tgkit.core.BotResponse;
+import io.lonmstalker.tgkit.core.args.Context;
+import io.lonmstalker.tgkit.core.BotRequest;
+import io.lonmstalker.tgkit.core.bot.BotConfig;
+import io.lonmstalker.tgkit.core.bot.TelegramSender;
+import io.lonmstalker.tgkit.core.i18n.MessageLocalizer;
+import io.lonmstalker.tgkit.core.state.InMemoryStateStore;
+import io.lonmstalker.tgkit.core.user.BotUserInfo;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.methods.send.SendPhoto;
+import org.telegram.telegrambots.meta.api.objects.InputFile;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ResponseDispatcherTest {
+
+    private Context createContext() {
+        BotConfig cfg = BotConfig.builder().build();
+        TelegramSender sender = new TelegramSender(cfg, "token");
+        BotInfo info = new BotInfo(1L, new InMemoryStateStore(), sender, new MessageLocalizer());
+        BotUserInfo user = new BotUserInfo() {
+            @Override
+            public @NonNull String chatId() { return "1"; }
+            @Override
+            public @NonNull Set<String> roles() { return Set.of(); }
+        };
+        BotRequest<Update> req = new BotRequest<>(1, new Update(), info, user);
+        return new Context(req, null);
+    }
+
+    @Test
+    void text_renderer_selected() throws Exception {
+        ResponseDispatcher d = new ResponseDispatcher(getClass().getClassLoader());
+        BotResponse r = d.toResponse(new MarkdownMsg("hi"), createContext());
+        assertTrue(r.getMethod() instanceof SendMessage);
+    }
+
+    @Test
+    void photo_renderer_selected() throws Exception {
+        ResponseDispatcher d = new ResponseDispatcher(getClass().getClassLoader());
+        PhotoMsg msg = new PhotoMsg(new InputFile("id"), "cap");
+        BotResponse r = d.toResponse(msg, createContext());
+        assertTrue(r.getMethod() instanceof SendPhoto);
+    }
+
+    @Test
+    void no_renderer_error() {
+        ResponseDispatcher d = new ResponseDispatcher(getClass().getClassLoader());
+        assertThrows(IllegalArgumentException.class, () -> d.toResponse(42, createContext()));
+    }
+}


### PR DESCRIPTION
## Summary
- integrate `ResponseDispatcher` for converting plugin objects to `BotResponse`
- add Telegram renderers module under `tgkit-renderers-telegram`
- fix update type tag generation in `ObservabilityInterceptor`
- correct annotation processor package

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q -DskipTests=true package` *(fails: Could not resolve spotless plugin)*
- `mvn -q test` *(fails: Could not resolve spotless plugin)*

------
https://chatgpt.com/codex/tasks/task_e_684ec1384d048325b7b9e7f4056ee591