### PR TITLE
Enable Java modules

### DIFF
--- a/api/src/main/java/io/lonmstalker/tgkit/core/BotCommand.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/BotCommand.java
@@ -8,6 +8,8 @@ import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
 /**
  * Обработчик конкретной команды бота.
  *
+ * <p><b>Стабильность:</b> API считается стабильным и совместимым между версиями.</p>
+ *
  * @param <T> тип объекта Telegram API, с которым работает обработчик
  */
 public interface BotCommand<T extends BotApiObject> {

--- a/api/src/main/java/io/lonmstalker/tgkit/core/BotRequestConverter.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/BotRequestConverter.java
@@ -6,6 +6,8 @@ import org.telegram.telegrambots.meta.api.objects.Update;
 /**
  * Преобразователь {@link Update} в необходимый тип данных запроса.
  *
+ * <p><b>Стабильность:</b> API находится в стадии эксперимента и может изменяться.</p>
+ *
  * @param <T> тип результата преобразования
  */
 @FunctionalInterface

--- a/api/src/main/java/io/lonmstalker/tgkit/core/event/BotEventBus.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/event/BotEventBus.java
@@ -5,6 +5,11 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
+/**
+ * Шина событий бота.
+ *
+ * <p><b>Стабильность:</b> API планируется стабильным, но пока может измениться.</p>
+ */
 public interface BotEventBus {
 
     /**

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,0 +1,37 @@
+module io.lonmstalker.tgkit.api {
+    requires transitive org.telegram.telegrambots;
+
+    exports io.lonmstalker.tgkit.core;
+    exports io.lonmstalker.tgkit.core.annotation;
+    exports io.lonmstalker.tgkit.core.args;
+    exports io.lonmstalker.tgkit.core.bot;
+    exports io.lonmstalker.tgkit.core.config;
+    exports io.lonmstalker.tgkit.core.crypto;
+    exports io.lonmstalker.tgkit.core.dsl;
+    exports io.lonmstalker.tgkit.core.dsl.context;
+    exports io.lonmstalker.tgkit.core.dsl.feature_flags;
+    exports io.lonmstalker.tgkit.core.dsl.ttl;
+    exports io.lonmstalker.tgkit.core.dsl.validator;
+    exports io.lonmstalker.tgkit.core.event;
+    exports io.lonmstalker.tgkit.core.exception;
+    exports io.lonmstalker.tgkit.core.i18n;
+    exports io.lonmstalker.tgkit.core.interceptor;
+    exports io.lonmstalker.tgkit.core.matching;
+    exports io.lonmstalker.tgkit.core.parse_mode;
+    exports io.lonmstalker.tgkit.core.resource;
+    exports io.lonmstalker.tgkit.core.state;
+    exports io.lonmstalker.tgkit.core.storage;
+    exports io.lonmstalker.tgkit.core.ttl;
+    exports io.lonmstalker.tgkit.core.user;
+    exports io.lonmstalker.tgkit.core.user.store;
+    exports io.lonmstalker.tgkit.core.wizard;
+    exports io.lonmstalker.tgkit.core.wizard.annotation;
+    exports io.lonmstalker.tgkit.observability;
+    exports io.lonmstalker.tgkit.plugin;
+    exports io.lonmstalker.tgkit.security.antispam;
+    exports io.lonmstalker.tgkit.security.audit;
+    exports io.lonmstalker.tgkit.security.captcha;
+    exports io.lonmstalker.tgkit.security.ratelimit;
+    exports io.lonmstalker.tgkit.security.rbac;
+    exports io.lonmstalker.tgkit.security.secret;
+}

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -1,0 +1,29 @@
+module io.lonmstalker.tgkit.core {
+    requires io.lonmstalker.tgkit.api;
+    requires org.slf4j;
+    requires org.apache.commons.lang3;
+    requires org.telegram.telegrambots;
+    requires com.fasterxml.jackson.databind;
+    requires com.fasterxml.jackson.dataformat.yaml;
+    requires com.h2database;
+    requires org.reflections;
+    requires io.netty.transport;
+
+    exports io.lonmstalker.tgkit.core.bot;
+    exports io.lonmstalker.tgkit.core.config;
+    exports io.lonmstalker.tgkit.core.crypto;
+    exports io.lonmstalker.tgkit.core.event;
+    exports io.lonmstalker.tgkit.core.i18n;
+    exports io.lonmstalker.tgkit.core.init;
+    exports io.lonmstalker.tgkit.core.loader to io.lonmstalker.tgkit.plugin;
+    exports io.lonmstalker.tgkit.core.matching;
+    exports io.lonmstalker.tgkit.core.processor;
+    exports io.lonmstalker.tgkit.core.resource;
+    exports io.lonmstalker.tgkit.core.state;
+    exports io.lonmstalker.tgkit.core.update;
+    exports io.lonmstalker.tgkit.core.user;
+    exports io.lonmstalker.tgkit.core.user.store;
+    exports io.lonmstalker.tgkit.core.wizard;
+    exports io.lonmstalker.tgkit.core.args;
+    exports io.lonmstalker.tgkit.core.interceptor;
+}

--- a/observability/src/main/java/module-info.java
+++ b/observability/src/main/java/module-info.java
@@ -1,0 +1,13 @@
+module io.lonmstalker.tgkit.observability {
+    requires io.lonmstalker.tgkit.core;
+    requires io.micrometer.core;
+    requires io.opentelemetry.api;
+    requires io.opentelemetry.sdk;
+    requires io.opentelemetry.exporter.logging;
+    requires ch.qos.logback.classic;
+    requires io.micrometer.registry.prometheus;
+    requires io.prometheus.simpleclient_httpserver;
+
+    exports io.lonmstalker.observability;
+    exports io.lonmstalker.observability.impl to io.lonmstalker.tgkit.plugin;
+}

--- a/plugin/src/main/java/module-info.java
+++ b/plugin/src/main/java/module-info.java
@@ -1,0 +1,10 @@
+module io.lonmstalker.tgkit.plugin {
+    requires io.lonmstalker.tgkit.core;
+    requires io.lonmstalker.tgkit.observability;
+    requires io.lonmstalker.tgkit.security;
+    requires org.slf4j;
+    requires com.fasterxml.jackson.dataformat.yaml;
+
+    exports io.lonmstalker.tgkit.plugin;
+    exports io.lonmstalker.tgkit.plugin.sort;
+}

--- a/security/src/main/java/module-info.java
+++ b/security/src/main/java/module-info.java
@@ -1,0 +1,19 @@
+module io.lonmstalker.tgkit.security {
+    requires io.lonmstalker.tgkit.core;
+    requires org.slf4j;
+    requires com.github.benmanes.caffeine;
+    requires io.github.jopenlibs.vault.java.driver;
+    requires jedis;
+
+    exports io.lonmstalker.tgkit.security;
+    exports io.lonmstalker.tgkit.security.antispam;
+    exports io.lonmstalker.tgkit.security.audit;
+    exports io.lonmstalker.tgkit.security.captcha;
+    exports io.lonmstalker.tgkit.security.captcha.provider;
+    exports io.lonmstalker.tgkit.security.event;
+    exports io.lonmstalker.tgkit.security.init;
+    exports io.lonmstalker.tgkit.security.ratelimit;
+    exports io.lonmstalker.tgkit.security.ratelimit.impl to io.lonmstalker.tgkit.plugin;
+    exports io.lonmstalker.tgkit.security.rbac;
+    exports io.lonmstalker.tgkit.security.secret;
+}


### PR DESCRIPTION
## Summary
- define JPMS `module-info.java` for `api`, `core`, `plugin`, `observability`, and `security`
- document API stability in `BotCommand`, `BotRequestConverter` and `BotEventBus`

## Testing
- `mvn -q -DskipCheckerFramework=true test` *(fails: Could not download maven-compiler-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_685476dfec348325acde94984f202315