### PR TITLE
Add single-thread guard for DefaultEventBus

### DIFF
--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/DefaultEventBus.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/DefaultEventBus.java
@@ -4,18 +4,31 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Наивная реализация {@link EventBus} без потокобезопасности.
+ * Наивная реализация {@link EventBus} для однопоточного использования.
+ * <p>
+ * Не потокобезопасна. Для многопоточной среды используйте {@link SimpleEventBus}.
+ * Все вызовы должны происходить из того потока, где был создан экземпляр.
  */
 public class DefaultEventBus implements EventBus {
     private final List<MessageHandler> handlers = new ArrayList<>();
+    private final Thread owner = Thread.currentThread();
+
+    private void checkThread() {
+        if (!Thread.currentThread().equals(owner)) {
+            throw new IllegalStateException(
+                "DefaultEventBus is single-thread only; use SimpleEventBus instead");
+        }
+    }
 
     @Override
     public void subscribe(MessageHandler handler) {
+        checkThread();
         handlers.add(handler);
     }
 
     @Override
     public void publish(String message) {
+        checkThread();
         for (MessageHandler handler : handlers) {
             handler.onMessage(message);
         }


### PR DESCRIPTION
## Summary
- clarify Javadoc that `DefaultEventBus` is not threadsafe
- enforce single-thread usage via runtime check

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee806cba08325b1e1dde3540412c8