### PR TITLE
Add Incubating annotation

### DIFF
--- a/core/src/main/java/io/lonmstalker/tgkit/core/experimental/Incubating.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/experimental/Incubating.java
@@ -1,0 +1,30 @@
+package io.lonmstalker.tgkit.core.experimental;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Помечает API как экспериментальный.
+ *
+ * <p>Элементы, аннотированные {@code @Incubating}, могут измениться или быть удалены
+ * без предупреждения.
+ *
+ * <p>Пример использования:
+ *
+ * <pre>{@code
+ * @Incubating
+ * public class ExperimentalApi { }
+ *
+ * @Incubating
+ * public void experimentalMethod() { }
+ * }
+ * </pre>
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface Incubating {
+}

--- a/core/src/test/java/io/lonmstalker/tgkit/core/experimental/IncubatingTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/experimental/IncubatingTest.java
@@ -1,0 +1,40 @@
+package io.lonmstalker.tgkit.core.experimental;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Test;
+
+/** Тесты для аннотации {@link Incubating}. */
+public class IncubatingTest {
+
+    @Incubating
+    static class ExperimentalClass {
+        @Incubating
+        void method() {}
+    }
+
+    /** Проверяет настройки мета-аннотаций. */
+    @Test
+    void verifyMetaAnnotations() {
+        Retention retention = Incubating.class.getAnnotation(Retention.class);
+        assertNotNull(retention);
+        assertEquals(RetentionPolicy.CLASS, retention.value());
+
+        Target target = Incubating.class.getAnnotation(Target.class);
+        assertNotNull(target);
+        assertArrayEquals(new ElementType[] {ElementType.TYPE, ElementType.METHOD}, target.value());
+    }
+
+    /** Убеждаемся, что аннотация не доступна во время выполнения. */
+    @Test
+    void annotationNotVisibleAtRuntime() throws NoSuchMethodException {
+        assertNull(ExperimentalClass.class.getAnnotation(Incubating.class));
+        assertNull(ExperimentalClass.class.getDeclaredMethod("method")
+                .getAnnotation(Incubating.class));
+    }
+}


### PR DESCRIPTION
## Summary
- add `@Incubating` for marking unstable APIs
- add tests validating annotation meta-information
- translate Javadoc and comments to Russian

## Testing
- `mvn -q -DskipCheckerFramework=true test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-compiler-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_685476e077e483258418276903b9e510