### PR TITLE
Add request-context builders

### DIFF
--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/Button.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/Button.java
@@ -1,5 +1,6 @@
 package io.lonmstalker.tgkit.core.dsl;
 
+import io.lonmstalker.tgkit.core.i18n.MessageLocalizer;
 import org.telegram.telegrambots.meta.api.objects.WebAppInfo;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
 
@@ -9,11 +10,16 @@ import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKe
 public interface Button {
 
     /** Создаёт экземпляр кнопки. */
-    InlineKeyboardButton build();
+    InlineKeyboardButton build(MessageLocalizer loc);
+
+    /** Без локализации. */
+    default InlineKeyboardButton build() {
+        return build(null);
+    }
 
     /** Кнопка с callback data. */
     static Button cb(String label, String data) {
-        return () -> InlineKeyboardButton.builder().text(label).callbackData(data).build();
+        return req -> InlineKeyboardButton.builder().text(label).callbackData(data).build();
     }
 
     /** Обычная кнопка. */
@@ -21,13 +27,45 @@ public interface Button {
         return cb(label, label);
     }
 
+    /** Обычная кнопка из i18n. */
+    static Button btnKey(String key, Object... args) {
+        return loc -> {
+            String text = loc != null ? loc.get(key, args) : key;
+            return InlineKeyboardButton.builder().text(text).callbackData(text).build();
+        };
+    }
+
     /** Ссылка. */
     static Button url(String label, String url) {
-        return () -> InlineKeyboardButton.builder().text(label).url(url).build();
+        return loc -> InlineKeyboardButton.builder().text(label).url(url).build();
+    }
+
+    /** Ссылка с текстом из i18n. */
+    static Button urlKey(String key, String url, Object... args) {
+        return loc -> InlineKeyboardButton.builder()
+                .text(loc != null ? loc.get(key, args) : key)
+                .url(url)
+                .build();
     }
 
     /** Веб‑приложение. */
     static Button webApp(String label, String url) {
-        return () -> InlineKeyboardButton.builder().text(label).webApp(new WebAppInfo(url)).build();
+        return loc -> InlineKeyboardButton.builder().text(label).webApp(new WebAppInfo(url)).build();
+    }
+
+    /** Веб‑приложение с текстом из i18n. */
+    static Button webAppKey(String key, String url, Object... args) {
+        return loc -> InlineKeyboardButton.builder()
+                .text(loc != null ? loc.get(key, args) : key)
+                .webApp(new WebAppInfo(url))
+                .build();
+    }
+
+    /** Кнопка с callback и текстом из i18n. */
+    static Button cbKey(String key, String data, Object... args) {
+        return loc -> InlineKeyboardButton.builder()
+                .text(loc != null ? loc.get(key, args) : key)
+                .callbackData(data)
+                .build();
     }
 }

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/DeleteBuilder.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/DeleteBuilder.java
@@ -2,12 +2,14 @@ package io.lonmstalker.tgkit.core.dsl;
 
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.methods.updatingmessages.DeleteMessage;
+import io.lonmstalker.tgkit.core.BotRequest;
 
 /** Удаление сообщения. */
 public final class DeleteBuilder extends BotResponse.CommonBuilder<DeleteBuilder> {
     private final long msgId;
 
-    DeleteBuilder(long msgId) {
+    DeleteBuilder(BotRequest<?> req, long msgId) {
+        super(req);
         this.msgId = msgId;
     }
 

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/EditBuilder.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/EditBuilder.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageText;
 import org.telegram.telegrambots.meta.api.methods.send.SendChatAction;
+import io.lonmstalker.tgkit.core.BotRequest;
 
 /** Редактирование сообщения. */
 public final class EditBuilder extends BotResponse.CommonBuilder<EditBuilder> {
@@ -11,7 +12,8 @@ public final class EditBuilder extends BotResponse.CommonBuilder<EditBuilder> {
     private Duration typing;
     private String newText;
 
-    EditBuilder(long msgId) {
+    EditBuilder(BotRequest<?> req, long msgId) {
+        super(req);
         this.msgId = msgId;
     }
 

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/InlineResults.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/InlineResults.java
@@ -1,5 +1,7 @@
 package io.lonmstalker.tgkit.core.dsl;
 
+import io.lonmstalker.tgkit.core.BotRequest;
+import io.lonmstalker.tgkit.core.i18n.MessageLocalizer;
 import java.util.ArrayList;
 import java.util.List;
 import org.telegram.telegrambots.meta.api.objects.inlinequery.result.InlineQueryResult;
@@ -9,10 +11,13 @@ import org.telegram.telegrambots.meta.api.objects.inputmessagecontent.InputTextM
 
 /** Построитель результатов инлайн‑запроса. */
 public final class InlineResults {
+    private final BotRequest<?> req;
+    private final MessageLocalizer loc;
     private final List<InlineQueryResult> list = new ArrayList<>();
 
-    public static InlineResults build() {
-        return new InlineResults();
+    InlineResults(BotRequest<?> req) {
+        this.req = req;
+        this.loc = req != null ? req.botInfo().localizer() : null;
     }
 
     /** Статья. */
@@ -23,6 +28,12 @@ public final class InlineResults {
         a.setInputMessageContent(new InputTextMessageContent(text));
         list.add(a);
         return this;
+    }
+
+    /** Статья с текстом из i18n. */
+    public InlineResults articleKey(String id, String titleKey, String textKey, Object... args) {
+        return article(id, loc != null ? loc.get(titleKey, args) : titleKey,
+                loc != null ? loc.get(textKey, args) : textKey);
     }
 
     /** Фото. */

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/KbBuilder.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/KbBuilder.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import io.lonmstalker.tgkit.core.i18n.MessageLocalizer;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
 
@@ -12,7 +13,12 @@ import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKe
  */
 public final class KbBuilder {
 
+    private final MessageLocalizer loc;
     private final List<List<InlineKeyboardButton>> rows = new ArrayList<>();
+
+    KbBuilder(MessageLocalizer loc) {
+        this.loc = loc;
+    }
 
     /** Добавляет строку кнопок. */
     public KbBuilder row(Button... buttons) {
@@ -23,7 +29,7 @@ public final class KbBuilder {
     /** Каждая кнопка в отдельной строке. */
     public KbBuilder col(Button... buttons) {
         for (Button b : buttons) {
-            rows.add(List.of(b.build()));
+            rows.add(to(b));
         }
         return this;
     }
@@ -32,7 +38,7 @@ public final class KbBuilder {
     public KbBuilder grid(int cols, Button... buttons) {
         List<InlineKeyboardButton> cur = new ArrayList<>();
         for (Button b : buttons) {
-            cur.add(b.build());
+            cur.add(b.build(loc));
             if (cur.size() == cols) {
                 rows.add(cur);
                 cur = new ArrayList<>();
@@ -53,7 +59,11 @@ public final class KbBuilder {
         return rows;
     }
 
-    private static List<InlineKeyboardButton> to(Button[] buttons) {
-        return Arrays.stream(buttons).map(Button::build).collect(Collectors.toList());
+    private List<InlineKeyboardButton> to(Button... buttons) {
+        return Arrays.stream(buttons).map(b -> b.build(loc)).collect(Collectors.toList());
+    }
+
+    private List<InlineKeyboardButton> to(Button b) {
+        return List.of(b.build(loc));
     }
 }

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/MediaGroupBuilder.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/MediaGroupBuilder.java
@@ -9,10 +9,15 @@ import org.telegram.telegrambots.meta.api.objects.InputFile;
 import org.telegram.telegrambots.meta.api.objects.media.InputMedia;
 import org.telegram.telegrambots.meta.api.objects.media.InputMediaPhoto;
 import org.telegram.telegrambots.meta.api.objects.media.InputMediaVideo;
+import io.lonmstalker.tgkit.core.BotRequest;
 
 /** Построитель медиа-группы. */
 public final class MediaGroupBuilder extends BotResponse.CommonBuilder<MediaGroupBuilder> {
     private final List<InputMedia> items = new ArrayList<>();
+
+    MediaGroupBuilder(BotRequest<?> req) {
+        super(req);
+    }
 
     /** Фото с подписью. */
     public MediaGroupBuilder photo(InputFile file, String cap) {

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/MessageBuilder.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/MessageBuilder.java
@@ -4,12 +4,14 @@ import org.apache.commons.lang3.StringEscapeUtils;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.methods.ParseMode;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import io.lonmstalker.tgkit.core.BotRequest;
 
 /** Создание текстового сообщения. */
 public final class MessageBuilder extends BotResponse.CommonBuilder<MessageBuilder> {
     private final String text;
 
-    MessageBuilder(String text) {
+    MessageBuilder(BotRequest<?> req, String text) {
+        super(req);
         this.text = text;
     }
 

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/PhotoBuilder.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/PhotoBuilder.java
@@ -3,13 +3,15 @@ package io.lonmstalker.tgkit.core.dsl;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.methods.send.SendPhoto;
 import org.telegram.telegrambots.meta.api.objects.InputFile;
+import io.lonmstalker.tgkit.core.BotRequest;
 
 /** Построитель отправки фото. */
 public final class PhotoBuilder extends BotResponse.CommonBuilder<PhotoBuilder> {
     private final InputFile file;
     private String caption;
 
-    PhotoBuilder(InputFile file) {
+    PhotoBuilder(BotRequest<?> req, InputFile file) {
+        super(req);
         this.file = file;
     }
 

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/PollBuilder.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/PollBuilder.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.methods.polls.SendPoll;
+import io.lonmstalker.tgkit.core.BotRequest;
 
 /** Построитель опроса. */
 public class PollBuilder extends BotResponse.CommonBuilder<PollBuilder> {
@@ -11,7 +12,8 @@ public class PollBuilder extends BotResponse.CommonBuilder<PollBuilder> {
     private final List<String> options = new ArrayList<>();
     private boolean anonymous = true;
 
-    PollBuilder(String question) {
+    PollBuilder(BotRequest<?> req, String question) {
+        super(req);
         this.question = question;
     }
 

--- a/core/src/main/java/io/lonmstalker/tgkit/core/dsl/QuizBuilder.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/dsl/QuizBuilder.java
@@ -2,13 +2,14 @@ package io.lonmstalker.tgkit.core.dsl;
 
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.methods.polls.SendPoll;
+import io.lonmstalker.tgkit.core.BotRequest;
 
 /** Построитель викторины. */
 public final class QuizBuilder extends PollBuilder {
     private final int correct;
 
-    QuizBuilder(String q, int correct) {
-        super(q);
+    QuizBuilder(BotRequest<?> req, String q, int correct) {
+        super(req, q);
         this.correct = correct;
     }
 

--- a/core/src/main/java/io/lonmstalker/tgkit/core/i18n/MessageLocalizer.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/i18n/MessageLocalizer.java
@@ -2,6 +2,7 @@ package io.lonmstalker.tgkit.core.i18n;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 
+import java.text.MessageFormat;
 import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
@@ -24,5 +25,9 @@ public class MessageLocalizer {
         } catch (MissingResourceException ex) {
             return key;
         }
+    }
+
+    public @NonNull String get(@NonNull String key, Object... args) {
+        return MessageFormat.format(get(key), args);
     }
 }

--- a/core/src/main/java/io/lonmstalker/tgkit/core/wizard/WizardEngine.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/wizard/WizardEngine.java
@@ -30,7 +30,7 @@ public class WizardEngine {
         String key = in.chatId + ":" + wizard.id();
         WizardSession session = load(store, key);
 
-        if ("/cancel".equals(in.text)) {
+        if ("/cancel".equals(in.text) || "wiz:cancel".equals(in.text)) {
             store.set(key, "");
             return sendMessage(in.chatId, info.localizer().get("wizard.cancel", "Отменено"));
         }
@@ -79,13 +79,13 @@ public class WizardEngine {
     }
 
     private boolean processNav(String text, WizardSession session) {
-        if ("/back".equals(text)) {
+        if ("/back".equals(text) || "wiz:back".equals(text)) {
             if (session.getStepIdx() > 0) {
                 session.setStepIdx(session.getStepIdx() - 1);
             }
             return true;
         }
-        if ("/next".equals(text)) {
+        if ("/next".equals(text) || "wiz:next".equals(text)) {
             session.setStepIdx(session.getStepIdx() + 1);
             return true;
         }

--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -1,2 +1,5 @@
 command.ping.response=Pong
 captcha.math.question=Solve {0} + {1} = ?
+wizard.cancel=Canceled
+wizard.invalid=Invalid input
+wizard.done=Done

--- a/core/src/main/resources/i18n/messages_ru.properties
+++ b/core/src/main/resources/i18n/messages_ru.properties
@@ -1,2 +1,5 @@
 command.ping.response=Понг
 captcha.math.question=Сколько будет {0} + {1}?
+wizard.cancel=Отменено
+wizard.invalid=Неверный ввод
+wizard.done=Готово

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/AutoDeleteTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/AutoDeleteTest.java
@@ -10,7 +10,7 @@ public class AutoDeleteTest {
     @Test
     void schedulesDelete() {
         FakeTransport tg = new FakeTransport();
-        BotResponse.msg("bye").chat(1).ttl(Duration.ofMinutes(2)).send(tg);
+        BotResponse.msg(TestUtils.request(1), "bye").chat(1).ttl(Duration.ofMinutes(2)).send(tg);
         assertThat(tg.ttls).hasSize(1);
     }
 }

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/BranchAdminTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/BranchAdminTest.java
@@ -12,7 +12,7 @@ public class BranchAdminTest {
     void adminBranchAddsButton() {
         FakeContext ctx = new FakeContext(1L, Set.of("ADMIN"));
         FakeTransport tg = new FakeTransport();
-        BotResponse.msg("hi")
+        BotResponse.msg(TestUtils.request(1), "hi")
                 .chat(1)
                 .onlyAdmin(b -> b.keyboard(k -> k.row(Button.cb("A", "a"))))
                 .send(tg);

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/FeatureFlagTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/FeatureFlagTest.java
@@ -16,7 +16,7 @@ public class FeatureFlagTest {
         FakeContext ctx = new FakeContext(1L, Set.of());
         FakeTransport tg = new FakeTransport();
 
-        BotResponse.msg("hi")
+        BotResponse.msg(TestUtils.request(1), "hi")
                 .chat(1)
                 .ifFlag("new", ctx, b -> b.keyboard(k -> k.row(Button.cb("N", "n"))))
                 .send(tg);
@@ -26,7 +26,7 @@ public class FeatureFlagTest {
 
         flags.enable("new", 1L);
         tg.sent.clear();
-        BotResponse.msg("hi")
+        BotResponse.msg(TestUtils.request(1), "hi")
                 .chat(1)
                 .ifFlag("new", ctx, b -> b.keyboard(k -> k.row(Button.cb("N", "n"))))
                 .send(tg);

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/GlobalStyleTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/GlobalStyleTest.java
@@ -11,7 +11,7 @@ public class GlobalStyleTest {
     @Test
     void markdownSanitize() {
         BotResponse.config(c -> c.markdownV2().sanitizeMarkdown());
-        SendMessage msg = (SendMessage) BotResponse.msg("*").chat(1).build();
+        SendMessage msg = (SendMessage) BotResponse.msg(TestUtils.request(1), "*").chat(1).build();
         assertThat(msg.getParseMode()).isEqualTo(ParseMode.MARKDOWNV2);
         assertThat(msg.getText()).contains("&ast;");
     }

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/InlineResultTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/InlineResultTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 public class InlineResultTest {
     @Test
     void buildResults() {
-        InlineResults res = InlineResults.build().article("1", "T", "Text");
+        InlineResults res = BotResponse.inline(TestUtils.request(1)).article("1", "T", "Text");
         assertThat(res.results()).isNotEmpty();
     }
 }

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/MediaGroupTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/MediaGroupTest.java
@@ -11,7 +11,7 @@ public class MediaGroupTest {
     @Test
     void chunking() {
         FakeTransport tg = new FakeTransport();
-        MediaGroupBuilder b = BotResponse.mediaGroup().chat(1);
+        MediaGroupBuilder b = BotResponse.mediaGroup(TestUtils.request(1)).chat(1);
         IntStream.range(0, 12).forEach(i -> b.photo(new InputFile("f" + i), "c"));
         b.send(tg);
         assertThat(tg.sent).hasSize(2);

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/PollQuizTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/PollQuizTest.java
@@ -9,9 +9,11 @@ import org.telegram.telegrambots.meta.api.methods.polls.SendPoll;
 public class PollQuizTest {
     @Test
     void pollAndQuiz() {
-        SendPoll poll = (SendPoll) BotResponse.poll("Q").option("A").option("B").chat(1).build();
+        SendPoll poll = (SendPoll) BotResponse.poll(TestUtils.request(1), "Q")
+                .option("A").option("B").chat(1).build();
         assertThat(poll.getQuestion()).isEqualTo("Q");
-        SendPoll quiz = (SendPoll) BotResponse.quiz("2+2", 1).option("3").option("4").chat(1).build();
+        SendPoll quiz = (SendPoll) BotResponse.quiz(TestUtils.request(1), "2+2", 1)
+                .option("3").option("4").chat(1).build();
         assertThat(quiz.getCorrectOptionId()).isEqualTo(1);
     }
 }

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/TestUtils.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/TestUtils.java
@@ -1,0 +1,30 @@
+package io.lonmstalker.tgkit.core.dsl;
+
+import io.lonmstalker.tgkit.core.BotInfo;
+import io.lonmstalker.tgkit.core.BotRequest;
+import io.lonmstalker.tgkit.core.bot.BotConfig;
+import io.lonmstalker.tgkit.core.bot.TelegramSender;
+import io.lonmstalker.tgkit.core.i18n.MessageLocalizer;
+import io.lonmstalker.tgkit.core.state.InMemoryStateStore;
+import io.lonmstalker.tgkit.core.user.BotUserInfo;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.telegram.telegrambots.meta.api.objects.Message;
+
+import java.util.Locale;
+import java.util.Set;
+
+/** Utility helpers for DSL tests. */
+final class TestUtils {
+    private TestUtils() {}
+
+    static BotRequest<Message> request(long chatId) {
+        BotInfo info = new BotInfo(1L, new InMemoryStateStore(),
+                new TelegramSender(BotConfig.builder().build(), "T"),
+                new MessageLocalizer(Locale.US));
+        BotUserInfo user = new BotUserInfo() {
+            @Override public @NonNull String chatId() { return String.valueOf(chatId); }
+            @Override public @NonNull Set<String> roles() { return Set.of(); }
+        };
+        return new BotRequest<>(0, new Message(), info, user);
+    }
+}

--- a/core/src/test/java/io/lonmstalker/tgkit/core/i18n/MessageLocalizerTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/i18n/MessageLocalizerTest.java
@@ -13,4 +13,10 @@ public class MessageLocalizerTest {
         MessageLocalizer localizer = new MessageLocalizer(Locale.forLanguageTag("ru"));
         assertEquals("Понг", localizer.get("command.ping.response"));
     }
+
+    @Test
+    void formatArgs() {
+        MessageLocalizer loc = new MessageLocalizer(Locale.forLanguageTag("ru"));
+        assertEquals("Сколько будет 1 + 2?", loc.get("captcha.math.question", 1, 2));
+    }
 }


### PR DESCRIPTION
## Summary
- refactor builder factories to require `BotRequest`
- store request in `CommonBuilder` for localization and context
- adjust tests to supply dummy requests

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-compiler-plugin:3.14.0 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684f223080348325b45ec05b4c00f75f