### PR TITLE
Improve plugin readability

### DIFF
--- a/examples/plugin-demo/src/main/java/demo/GreeterPlugin.java
+++ b/examples/plugin-demo/src/main/java/demo/GreeterPlugin.java
@@ -4,14 +4,18 @@ import io.lonmstalker.tgkit.plugin.spi.Plugin;
 import io.lonmstalker.tgkit.plugin.spi.PluginContext;
 
 public class GreeterPlugin implements Plugin {
+
     private PluginContext context;
 
     @Override
-    public int abiVersion() { return 1; }
+    public int abiVersion() {
+        return 1;
+    }
 
     @Override
     public void init(PluginContext context) {
         this.context = context;
+
         context.bus().subscribe(msg -> {
             if ("/hello".equals(msg)) {
                 context.bus().publish("\uD83D\uDC4B");
@@ -20,8 +24,12 @@ public class GreeterPlugin implements Plugin {
     }
 
     @Override
-    public void start() {}
+    public void start() {
+        // nothing
+    }
 
     @Override
-    public void stop() {}
+    public void stop() {
+        // nothing
+    }
 }

--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/DefaultPluginContext.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/DefaultPluginContext.java
@@ -27,32 +27,52 @@ public class DefaultPluginContext implements PluginContext {
     }
 
     @Override
-    public BotRegistry bots() { throw new UnsupportedOperationException(); }
+    public BotRegistry bots() {
+        throw new UnsupportedOperationException();
+    }
 
     @Override
-    public EventBus bus() { return eventBus; }
+    public EventBus bus() {
+        return eventBus;
+    }
 
     @Override
-    public StateStore defaultStore() { throw new UnsupportedOperationException(); }
+    public StateStore defaultStore() {
+        throw new UnsupportedOperationException();
+    }
 
     @Override
-    public HttpClient httpClient() { throw new UnsupportedOperationException(); }
+    public HttpClient httpClient() {
+        throw new UnsupportedOperationException();
+    }
 
     @Override
-    public InputStream readFile(Path path) { throw new UnsupportedOperationException(); }
+    public InputStream readFile(Path path) {
+        throw new UnsupportedOperationException();
+    }
 
     @Override
-    public OutputStream writeFile(Path path) { throw new UnsupportedOperationException(); }
+    public OutputStream writeFile(Path path) {
+        throw new UnsupportedOperationException();
+    }
 
     @Override
-    public MetricsCollector metrics() { throw new UnsupportedOperationException(); }
+    public MetricsCollector metrics() {
+        throw new UnsupportedOperationException();
+    }
 
     @Override
-    public Tracer tracer() { throw new UnsupportedOperationException(); }
+    public Tracer tracer() {
+        throw new UnsupportedOperationException();
+    }
 
     @Override
-    public Optional<ConfigSection> config(String pluginId) { return Optional.empty(); }
+    public Optional<ConfigSection> config(String pluginId) {
+        return Optional.empty();
+    }
 
     @Override
-    public void registerConfig(String pluginId, ConfigSection config) { }
+    public void registerConfig(String pluginId, ConfigSection config) {
+        // nothing
+    }
 }

--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/PluginLoader.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/PluginLoader.java
@@ -48,7 +48,9 @@ public final class PluginLoader {
      */
     private PluginManifest readManifest(ClassLoader cl) throws Exception {
         try (InputStream is = cl.getResourceAsStream("tgkit-plugin.yaml")) {
-            if (is == null) return new PluginManifest();
+            if (is == null) {
+                return new PluginManifest();
+            }
             return mapper.readValue(is, PluginManifest.class);
         }
     }

--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/PluginManager.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/PluginManager.java
@@ -83,7 +83,9 @@ public class PluginManager {
      */
     public void reload(String id) throws Exception {
         LoadedPlugin lp = plugins.get(id);
-        if (lp == null) return;
+        if (lp == null) {
+            return;
+        }
         Path jar = lp.jarPath;
         unload(id);
         load(jar);
@@ -108,7 +110,10 @@ public class PluginManager {
      */
     public PluginManifest getManifest(String id) {
         LoadedPlugin lp = plugins.get(id);
-        return lp == null ? null : lp.manifest;
+        if (lp == null) {
+            return null;
+        }
+        return lp.manifest;
     }
 
     private record LoadedPlugin(Plugin plugin, PluginManifest manifest, URLClassLoader loader, Path jarPath) {}

--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/SimpleEventBus.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/SimpleEventBus.java
@@ -24,7 +24,9 @@ public final class SimpleEventBus implements EventBus {
     public void publish(Object event) {
         Class<?> cls = event.getClass();
         List<EventHandler<?>> list = handlers.get(cls);
-        if (list == null) return;
+        if (list == null) {
+            return;
+        }
         for (EventHandler<?> h : list) {
             ((EventHandler<Object>) h).handle(event);
         }


### PR DESCRIPTION
## Summary
- update DefaultPluginContext: expand one-line methods for clarity
- expand logic for missing plugin manifest in PluginLoader
- clarify null checks in PluginManager and SimpleEventBus
- rewrite plugin demo GreeterPlugin for better layout

## Testing
- `mvn -q test` *(fails: could not download spotless maven plugin)*

------
https://chatgpt.com/codex/tasks/task_e_684ee2de97bc8325a1931ebb3cec2ab5