### PR TITLE
Переместить утилиты в отдельные пакеты

### DIFF
--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotAdapterImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotAdapterImpl.java
@@ -13,7 +13,7 @@ import io.lonmstalker.tgkit.core.interceptor.BotInterceptor;
 import io.lonmstalker.tgkit.core.storage.BotRequestHolder;
 import io.lonmstalker.tgkit.core.user.BotUserInfo;
 import io.lonmstalker.tgkit.core.user.BotUserProvider;
-import io.lonmstalker.tgkit.core.utils.UpdateUtils;
+import io.lonmstalker.tgkit.core.update.UpdateUtils;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.checkerframework.checker.nullness.qual.Nullable;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotDataSourceFactory.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotDataSourceFactory.java
@@ -6,7 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import io.lonmstalker.tgkit.core.exception.BotApiException;
-import io.lonmstalker.tgkit.core.utils.TokenCipher;
+import io.lonmstalker.tgkit.core.crypto.TokenCipher;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.telegram.telegrambots.bots.DefaultBotOptions;
 

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotFactory.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotFactory.java
@@ -2,7 +2,7 @@ package io.lonmstalker.tgkit.core.bot;
 
 import io.lonmstalker.tgkit.core.BotAdapter;
 import io.lonmstalker.tgkit.core.bot.BotDataSourceFactory.BotData;
-import io.lonmstalker.tgkit.core.utils.TokenCipher;
+import io.lonmstalker.tgkit.core.crypto.TokenCipher;
 import io.lonmstalker.tgkit.core.loader.AnnotatedCommandLoader;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/crypto/TokenCipher.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/crypto/TokenCipher.java
@@ -1,4 +1,4 @@
-package io.lonmstalker.tgkit.core.utils;
+package io.lonmstalker.tgkit.core.crypto;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 

--- a/core/src/main/java/io/lonmstalker/tgkit/core/crypto/TokenCipherImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/crypto/TokenCipherImpl.java
@@ -1,4 +1,4 @@
-package io.lonmstalker.tgkit.core.utils;
+package io.lonmstalker.tgkit.core.crypto;
 
 import io.lonmstalker.tgkit.core.exception.BotApiException;
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/update/UpdateUtils.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/update/UpdateUtils.java
@@ -1,4 +1,4 @@
-package io.lonmstalker.tgkit.core.utils;
+package io.lonmstalker.tgkit.core.update;
 
 import io.lonmstalker.tgkit.core.BotRequestType;
 import io.lonmstalker.tgkit.core.exception.BotApiException;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotDataSourceFactoryTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotDataSourceFactoryTest.java
@@ -3,7 +3,7 @@ package io.lonmstalker.tgkit.core.bot;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.lonmstalker.tgkit.core.exception.BotApiException;
-import io.lonmstalker.tgkit.core.utils.TokenCipherImpl;
+import io.lonmstalker.tgkit.core.crypto.TokenCipherImpl;
 import org.h2.jdbcx.JdbcDataSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotFactoryTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotFactoryTest.java
@@ -3,7 +3,7 @@ package io.lonmstalker.tgkit.core.bot;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.lonmstalker.tgkit.core.BotAdapter;
-import io.lonmstalker.tgkit.core.utils.TokenCipherImpl;
+import io.lonmstalker.tgkit.core.crypto.TokenCipherImpl;
 import org.h2.jdbcx.JdbcDataSource;
 import org.junit.jupiter.api.Test;
 import org.telegram.telegrambots.meta.api.methods.updates.SetWebhook;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/crypto/TokenCipherImplTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/crypto/TokenCipherImplTest.java
@@ -1,4 +1,4 @@
-package io.lonmstalker.tgkit.core.utils;
+package io.lonmstalker.tgkit.core.crypto;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/core/src/test/java/io/lonmstalker/tgkit/core/update/UpdateUtilsTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/update/UpdateUtilsTest.java
@@ -1,4 +1,4 @@
-package io.lonmstalker.tgkit.core.utils;
+package io.lonmstalker.tgkit.core.update;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/examples/simple-bot/src/test/java/io/lonmstalker/examples/simplebot/SimpleBotCommandsTest.java
+++ b/examples/simple-bot/src/test/java/io/lonmstalker/examples/simplebot/SimpleBotCommandsTest.java
@@ -11,7 +11,7 @@ import io.lonmstalker.tgkit.core.bot.BotConfig;
 import io.lonmstalker.tgkit.core.i18n.MessageLocalizer;
 import io.lonmstalker.tgkit.core.loader.AnnotatedCommandLoader;
 import io.lonmstalker.tgkit.core.state.InMemoryStateStore;
-import io.lonmstalker.tgkit.core.utils.UpdateUtils;
+import io.lonmstalker.tgkit.core.update.UpdateUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Summary
- создать пакеты `crypto` и `update`
- перенести `TokenCipher`, `TokenCipherImpl` и `UpdateUtils`
- обновить импорты во всём проекте

## Testing
- `mvn -q test` *(failed: PluginResolutionException: Could not transfer artifact com.diffplug.spotless:spotless-maven-plugin from https://repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_684edfca2e508325bef29ae1f144d4de