### PR TITLE
Add advanced response DSL

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -66,6 +66,17 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.25.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/BotResponse.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/BotResponse.java
@@ -1,0 +1,238 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import io.lonmstalker.tgkit.core.BotRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.methods.ParseMode;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.methods.send.SendMediaGroup;
+import org.telegram.telegrambots.meta.api.methods.send.SendPhoto;
+import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageText;
+import org.telegram.telegrambots.meta.api.objects.InputFile;
+import org.telegram.telegrambots.meta.api.objects.media.InputMedia;
+import org.telegram.telegrambots.meta.api.objects.media.InputMediaPhoto;
+import org.telegram.telegrambots.meta.api.objects.media.InputMediaVideo;
+
+/**
+ * Точка входа в DSL ответа бота.
+ */
+public final class BotResponse {
+
+    private static final Logger log = LoggerFactory.getLogger(BotResponse.class);
+
+    /** Глобальная конфигурация. */
+    private static final Config CONFIG = new Config();
+
+    private BotResponse() {}
+
+    /** Конфигурирует глобальные параметры. */
+    public static void config(Consumer<Config> cfg) {
+        cfg.accept(CONFIG);
+    }
+
+    /** Сообщение. */
+    public static MessageBuilder msg(String text) {
+        return new MessageBuilder(text);
+    }
+
+    /** Сообщение из i18n. */
+    public static MessageBuilder msgKey(String key, Function<String, Object[], String> i18n, Object... args) {
+        return new MessageBuilder(i18n.apply(key, args));
+    }
+
+    /** Фото. */
+    public static PhotoBuilder photo(InputFile file) {
+        return new PhotoBuilder(file);
+    }
+
+    /** Редактирование сообщения. */
+    public static EditBuilder edit(long msgId) {
+        return new EditBuilder(msgId);
+    }
+
+    /** Удаление сообщения. */
+    public static DeleteBuilder delete(long msgId) {
+        return new DeleteBuilder(msgId);
+    }
+
+    /** Отправка медиа-группы. */
+    public static MediaGroupBuilder mediaGroup() {
+        return new MediaGroupBuilder();
+    }
+
+    /** Опрос. */
+    public static PollBuilder poll(String question) {
+        return new PollBuilder(question);
+    }
+
+    /** Викторина. */
+    public static QuizBuilder quiz(String question, int correct) {
+        return new QuizBuilder(question, correct);
+    }
+
+    /** Результаты инлайн-запроса. */
+    public static InlineResults inline() {
+        return new InlineResults();
+    }
+
+    /** Базовый строитель. */
+    @SuppressWarnings("unchecked")
+    static abstract class CommonBuilder<T extends CommonBuilder<T>> implements Common<T> {
+        protected long chatId;
+        protected Long replyTo;
+        protected boolean disableNotif;
+        protected KbBuilder keyboard;
+        protected Duration ttl;
+        protected Consumer<Long> success;
+        protected Consumer<Throwable> error;
+        protected Context ctx;
+
+        @Override
+        public T chat(long id) {
+            this.chatId = id;
+            return (T) this;
+        }
+
+        @Override
+        public T autoChat(BotRequest<?> req) {
+            this.chatId = Long.parseLong(req.user().chatId());
+            this.ctx = new Context(chatId, req.user().roles());
+            return (T) this;
+        }
+
+        @Override
+        public T replyTo(long msgId) {
+            this.replyTo = msgId;
+            return (T) this;
+        }
+
+        @Override
+        public T disableNotif() {
+            this.disableNotif = true;
+            return (T) this;
+        }
+
+        @Override
+        public T keyboard(Consumer<KbBuilder> cfg) {
+            KbBuilder kb = new KbBuilder();
+            cfg.accept(kb);
+            this.keyboard = kb;
+            return (T) this;
+        }
+
+        @Override
+        public T when(Predicate<Context> cond, Consumer<? extends Common<?>> branch) {
+            if (ctx != null && cond.test(ctx)) {
+                branch.accept(this);
+            }
+            return (T) this;
+        }
+
+        @Override
+        public T onlyAdmin(Consumer<? extends Common<?>> branch) {
+            if (ctx != null && ctx.isAdmin()) {
+                branch.accept(this);
+            }
+            return (T) this;
+        }
+
+        @Override
+        public T ifFlag(String flag, Context c, Consumer<? extends Common<?>> branch) {
+            if (CONFIG.flags.enabled(flag, c.chatId())) {
+                branch.accept(this);
+            }
+            return (T) this;
+        }
+
+        @Override
+        public T flag(String flag, Context c, Consumer<? extends Common<?>> branch) {
+            return ifFlag(flag, c, branch);
+        }
+
+        @Override
+        public T ttl(Duration duration) {
+            this.ttl = duration;
+            return (T) this;
+        }
+
+        @Override
+        public T hooks(Consumer<Long> ok, Consumer<Throwable> fail) {
+            this.success = ok;
+            this.error = fail;
+            return (T) this;
+        }
+
+        @Override
+        public BotResponse send(TelegramTransport tg) {
+            try {
+                BotApiMethod<?> m = build();
+                long id = tg.execute(m);
+                if (ttl != null) {
+                    tg.scheduleDelete(chatId, id, ttl);
+                }
+                if (success != null) {
+                    success.accept(id);
+                }
+                return new BotResponse();
+            } catch (Exception ex) {
+                if (error != null) {
+                    error.accept(ex);
+                }
+                throw ex instanceof RuntimeException r ? r : new RuntimeException(ex);
+            }
+        }
+
+        @Override
+        public CompletableFuture<BotResponse> sendAsync(Executor executor) {
+            return CompletableFuture.supplyAsync(() -> send(CONFIG.transport), executor);
+        }
+
+        protected abstract BotApiMethod<?> build();
+    }
+
+    /** Настройки по умолчанию. */
+    public static final class Config {
+        private String parseMode = ParseMode.HTML;
+        private boolean sanitize;
+        private FeatureFlags flags = FeatureFlags.noop();
+        private TelegramTransport transport = new TelegramTransport() {
+            @Override
+            public long execute(BotApiMethod<?> method) {
+                log.debug("execute: {}", method); return 0;
+            }
+            @Override
+            public void delete(long chatId, long messageId) {
+                log.debug("delete: {}", messageId);
+            }
+        };
+
+        public Config markdownV2() {
+            this.parseMode = ParseMode.MARKDOWNV2;
+            return this;
+        }
+
+        public Config sanitizeMarkdown() {
+            this.sanitize = true;
+            return this;
+        }
+
+        public Config featureFlags(FeatureFlags flags) {
+            this.flags = flags;
+            return this;
+        }
+
+        public Config transport(TelegramTransport tr) {
+            this.transport = tr;
+            return this;
+        }
+    }
+}

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/Button.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/Button.java
@@ -1,0 +1,33 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import org.telegram.telegrambots.meta.api.objects.WebAppInfo;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
+
+/**
+ * Фабрика кнопок.
+ */
+public interface Button {
+
+    /** Создаёт экземпляр кнопки. */
+    InlineKeyboardButton build();
+
+    /** Кнопка с callback data. */
+    static Button cb(String label, String data) {
+        return () -> InlineKeyboardButton.builder().text(label).callbackData(data).build();
+    }
+
+    /** Обычная кнопка. */
+    static Button btn(String label) {
+        return cb(label, label);
+    }
+
+    /** Ссылка. */
+    static Button url(String label, String url) {
+        return () -> InlineKeyboardButton.builder().text(label).url(url).build();
+    }
+
+    /** Веб‑приложение. */
+    static Button webApp(String label, String url) {
+        return () -> InlineKeyboardButton.builder().text(label).webApp(new WebAppInfo(url)).build();
+    }
+}

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/Common.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/Common.java
@@ -1,0 +1,39 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+
+/** Общие операции билдера. */
+public interface Common<T extends Common<T>> {
+    T chat(long id);
+
+    T autoChat(BotRequest<?> req);
+
+    T replyTo(long msgId);
+
+    T disableNotif();
+
+    T keyboard(java.util.function.Consumer<KbBuilder> cfg);
+
+    T when(Predicate<Context> cond, Consumer<? extends Common<?>> branch);
+
+    T onlyAdmin(Consumer<? extends Common<?>> branch);
+
+    T ifFlag(String flag, Context ctx, Consumer<? extends Common<?>> branch);
+
+    T flag(String flag, Context ctx, Consumer<? extends Common<?>> branch);
+
+    T ttl(Duration duration);
+
+    T hooks(Consumer<Long> ok, Consumer<Throwable> fail);
+
+    BotResponse send(TelegramTransport tg);
+
+    CompletableFuture<BotResponse> sendAsync(Executor executor);
+
+    BotApiMethod<?> build();
+}

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/Context.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/Context.java
@@ -1,0 +1,16 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import java.util.Set;
+
+/**
+ * Контекст выполнения ответа.
+ *
+ * @param chatId идентификатор чата
+ * @param roles  роли пользователя
+ */
+public record Context(long chatId, Set<String> roles) {
+    /** Проверяет роль администратора. */
+    public boolean isAdmin() {
+        return roles.contains("ADMIN");
+    }
+}

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/DeleteBuilder.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/DeleteBuilder.java
@@ -1,0 +1,19 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.methods.updatingmessages.DeleteMessage;
+
+/** Удаление сообщения. */
+public final class DeleteBuilder extends BotResponse.CommonBuilder<DeleteBuilder> {
+    private final long msgId;
+
+    DeleteBuilder(long msgId) {
+        this.msgId = msgId;
+    }
+
+    @Override
+    protected BotApiMethod<?> build() {
+        DeleteMessage dm = new DeleteMessage(String.valueOf(chatId), (int) msgId);
+        return dm;
+    }
+}

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/EditBuilder.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/EditBuilder.java
@@ -1,0 +1,44 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import java.time.Duration;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageText;
+import org.telegram.telegrambots.meta.api.methods.send.SendChatAction;
+
+/** Редактирование сообщения. */
+public final class EditBuilder extends BotResponse.CommonBuilder<EditBuilder> {
+    private final long msgId;
+    private Duration typing;
+    private String newText;
+
+    EditBuilder(long msgId) {
+        this.msgId = msgId;
+    }
+
+    /** Показать набор текста перед редактированием. */
+    public EditBuilder typing(Duration d) {
+        this.typing = d;
+        return this;
+    }
+
+    /** Текст после редактирования. */
+    public EditBuilder thenEdit(String text) {
+        this.newText = text;
+        return this;
+    }
+
+    @Override
+    protected BotApiMethod<?> build() {
+        if (typing != null) {
+            SendChatAction act = new SendChatAction();
+            act.setChatId(String.valueOf(chatId));
+            act.setAction("typing");
+            CONFIG.transport.execute(act);
+        }
+        EditMessageText edit = new EditMessageText();
+        edit.setChatId(String.valueOf(chatId));
+        edit.setMessageId((int) msgId);
+        edit.setText(newText);
+        return edit;
+    }
+}

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/FeatureFlags.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/FeatureFlags.java
@@ -1,0 +1,21 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+/**
+ * Проверяет, включена ли фича для чата.
+ */
+public interface FeatureFlags {
+
+    /**
+     * @param key  название фичи
+     * @param chat идентификатор чата
+     * @return {@code true}, если включено
+     */
+    boolean enabled(String key, long chat);
+
+    /**
+     * Реализация по умолчанию, всегда возвращает {@code false}.
+     */
+    static FeatureFlags noop() {
+        return (k, c) -> false;
+    }
+}

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/InMemoryFeatureFlags.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/InMemoryFeatureFlags.java
@@ -1,0 +1,31 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Хранит состояние флагов в памяти.
+ */
+public final class InMemoryFeatureFlags implements FeatureFlags {
+
+    private final Map<String, Set<Long>> flags = new ConcurrentHashMap<>();
+
+    @Override
+    public boolean enabled(String key, long chat) {
+        return flags.getOrDefault(key, Set.of()).contains(chat);
+    }
+
+    /** Включает флаг. */
+    public void enable(String key, long chat) {
+        flags.computeIfAbsent(key, k -> ConcurrentHashMap.newKeySet()).add(chat);
+    }
+
+    /** Выключает флаг. */
+    public void disable(String key, long chat) {
+        Set<Long> set = flags.get(key);
+        if (set != null) {
+            set.remove(chat);
+        }
+    }
+}

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/InlineResults.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/InlineResults.java
@@ -1,0 +1,41 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.telegram.telegrambots.meta.api.objects.inlinequery.result.InlineQueryResult;
+import org.telegram.telegrambots.meta.api.objects.inlinequery.result.InlineQueryResultArticle;
+import org.telegram.telegrambots.meta.api.objects.inlinequery.result.InlineQueryResultPhoto;
+import org.telegram.telegrambots.meta.api.objects.inputmessagecontent.InputTextMessageContent;
+
+/** Построитель результатов инлайн‑запроса. */
+public final class InlineResults {
+    private final List<InlineQueryResult> list = new ArrayList<>();
+
+    public static InlineResults build() {
+        return new InlineResults();
+    }
+
+    /** Статья. */
+    public InlineResults article(String id, String title, String text) {
+        InlineQueryResultArticle a = new InlineQueryResultArticle();
+        a.setId(id);
+        a.setTitle(title);
+        a.setInputMessageContent(new InputTextMessageContent(text));
+        list.add(a);
+        return this;
+    }
+
+    /** Фото. */
+    public InlineResults photo(String id, String url, String thumb) {
+        InlineQueryResultPhoto p = new InlineQueryResultPhoto();
+        p.setId(id);
+        p.setPhotoUrl(url);
+        p.setThumbUrl(thumb);
+        list.add(p);
+        return this;
+    }
+
+    public List<InlineQueryResult> results() {
+        return list;
+    }
+}

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/KbBuilder.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/KbBuilder.java
@@ -1,0 +1,59 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
+
+/**
+ * Конструктор inline-клавиатуры.
+ */
+public final class KbBuilder {
+
+    private final List<List<InlineKeyboardButton>> rows = new ArrayList<>();
+
+    /** Добавляет строку кнопок. */
+    public KbBuilder row(Button... buttons) {
+        rows.add(to(buttons));
+        return this;
+    }
+
+    /** Каждая кнопка в отдельной строке. */
+    public KbBuilder col(Button... buttons) {
+        for (Button b : buttons) {
+            rows.add(List.of(b.build()));
+        }
+        return this;
+    }
+
+    /** Размещает кнопки по сетке. */
+    public KbBuilder grid(int cols, Button... buttons) {
+        List<InlineKeyboardButton> cur = new ArrayList<>();
+        for (Button b : buttons) {
+            cur.add(b.build());
+            if (cur.size() == cols) {
+                rows.add(cur);
+                cur = new ArrayList<>();
+            }
+        }
+        if (!cur.isEmpty()) {
+            rows.add(cur);
+        }
+        return this;
+    }
+
+    /** Итоговая разметка. */
+    public InlineKeyboardMarkup build() {
+        return new InlineKeyboardMarkup(rows);
+    }
+
+    List<List<InlineKeyboardButton>> rows() {
+        return rows;
+    }
+
+    private static List<InlineKeyboardButton> to(Button[] buttons) {
+        return Arrays.stream(buttons).map(Button::build).collect(Collectors.toList());
+    }
+}

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/MediaGroupBuilder.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/MediaGroupBuilder.java
@@ -1,0 +1,64 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.methods.send.SendMediaGroup;
+import org.telegram.telegrambots.meta.api.objects.InputFile;
+import org.telegram.telegrambots.meta.api.objects.media.InputMedia;
+import org.telegram.telegrambots.meta.api.objects.media.InputMediaPhoto;
+import org.telegram.telegrambots.meta.api.objects.media.InputMediaVideo;
+
+/** Построитель медиа-группы. */
+public final class MediaGroupBuilder extends BotResponse.CommonBuilder<MediaGroupBuilder> {
+    private final List<InputMedia> items = new ArrayList<>();
+
+    /** Фото с подписью. */
+    public MediaGroupBuilder photo(InputFile file, String cap) {
+        InputMediaPhoto ph = new InputMediaPhoto();
+        ph.setMedia(file.getNewMediaFile(), file.getMediaName());
+        ph.setCaption(cap);
+        items.add(ph);
+        return this;
+    }
+
+    /** Видео. */
+    public MediaGroupBuilder video(InputFile file) {
+        InputMediaVideo v = new InputMediaVideo();
+        v.setMedia(file.getNewMediaFile(), file.getMediaName());
+        items.add(v);
+        return this;
+    }
+
+    @Override
+    protected BotApiMethod<?> build() {
+        SendMediaGroup group = new SendMediaGroup();
+        group.setChatId(String.valueOf(chatId));
+        group.setMedias(items);
+        return group;
+    }
+
+    @Override
+    public BotResponse send(TelegramTransport tg) {
+        List<List<InputMedia>> chunks = new ArrayList<>();
+        List<InputMedia> cur = new ArrayList<>();
+        for (InputMedia m : items) {
+            cur.add(m);
+            if (cur.size() == 10) {
+                chunks.add(cur);
+                cur = new ArrayList<>();
+            }
+        }
+        if (!cur.isEmpty()) {
+            chunks.add(cur);
+        }
+        for (List<InputMedia> c : chunks) {
+            SendMediaGroup g = new SendMediaGroup();
+            g.setChatId(String.valueOf(chatId));
+            g.setMedias(c);
+            tg.execute(g);
+        }
+        return new BotResponse();
+    }
+}

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/MessageBuilder.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/MessageBuilder.java
@@ -1,0 +1,26 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.methods.ParseMode;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+
+/** Создание текстового сообщения. */
+public final class MessageBuilder extends BotResponse.CommonBuilder<MessageBuilder> {
+    private final String text;
+
+    MessageBuilder(String text) {
+        this.text = text;
+    }
+
+    @Override
+    protected BotApiMethod<?> build() {
+        String t = CONFIG.sanitize ? StringEscapeUtils.escapeHtml4(text) : text;
+        SendMessage msg = new SendMessage(String.valueOf(chatId), t);
+        msg.setParseMode(CONFIG.parseMode);
+        if (replyTo != null) msg.setReplyToMessageId(replyTo.intValue());
+        msg.setDisableNotification(disableNotif);
+        if (keyboard != null) msg.setReplyMarkup(keyboard.build());
+        return msg;
+    }
+}

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/PhotoBuilder.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/PhotoBuilder.java
@@ -1,0 +1,30 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.methods.send.SendPhoto;
+import org.telegram.telegrambots.meta.api.objects.InputFile;
+
+/** Построитель отправки фото. */
+public final class PhotoBuilder extends BotResponse.CommonBuilder<PhotoBuilder> {
+    private final InputFile file;
+    private String caption;
+
+    PhotoBuilder(InputFile file) {
+        this.file = file;
+    }
+
+    /** Подпись к фото. */
+    public PhotoBuilder caption(String text) {
+        this.caption = text;
+        return this;
+    }
+
+    @Override
+    protected BotApiMethod<?> build() {
+        SendPhoto photo = new SendPhoto(String.valueOf(chatId), file);
+        photo.setCaption(caption);
+        if (keyboard != null) photo.setReplyMarkup(keyboard.build());
+        photo.setDisableNotification(disableNotif);
+        return photo;
+    }
+}

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/PollBuilder.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/PollBuilder.java
@@ -1,0 +1,39 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.methods.polls.SendPoll;
+
+/** Построитель опроса. */
+public class PollBuilder extends BotResponse.CommonBuilder<PollBuilder> {
+    private final String question;
+    private final List<String> options = new ArrayList<>();
+    private boolean anonymous = true;
+
+    PollBuilder(String question) {
+        this.question = question;
+    }
+
+    /** Добавляет вариант ответа. */
+    public PollBuilder option(String o) {
+        options.add(o);
+        return this;
+    }
+
+    /** Устанавливает режим анонимности. */
+    public PollBuilder anonymous(boolean a) {
+        this.anonymous = a;
+        return this;
+    }
+
+    @Override
+    protected BotApiMethod<?> build() {
+        SendPoll poll = new SendPoll();
+        poll.setChatId(String.valueOf(chatId));
+        poll.setQuestion(question);
+        poll.setOptions(options);
+        poll.setAnonymous(anonymous);
+        return poll;
+    }
+}

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/QuizBuilder.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/QuizBuilder.java
@@ -1,0 +1,22 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.methods.polls.SendPoll;
+
+/** Построитель викторины. */
+public final class QuizBuilder extends PollBuilder {
+    private final int correct;
+
+    QuizBuilder(String q, int correct) {
+        super(q);
+        this.correct = correct;
+    }
+
+    @Override
+    protected BotApiMethod<?> build() {
+        SendPoll poll = (SendPoll) super.build();
+        poll.setType("quiz");
+        poll.setCorrectOptionId(correct);
+        return poll;
+    }
+}

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/RichText.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/RichText.java
@@ -1,0 +1,29 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+/**
+ * Построитель форматированного текста Markdown.
+ */
+public final class RichText {
+    private final StringBuilder sb = new StringBuilder();
+
+    public static RichText text() {
+        return new RichText();
+    }
+
+    /** Полужирный текст. */
+    public RichText bold(String text) {
+        sb.append("**").append(text).append("**");
+        return this;
+    }
+
+    /** Ссылка. */
+    public RichText url(String label, String url) {
+        sb.append("[").append(label).append("](").append(url).append(")");
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return sb.toString();
+    }
+}

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/TelegramTransport.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/TelegramTransport.java
@@ -1,0 +1,23 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import java.time.Duration;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+
+/**
+ * Интерфейс транспорта Telegram.
+ */
+public interface TelegramTransport {
+
+    /**
+     * Отправляет метод Telegram API.
+     *
+     * @return идентификатор сообщения
+     */
+    long execute(BotApiMethod<?> method);
+
+    /** Удаляет сообщение. */
+    void delete(long chatId, long messageId);
+
+    /** Планирует удаление сообщения. */
+    default void scheduleDelete(long chatId, long messageId, Duration ttl) {}
+}

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/TgButtons.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/TgButtons.java
@@ -1,0 +1,17 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.KeyboardButton;
+
+/**
+ * Готовые кнопки.
+ */
+public final class TgButtons {
+    private TgButtons() {}
+
+    /** Кнопка запроса номера телефона. */
+    public static KeyboardButton sharePhone() {
+        KeyboardButton b = new KeyboardButton("Share phone");
+        b.setRequestContact(true);
+        return b;
+    }
+}

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/TgKeyboardPresets.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/TgKeyboardPresets.java
@@ -1,0 +1,13 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+/**
+ * Шаблоны клавиатур.
+ */
+public final class TgKeyboardPresets {
+    private TgKeyboardPresets() {}
+
+    /** Клавиатура подтверждения. */
+    public static KbBuilder confirmYesNo(Context ctx) {
+        return new KbBuilder().row(Button.cb("Yes", "yes"), Button.cb("No", "no"));
+    }
+}

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/AutoDeleteTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/AutoDeleteTest.java
@@ -1,0 +1,16 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+/** Проверка автУдаления сообщений. */
+public class AutoDeleteTest {
+    @Test
+    void schedulesDelete() {
+        FakeTransport tg = new FakeTransport();
+        BotResponse.msg("bye").chat(1).ttl(Duration.ofMinutes(2)).send(tg);
+        assertThat(tg.ttls).hasSize(1);
+    }
+}

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/BranchAdminTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/BranchAdminTest.java
@@ -1,0 +1,22 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+
+/** Проверка onlyAdmin ветки. */
+public class BranchAdminTest {
+    @Test
+    void adminBranchAddsButton() {
+        FakeContext ctx = new FakeContext(1L, Set.of("ADMIN"));
+        FakeTransport tg = new FakeTransport();
+        BotResponse.msg("hi")
+                .chat(1)
+                .onlyAdmin(b -> b.keyboard(k -> k.row(Button.cb("A", "a"))))
+                .send(tg);
+        SendMessage msg = (SendMessage) tg.sent.get(0);
+        assertThat(msg.getReplyMarkup()).isNotNull();
+    }
+}

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/FakeContext.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/FakeContext.java
@@ -1,0 +1,10 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import java.util.Set;
+
+/** Простой контекст для тестов. */
+public final class FakeContext extends Context {
+    public FakeContext(long chatId, Set<String> roles) {
+        super(chatId, roles);
+    }
+}

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/FakeTransport.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/FakeTransport.java
@@ -1,0 +1,30 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.methods.send.SendMediaGroup;
+
+/** Простейшая реализация транспорта для тестов. */
+public final class FakeTransport implements TelegramTransport {
+    public final List<BotApiMethod<?>> sent = new ArrayList<>();
+    public final List<Long> deleted = new ArrayList<>();
+    public final List<Duration> ttls = new ArrayList<>();
+
+    @Override
+    public long execute(BotApiMethod<?> method) {
+        sent.add(method);
+        return sent.size();
+    }
+
+    @Override
+    public void delete(long chatId, long messageId) {
+        deleted.add(messageId);
+    }
+
+    @Override
+    public void scheduleDelete(long chatId, long messageId, Duration ttl) {
+        ttls.add(ttl);
+    }
+}

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/FeatureFlagTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/FeatureFlagTest.java
@@ -1,0 +1,36 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+
+/** Проверка работы фичевых флагов. */
+public class FeatureFlagTest {
+
+    @Test
+    void toggleFlag() {
+        StubFeatureFlags flags = new StubFeatureFlags();
+        BotResponse.config(c -> c.featureFlags(flags));
+        FakeContext ctx = new FakeContext(1L, Set.of());
+        FakeTransport tg = new FakeTransport();
+
+        BotResponse.msg("hi")
+                .chat(1)
+                .ifFlag("new", ctx, b -> b.keyboard(k -> k.row(Button.cb("N", "n"))))
+                .send(tg);
+        assertThat(tg.sent).hasSize(1);
+        SendMessage msg1 = (SendMessage) tg.sent.get(0);
+        assertThat(msg1.getReplyMarkup()).isNull();
+
+        flags.enable("new", 1L);
+        tg.sent.clear();
+        BotResponse.msg("hi")
+                .chat(1)
+                .ifFlag("new", ctx, b -> b.keyboard(k -> k.row(Button.cb("N", "n"))))
+                .send(tg);
+        SendMessage msg2 = (SendMessage) tg.sent.get(0);
+        assertThat(msg2.getReplyMarkup()).isNotNull();
+    }
+}

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/GlobalStyleTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/GlobalStyleTest.java
@@ -1,0 +1,18 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.methods.ParseMode;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+
+/** Проверка глобального стиля сообщений. */
+public class GlobalStyleTest {
+    @Test
+    void markdownSanitize() {
+        BotResponse.config(c -> c.markdownV2().sanitizeMarkdown());
+        SendMessage msg = (SendMessage) BotResponse.msg("*").chat(1).build();
+        assertThat(msg.getParseMode()).isEqualTo(ParseMode.MARKDOWNV2);
+        assertThat(msg.getText()).contains("&ast;");
+    }
+}

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/InlineResultTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/InlineResultTest.java
@@ -1,0 +1,14 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/** Проверка билдера инлайн-результатов. */
+public class InlineResultTest {
+    @Test
+    void buildResults() {
+        InlineResults res = InlineResults.build().article("1", "T", "Text");
+        assertThat(res.results()).isNotEmpty();
+    }
+}

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/KeyboardLayoutTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/KeyboardLayoutTest.java
@@ -1,0 +1,26 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
+
+/** Проверка раскладки клавиатуры. */
+public class KeyboardLayoutTest {
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void layoutToJson() throws Exception {
+        InlineKeyboardMarkup kb = new KbBuilder()
+                .row(Button.cb("A", "a"), Button.cb("B", "b"))
+                .col(Button.cb("C", "c"))
+                .grid(2, Button.cb("D", "d"), Button.cb("E", "e"), Button.cb("F", "f"))
+                .build();
+        String json = mapper.writeValueAsString(kb);
+        assertThat(json).contains("\"callback_data\":\"a\"");
+        assertThat(kb.getKeyboard()).hasSize(5);
+        assertThat(kb.getKeyboard().get(3)).hasSize(2);
+    }
+}

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/MediaGroupTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/MediaGroupTest.java
@@ -1,0 +1,19 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.objects.InputFile;
+
+/** Проверка отправки медиа-групп. */
+public class MediaGroupTest {
+    @Test
+    void chunking() {
+        FakeTransport tg = new FakeTransport();
+        MediaGroupBuilder b = BotResponse.mediaGroup().chat(1);
+        IntStream.range(0, 12).forEach(i -> b.photo(new InputFile("f" + i), "c"));
+        b.send(tg);
+        assertThat(tg.sent).hasSize(2);
+    }
+}

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/PollQuizTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/PollQuizTest.java
@@ -1,0 +1,17 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.methods.polls.SendPoll;
+
+/** Проверка опросов и викторин. */
+public class PollQuizTest {
+    @Test
+    void pollAndQuiz() {
+        SendPoll poll = (SendPoll) BotResponse.poll("Q").option("A").option("B").chat(1).build();
+        assertThat(poll.getQuestion()).isEqualTo("Q");
+        SendPoll quiz = (SendPoll) BotResponse.quiz("2+2", 1).option("3").option("4").chat(1).build();
+        assertThat(quiz.getCorrectOptionId()).isEqualTo(1);
+    }
+}

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/StubFeatureFlags.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/StubFeatureFlags.java
@@ -1,0 +1,4 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+/** Заглушка фичевых флагов для тестов. */
+public final class StubFeatureFlags extends InMemoryFeatureFlags {}


### PR DESCRIPTION
## Summary
- implement BotResponse DSL with builders
- provide keyboard helpers and feature flags
- add rich text and inline result builders
- supply fake transport and context for tests
- create unit tests for new DSL features
- update core module dependencies

## Testing
- `mvn -q -DskipTests install` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684ef88824288325b0401b02209c5e8b