### PR TITLE
Add Maven central mirror settings

### DIFF
--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,0 +1,10 @@
+<settings>
+  <mirrors>
+    <mirror>
+      <id>central</id>
+      <name>Maven Central (HTTPS)</name>
+      <url>https://repo.maven.apache.org/maven2/</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>


### PR DESCRIPTION
## Summary
- add `.mvn/settings.xml` to use Maven Central mirror

## Testing
- `mvn -q test` *(failed: Network is unreachable)*
- `mvn -q checkstyle:check` *(failed: No plugin found due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68547eed0cb0832580d50dfad91c0732