### PR TITLE
Annotate plugin module with NonNull/Nullable

### DIFF
--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/DefaultEventBus.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/DefaultEventBus.java
@@ -1,5 +1,7 @@
 package io.lonmstalker.tgkit.plugin;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -21,13 +23,13 @@ public class DefaultEventBus implements EventBus {
     }
 
     @Override
-    public void subscribe(MessageHandler handler) {
+    public void subscribe(@NonNull MessageHandler handler) {
         checkThread();
         handlers.add(handler);
     }
 
     @Override
-    public void publish(String message) {
+    public void publish(@NonNull String message) {
         checkThread();
         for (MessageHandler handler : handlers) {
             handler.onMessage(message);

--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/DefaultPluginContext.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/DefaultPluginContext.java
@@ -6,6 +6,7 @@ import io.lonmstalker.tgkit.core.state.StateStore;
 import io.lonmstalker.tgkit.plugin.spi.BotRegistry;
 import io.lonmstalker.tgkit.plugin.spi.ConfigSection;
 import io.lonmstalker.tgkit.plugin.spi.PluginContext;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.http.HttpClient;
@@ -22,57 +23,57 @@ public class DefaultPluginContext implements PluginContext {
     /**
      * @param eventBus шина событий
      */
-    public DefaultPluginContext(EventBus eventBus) {
+    public DefaultPluginContext(@NonNull EventBus eventBus) {
         this.eventBus = eventBus;
     }
 
     @Override
-    public BotRegistry bots() {
+    public @NonNull BotRegistry bots() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public EventBus bus() {
+    public @NonNull EventBus bus() {
         return eventBus;
     }
 
     @Override
-    public StateStore defaultStore() {
+    public @NonNull StateStore defaultStore() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public HttpClient httpClient() {
+    public @NonNull HttpClient httpClient() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public InputStream readFile(Path path) {
+    public @NonNull InputStream readFile(@NonNull Path path) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public OutputStream writeFile(Path path) {
+    public @NonNull OutputStream writeFile(@NonNull Path path) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public MetricsCollector metrics() {
+    public @NonNull MetricsCollector metrics() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Tracer tracer() {
+    public @NonNull Tracer tracer() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Optional<ConfigSection> config(String pluginId) {
+    public @NonNull Optional<ConfigSection> config(@NonNull String pluginId) {
         return Optional.empty();
     }
 
     @Override
-    public void registerConfig(String pluginId, ConfigSection config) {
+    public void registerConfig(@NonNull String pluginId, @NonNull ConfigSection config) {
         // nothing
     }
 }

--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/EventBus.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/EventBus.java
@@ -1,5 +1,7 @@
 package io.lonmstalker.tgkit.plugin;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+
 /**
  * Простая шина сообщений между плагинами.
  */
@@ -10,18 +12,18 @@ public interface EventBus {
      *
      * @param handler обработчик сообщений
      */
-    void subscribe(MessageHandler handler);
+    void subscribe(@NonNull MessageHandler handler);
 
     /**
      * Публикует новое сообщение всем подписчикам.
      *
      * @param message текст сообщения
      */
-    void publish(String message);
+    void publish(@NonNull String message);
 
     /** Обработчик сообщений. */
     interface MessageHandler {
         /** Вызывается при получении сообщения. */
-        void onMessage(String message);
+        void onMessage(@NonNull String message);
     }
 }

--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/EventHandler.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/EventHandler.java
@@ -1,5 +1,7 @@
 package io.lonmstalker.tgkit.plugin;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+
 /**
  * Обработчик события шины.
  */
@@ -11,5 +13,5 @@ public interface EventHandler<T> {
      *
      * @param event событие
      */
-    void handle(T event);
+    void handle(@NonNull T event);
 }

--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/PluginContextImpl.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/PluginContextImpl.java
@@ -30,14 +30,14 @@ public final class PluginContextImpl implements PluginContext {
     private final HttpClient httpClient;
 
     public PluginContextImpl(
-            BotRegistry bots,
-            EventBus bus,
-            StateStore store,
-            MetricsCollector metrics,
-            Tracer tracer,
-            Map<String, ConfigSection> configs,
-            PluginPermissions permissions,
-            HttpClient httpClient) {
+            @NonNull BotRegistry bots,
+            @NonNull EventBus bus,
+            @NonNull StateStore store,
+            @NonNull MetricsCollector metrics,
+            @NonNull Tracer tracer,
+            @NonNull Map<String, ConfigSection> configs,
+            @NonNull PluginPermissions permissions,
+            @NonNull HttpClient httpClient) {
         this.bots = bots;
         this.bus = bus;
         this.store = store;

--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/PluginLoader.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/PluginLoader.java
@@ -3,6 +3,7 @@ package io.lonmstalker.tgkit.plugin;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.lonmstalker.tgkit.plugin.spi.Plugin;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -25,7 +26,7 @@ public final class PluginLoader {
     /**
      * Загружает все плагины из директории {@code plugins}.
      */
-    public Collection<PluginWrapper> loadAll() throws Exception {
+    public @NonNull Collection<PluginWrapper> loadAll() throws Exception {
         List<PluginWrapper> list = new ArrayList<>();
         if (!Files.isDirectory(pluginsDir)) {
             return list;
@@ -46,7 +47,7 @@ public final class PluginLoader {
     /**
      * Считывает манифест плагина из ресурса {@code tgkit-plugin.yaml}.
      */
-    private PluginManifest readManifest(ClassLoader cl) throws Exception {
+    private @NonNull PluginManifest readManifest(@NonNull ClassLoader cl) throws Exception {
         try (InputStream is = cl.getResourceAsStream("tgkit-plugin.yaml")) {
             if (is == null) {
                 return new PluginManifest();

--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/PluginManager.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/PluginManager.java
@@ -14,6 +14,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.ServiceLoader;
 import io.lonmstalker.tgkit.plugin.spi.Plugin;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Менеджер плагинов: загрузка, выгрузка и перезагрузка JAR-файлов.
@@ -28,7 +30,7 @@ public class PluginManager {
      * @param pluginsDir каталог с JAR-плагинами
      * @param eventBus   шина событий
      */
-    public PluginManager(Path pluginsDir, EventBus eventBus) {
+    public PluginManager(@NonNull Path pluginsDir, @NonNull EventBus eventBus) {
         this.pluginsDir = pluginsDir;
         this.eventBus = eventBus;
     }
@@ -52,7 +54,7 @@ public class PluginManager {
      *
      * @param jarPath путь к JAR
      */
-    public void load(Path jarPath) throws Exception {
+    public void load(@NonNull Path jarPath) throws Exception {
         URLClassLoader loader = new URLClassLoader(new URL[] {jarPath.toUri().toURL()});
         ServiceLoader<Plugin> sl = ServiceLoader.load(Plugin.class, loader);
         Iterator<Plugin> it = sl.iterator();
@@ -67,7 +69,7 @@ public class PluginManager {
         plugins.put(manifest.getId(), new LoadedPlugin(plugin, manifest, loader, jarPath));
     }
 
-    private PluginManifest readManifest(ClassLoader loader) throws IOException {
+    private @NonNull PluginManifest readManifest(@NonNull ClassLoader loader) throws IOException {
         try (InputStream is = loader.getResourceAsStream("tgkit-plugin.yaml")) {
             if (is == null) {
                 throw new IOException("tgkit-plugin.yaml not found");
@@ -81,7 +83,7 @@ public class PluginManager {
      *
      * @param id идентификатор плагина
      */
-    public void reload(String id) throws Exception {
+    public void reload(@NonNull String id) throws Exception {
         LoadedPlugin lp = plugins.get(id);
         if (lp == null) {
             return;
@@ -96,7 +98,7 @@ public class PluginManager {
      *
      * @param id идентификатор
      */
-    public void unload(String id) throws Exception {
+    public void unload(@NonNull String id) throws Exception {
         LoadedPlugin lp = plugins.remove(id);
         if (lp != null) {
             lp.plugin.stop();
@@ -108,7 +110,7 @@ public class PluginManager {
      * @param id идентификатор плагина
      * @return манифест или {@code null}, если не найден
      */
-    public PluginManifest getManifest(String id) {
+    public @Nullable PluginManifest getManifest(@NonNull String id) {
         LoadedPlugin lp = plugins.get(id);
         if (lp == null) {
             return null;
@@ -116,5 +118,9 @@ public class PluginManager {
         return lp.manifest;
     }
 
-    private record LoadedPlugin(Plugin plugin, PluginManifest manifest, URLClassLoader loader, Path jarPath) {}
+    private record LoadedPlugin(
+            @NonNull Plugin plugin,
+            @NonNull PluginManifest manifest,
+            @NonNull URLClassLoader loader,
+            @NonNull Path jarPath) {}
 }

--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/PluginWrapper.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/PluginWrapper.java
@@ -1,5 +1,7 @@
 package io.lonmstalker.tgkit.plugin;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+
 import io.lonmstalker.tgkit.plugin.spi.Plugin;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
@@ -7,4 +9,8 @@ import java.nio.file.Path;
 /**
  * Пара плагин + его метаданные.
  */
-public record PluginWrapper(Plugin plugin, URLClassLoader classLoader, Path path, PluginManifest manifest) {}
+public record PluginWrapper(
+        @NonNull Plugin plugin,
+        @NonNull URLClassLoader classLoader,
+        @NonNull Path path,
+        @NonNull PluginManifest manifest) {}

--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/SimpleEventBus.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/SimpleEventBus.java
@@ -21,7 +21,7 @@ public final class SimpleEventBus implements EventBus {
 
     @Override
     @SuppressWarnings("unchecked")
-    public void publish(Object event) {
+    public void publish(@NonNull Object event) {
         Class<?> cls = event.getClass();
         List<EventHandler<?>> list = handlers.get(cls);
         if (list == null) {

--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/YamlConfigSection.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/YamlConfigSection.java
@@ -3,6 +3,7 @@ package io.lonmstalker.tgkit.plugin;
 import io.lonmstalker.tgkit.plugin.spi.ConfigSection;
 import java.util.Map;
 import java.util.Optional;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * Чтение конфигурации из YAML-мэпки.
@@ -10,12 +11,12 @@ import java.util.Optional;
 public class YamlConfigSection implements ConfigSection {
     private final Map<String, Object> values;
 
-    public YamlConfigSection(Map<String, Object> values) {
+    public YamlConfigSection(@NonNull Map<String, Object> values) {
         this.values = values;
     }
 
     @Override
-    public Optional<String> get(String key) {
+    public @NonNull Optional<String> get(@NonNull String key) {
         Object v = values.get(key);
         return v == null ? Optional.empty() : Optional.of(v.toString());
     }

--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/spi/ConfigSection.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/spi/ConfigSection.java
@@ -1,13 +1,14 @@
 package io.lonmstalker.tgkit.plugin.spi;
 
 import java.util.Optional;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * Конфигурационный раздел плагина.
  */
 public interface ConfigSection {
 
-    Optional<String> get(String key);
+    @NonNull Optional<String> get(@NonNull String key);
 
     default int getInt(String key, int def) {
         return get(key).map(Integer::parseInt).orElse(def);

--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/spi/Plugin.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/spi/Plugin.java
@@ -1,5 +1,7 @@
 package io.lonmstalker.tgkit.plugin.spi;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+
 /**
  * Контракт плагина. Минимальный ABI, чтобы ядро могло безопасно загружать
  * внешние расширения.
@@ -15,7 +17,7 @@ public interface Plugin {
      * Инициализация плагина. Здесь следует только сохранять ссылки и
      * подписываться на события.
      */
-    void init(PluginContext ctx) throws Exception;
+    void init(@NonNull PluginContext ctx) throws Exception;
 
     /** Запуск логики после инициализации. */
     void start() throws Exception;


### PR DESCRIPTION
## Summary
- add Checker Framework annotations to plugin interfaces and implementations
- apply annotations to constructors, methods and record components

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684f451384a48325b793be64876b9ad8