### PR TITLE
Rename test methods using shouldWhen pattern

### DIFF
--- a/core/src/test/java/io/lonmstalker/tgkit/core/args/ArgBindingTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/args/ArgBindingTest.java
@@ -41,7 +41,7 @@ public class ArgBindingTest {
     }
 
     @Test
-    void bindArgument() {
+    void shouldBindArgumentWhenRegexMatches() {
         BotCommandRegistryImpl reg = new BotCommandRegistryImpl();
         AnnotatedCommandLoader.load(reg, Commands.class.getPackageName());
 

--- a/core/src/test/java/io/lonmstalker/tgkit/core/args/ConvertersTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/args/ConvertersTest.java
@@ -9,7 +9,7 @@ import java.math.BigDecimal;
 
 public class ConvertersTest {
     @Test
-    void unsupported_number_converter() {
+    void shouldThrowWhenNumberConverterUnsupported() {
         var converter = Converters.getByType(BigDecimal.class);
         assertThrows(BotApiException.class,
                 () -> converter.convert("1", new Context(null, null)));

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotAdapterImplTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotAdapterImplTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.*;
 public class BotAdapterImplTest {
 
     @Test
-    void exception_in_preHandle_invokes_afterCompletion() {
+    void shouldInvokeAfterCompletionWhenPreHandleThrowsException() {
         TestInterceptor interceptor = new TestInterceptor();
         BotConfig config = BotConfig.builder()
                 .globalInterceptors(List.of(interceptor))

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotCommandRegistryImplTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotCommandRegistryImplTest.java
@@ -16,7 +16,7 @@ import io.lonmstalker.tgkit.core.exception.BotApiException;
 class BotCommandRegistryImplTest {
 
     @Test
-    void add_and_find_commands() {
+    void shouldFindCommandWhenAdded() {
         BotCommandRegistryImpl registry = new BotCommandRegistryImpl();
         BotCommand<Message> first = new TestCommand(1);
         BotCommand<Message> second = new TestCommand(2);
@@ -30,7 +30,7 @@ class BotCommandRegistryImplTest {
     }
 
     @Test
-    void find_wrong_type_throws() {
+    void shouldThrowWhenFindingWrongType() {
         BotCommandRegistryImpl registry = new BotCommandRegistryImpl();
         registry.add(new TestCommand(1));
 

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotDataSourceFactoryTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotDataSourceFactoryTest.java
@@ -30,7 +30,7 @@ public class BotDataSourceFactoryTest {
     }
 
     @Test
-    void load_data() throws Exception {
+    void shouldLoadDataWhenRecordExists() throws Exception {
         var cipher = new TokenCipherImpl("secretkey123456");
         String enc = cipher.encrypt("TEST_TOKEN");
         try (Connection c = ds.getConnection();
@@ -45,14 +45,14 @@ public class BotDataSourceFactoryTest {
     }
 
     @Test
-    void bot_not_found_throws() {
+    void shouldThrowWhenBotNotFound() {
         var cipher = new TokenCipherImpl("secretkey123456");
         assertThrows(BotApiException.class,
                 () -> BotDataSourceFactory.INSTANCE.load(ds, 99, cipher));
     }
 
     @Test
-    void empty_token_throws() throws Exception {
+    void shouldThrowWhenTokenEmpty() throws Exception {
         var cipher = new TokenCipherImpl("secretkey123456");
         String enc = cipher.encrypt("");
         try (Connection c = ds.getConnection();

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotFactoryTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotFactoryTest.java
@@ -15,7 +15,7 @@ import java.sql.Statement;
 public class BotFactoryTest {
 
     @Test
-    void createFromToken() {
+    void shouldCreateBotWhenFromToken() {
         BotAdapter adapter = u -> null;
         BotConfig cfg = BotConfig.builder().build();
         Bot bot = BotFactory.INSTANCE.from("TOKEN", cfg, adapter);
@@ -24,7 +24,7 @@ public class BotFactoryTest {
     }
 
     @Test
-    void createFromWebhook() {
+    void shouldCreateBotWhenFromWebhook() {
         BotAdapter adapter = u -> null;
         BotConfig cfg = BotConfig.builder().build();
         SetWebhook hook = new SetWebhook();
@@ -34,7 +34,7 @@ public class BotFactoryTest {
     }
 
     @Test
-    void createFromDataSource() throws Exception {
+    void shouldCreateBotWhenFromDataSource() throws Exception {
         JdbcDataSource h2 = new JdbcDataSource();
         h2.setURL("jdbc:h2:mem:bot;DB_CLOSE_DELAY=-1");
         DataSource ds = h2;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotSessionImplTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotSessionImplTest.java
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit;
 public class BotSessionImplTest {
 
     @Test
-    void startAndStop() {
+    void shouldStartAndStopSessionWhenInvoked() {
         NoopExecutor executor = new NoopExecutor();
         BotSessionImpl session = new BotSessionImpl(executor, new ObjectMapper());
         DefaultBotOptions options = new DefaultBotOptions();

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/RateLimiterTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/RateLimiterTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class RateLimiterTest {
 
     @Test
-    void permitsPerSecond() throws Exception {
+    void shouldRespectPermitsPerSecondWhenAcquiring() throws Exception {
         RateLimiter limiter = new RateLimiter(2);
         long start = System.currentTimeMillis();
         limiter.acquire();
@@ -27,7 +27,7 @@ class RateLimiterTest {
     }
 
     @Test
-    void externalSchedulerNotClosed() {
+    void shouldNotCloseExternalSchedulerWhenClosed() {
         ScheduledExecutorService external = Executors.newSingleThreadScheduledExecutor();
         RateLimiter limiter = new RateLimiter(1, external);
         limiter.close();

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/TelegramSenderTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/TelegramSenderTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 public class TelegramSenderTest {
 
     @Test
-    void convertException() throws Exception {
+    void shouldConvertExceptionWhenUsingConvertException() throws Exception {
         TestSender sender = new TestSender();
         Method m = TelegramSender.class.getDeclaredMethod("withConvertException", TelegramSender.RuntimeExceptionExecutor.class);
         m.setAccessible(true);

--- a/core/src/test/java/io/lonmstalker/tgkit/core/i18n/MessageLocalizerTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/i18n/MessageLocalizerTest.java
@@ -9,7 +9,7 @@ import java.util.Locale;
 public class MessageLocalizerTest {
 
     @Test
-    void russianLocale() {
+    void shouldReturnRussianMessageWhenLocaleIsRussian() {
         MessageLocalizer localizer = new MessageLocalizer(Locale.forLanguageTag("ru"));
         assertEquals("Понг", localizer.get("command.ping.response"));
     }

--- a/core/src/test/java/io/lonmstalker/tgkit/core/interceptor/LoggingBotInterceptorTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/interceptor/LoggingBotInterceptorTest.java
@@ -25,7 +25,7 @@ public class LoggingBotInterceptorTest {
     }
 
     @Test
-    void logs_user_and_message_id_on_error() {
+    void shouldLogUserAndMessageIdWhenError() {
         appender.start();
         logger.addAppender(appender);
         LoggingBotInterceptor interceptor = new LoggingBotInterceptor();

--- a/core/src/test/java/io/lonmstalker/tgkit/core/matching/MatchersTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/matching/MatchersTest.java
@@ -22,7 +22,7 @@ public class MatchersTest {
     void clear() { BotRequestHolder.clear(); }
 
     @Test
-    void messageTextMatch() {
+    void shouldMatchWhenMessageTextMatches() {
         Message msg = new Message();
         msg.setText("hello");
         assertTrue(new MessageTextMatch("hello").match(msg));
@@ -31,7 +31,7 @@ public class MatchersTest {
     }
 
     @Test
-    void messageContainsMatch() {
+    void shouldMatchWhenMessageContainsText() {
         Message msg = new Message();
         msg.setText("hello world");
         assertTrue(new MessageContainsMatch("world").match(msg));
@@ -40,7 +40,7 @@ public class MatchersTest {
     }
 
     @Test
-    void messageRegexMatch() {
+    void shouldMatchWhenMessageMatchesRegex() {
         Message msg = new Message();
         msg.setText("abc123");
         assertTrue(new MessageRegexMatch("[a-z]+\\d+").match(msg));
@@ -48,13 +48,13 @@ public class MatchersTest {
     }
 
     @Test
-    void alwaysMatch() {
+    void shouldAlwaysMatchWhenCalled() {
         BotApiObject obj = Mockito.mock(BotApiObject.class);
         assertTrue(new AlwaysMatch<>().match(obj));
     }
 
     @Test
-    void userRoleMatch() {
+    void shouldMatchWhenUserRoleAllowed() {
         BotUserProvider provider = u -> new BotUserInfo() {
             @Override public @NonNull String chatId() { return "1"; }
             @Override public @NonNull Set<String> roles() { return Set.of("ADMIN"); }

--- a/core/src/test/java/io/lonmstalker/tgkit/core/storage/BotRequestHolderTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/storage/BotRequestHolderTest.java
@@ -10,7 +10,7 @@ import org.telegram.telegrambots.meta.api.objects.Update;
 public class BotRequestHolderTest {
 
     @Test
-    void setAndGet() {
+    void shouldSetAndGetWhenStored() {
         Update u = new Update();
         TelegramSender sender = new TelegramSender(BotConfig.builder().build(), "token") {
         };
@@ -24,7 +24,7 @@ public class BotRequestHolderTest {
     }
 
     @Test
-    void clearAndExceptions() {
+    void shouldThrowWhenAccessingAfterClear() {
         BotRequestHolder.clear();
         assertNull(BotRequestHolder.getUpdate());
         assertNull(BotRequestHolder.getSender());

--- a/core/src/test/java/io/lonmstalker/tgkit/core/utils/TokenCipherImplTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/utils/TokenCipherImplTest.java
@@ -8,7 +8,7 @@ import io.lonmstalker.tgkit.core.exception.BotApiException;
 public class TokenCipherImplTest {
 
     @Test
-    void encrypt_decrypt_roundtrip() {
+    void shouldReturnOriginalWhenEncryptingAndDecrypting() {
         var cipher = new TokenCipherImpl("secretkey123456");
         var original = "myToken";
         var encrypted = cipher.encrypt(original);
@@ -18,7 +18,7 @@ public class TokenCipherImplTest {
     }
 
     @Test
-    void decrypt_invalid_data_throws() {
+    void shouldThrowWhenDecryptingInvalidData() {
         var cipher = new TokenCipherImpl("secretkey123456");
         assertThrows(BotApiException.class, () -> cipher.decrypt("boom"));
     }

--- a/core/src/test/java/io/lonmstalker/tgkit/core/utils/UpdateUtilsTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/utils/UpdateUtilsTest.java
@@ -10,27 +10,27 @@ import org.telegram.telegrambots.meta.api.objects.*;
 
 public class UpdateUtilsTest {
     @Test
-    void getTypeMessage() {
+    void shouldReturnTypeMessageWhenMessagePresent() {
         Update update = new Update();
         update.setMessage(new Message());
         assertEquals(BotRequestType.MESSAGE, UpdateUtils.getType(update));
     }
 
     @Test
-    void getTypeCallbackQuery() {
+    void shouldReturnTypeCallbackQueryWhenCallbackPresent() {
         Update update = new Update();
         update.setCallbackQuery(new CallbackQuery());
         assertEquals(BotRequestType.CALLBACK_QUERY, UpdateUtils.getType(update));
     }
 
     @Test
-    void getTypeUnknownThrows() {
+    void shouldThrowWhenTypeUnknown() {
         Update update = new Update();
         assertThrows(BotApiException.class, () -> UpdateUtils.getType(update));
     }
 
     @Test
-    void getUserFromCallback() {
+    void shouldReturnUserWhenCallbackQuery() {
         User user = new User();
         user.setId(1L);
         CallbackQuery cq = new CallbackQuery();

--- a/examples/plugin-demo/src/test/java/demo/GreeterPluginTest.java
+++ b/examples/plugin-demo/src/test/java/demo/GreeterPluginTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 public class GreeterPluginTest {
     @Test
-    public void testReply() throws Exception {
+    public void shouldReplyWithWaveWhenHelloPublished() throws Exception {
         DefaultEventBus bus = new DefaultEventBus();
         RecordingHandler recorder = new RecordingHandler();
         bus.subscribe(recorder);

--- a/examples/simple-bot/src/test/java/io/lonmstalker/examples/simplebot/SimpleBotCommandsTest.java
+++ b/examples/simple-bot/src/test/java/io/lonmstalker/examples/simplebot/SimpleBotCommandsTest.java
@@ -38,7 +38,7 @@ class SimpleBotCommandsTest {
 
     @Test
     @DisplayName("тест MessageTextMatch")
-    void textPing() {
+    void shouldRespondWithSendMessageWhenPingText() {
         User user = new User();
         Chat chat = new Chat();
         Message msg = new Message();
@@ -58,7 +58,7 @@ class SimpleBotCommandsTest {
 
     @Test
     @DisplayName("тест MessageContainsMatch")
-    void containsHello() {
+    void shouldRespondWithSendMessageWhenContainsHello() {
         Chat chat = new Chat();
         User user = new User();
         Message msg = new Message();
@@ -78,7 +78,7 @@ class SimpleBotCommandsTest {
 
     @Test
     @DisplayName("тест MessageRegexMatch")
-    void regexNumbers() {
+    void shouldRespondWithSendMessageWhenRegexMatchesNumbers() {
         User user = new User();
         Chat chat = new Chat();
         Message msg = new Message();
@@ -98,7 +98,7 @@ class SimpleBotCommandsTest {
 
     @Test
     @DisplayName("тест UserRoleMatch")
-    void callback() {
+    void shouldRespondWithAnswerCallbackQueryWhenCallback() {
         User user = new User();
         CallbackQuery cq = new CallbackQuery();
 
@@ -115,7 +115,7 @@ class SimpleBotCommandsTest {
 
     @Test
     @DisplayName("тест AlwaysMatch")
-    void inlineQuery() {
+    void shouldRespondWithAnswerInlineQueryWhenInlineQuery() {
         User user = new User();
         InlineQuery iq = new InlineQuery();
 

--- a/examples/simple-bot/src/test/java/io/lonmstalker/examples/simplebot/SimpleRoleProviderTest.java
+++ b/examples/simple-bot/src/test/java/io/lonmstalker/examples/simplebot/SimpleRoleProviderTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class SimpleRoleProviderTest {
 
     @Test
-    void resolveFailsWhenUserMissing() {
+    void shouldThrowWhenUserMissing() {
         SimpleRoleProvider provider = new SimpleRoleProvider();
         Update update = new Update();
         assertThrows(BotApiException.class, () -> provider.resolve(update));

--- a/observability/src/test/java/io/lonmstalker/observability/ObservabilityInterceptorTest.java
+++ b/observability/src/test/java/io/lonmstalker/observability/ObservabilityInterceptorTest.java
@@ -56,7 +56,7 @@ public class ObservabilityInterceptorTest {
     }
 
     @Test
-    void span_and_metrics_on_success() {
+    void shouldRecordSpanAndMetricsWhenSuccess() {
         Update update = createUpdate(1);
         interceptor.preHandle(update);
         assertEquals("1", MDC.get("updateId"));
@@ -69,7 +69,7 @@ public class ObservabilityInterceptorTest {
     }
 
     @Test
-    void error_metrics_and_span() {
+    void shouldRecordErrorAndMetricsWhenError() {
         Update update = createUpdate(2);
         interceptor.preHandle(update);
         RuntimeException ex = new RuntimeException("boom");

--- a/plugin/src/test/java/io/lonmstalker/tgkit/plugin/EventBusTest.java
+++ b/plugin/src/test/java/io/lonmstalker/tgkit/plugin/EventBusTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 public class EventBusTest {
 
     @Test
-    public void publishAndSubscribe() {
+    public void shouldReceiveMessageWhenPublished() {
         SimpleEventBus bus = new SimpleEventBus();
         AtomicInteger counter = new AtomicInteger();
         bus.subscribe(String.class, s -> counter.incrementAndGet());

--- a/plugin/src/test/java/io/lonmstalker/tgkit/plugin/PluginContextPermissionsTest.java
+++ b/plugin/src/test/java/io/lonmstalker/tgkit/plugin/PluginContextPermissionsTest.java
@@ -35,7 +35,7 @@ public class PluginContextPermissionsTest {
     }
 
     @Test
-    public void denyBotControl() {
+    public void shouldRestrictBotControlWhenPermissionMissing() {
         PluginPermissions perms = new PluginPermissions();
         PluginContextImpl ctx = new PluginContextImpl(
                 new DummyRegistry(),
@@ -52,7 +52,7 @@ public class PluginContextPermissionsTest {
     }
 
     @Test
-    public void readOnlyStore() {
+    public void shouldEnforceReadOnlyStoreWhenConfigured() {
         PluginPermissions perms = new PluginPermissions();
         perms.setStore(PluginPermissions.Store.READ_ONLY);
         PluginContextImpl ctx = new PluginContextImpl(

--- a/security/src/test/java/io/lonmstalker/tgkit/security/MathCaptchaTest.java
+++ b/security/src/test/java/io/lonmstalker/tgkit/security/MathCaptchaTest.java
@@ -7,7 +7,7 @@ import java.util.Locale;
 
 public class MathCaptchaTest {
     @Test
-    void verifyAnswer() {
+    void shouldVerifyAnswerWhenCorrect() {
         MathCaptcha c = MathCaptcha.easy();
         var msg = c.question(1L, new MessageLocalizer(Locale.US));
         String q = msg.getText();


### PR DESCRIPTION
## Summary
- rename JUnit test methods across modules following the `should*When*` pattern

## Testing
- `mvn -q test` *(fails: Could not transfer artifact com.diffplug.spotless:spotless-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_684edfda1548832586a45a76abdecc16