### PR TITLE
Clarify Prometheus server lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ public void quiz(BotRequest<Message> req) {
 
 ### 3 — Observability за 30 секунд
 ```java
-var metrics = MicrometerCollector.prometheus(9180);   // /prometheus
+var metrics = MicrometerCollector.prometheus(9180);   // /prometheus, сервер уже запущен
 var tracer  = OTelTracer.stdoutDev();                 // спаны в лог
 
 BotConfig cfg = BotConfig.builder()

--- a/observability/src/main/java/io/lonmstalker/observability/impl/PrometheusMetricsServer.java
+++ b/observability/src/main/java/io/lonmstalker/observability/impl/PrometheusMetricsServer.java
@@ -9,20 +9,26 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 
 /**
- * Реализация ClosableMetricsServer на базе Prometheus HTTPServer.
+ * Реализация {@link ClosableMetricsServer} на базе Prometheus {@link HTTPServer}.
+ * <p>
+ * Конструктор сразу создаёт и запускает HTTPServer, поэтому {@link #start()} оставлен
+ * пустым. Достаточно создать экземпляр этого класса и он начнёт принимать запросы на
+ * указанный порт.
+ * </p>
  */
 public class PrometheusMetricsServer implements ClosableMetricsServer {
     private final HTTPServer server;
 
     @Builder
     public PrometheusMetricsServer(int port, CollectorRegistry registry) throws IOException {
-        // Создаём сервер без автоматического запуска
+        // HTTPServer автоматически запускается внутри конструктора
         server = new HTTPServer(new InetSocketAddress(port), registry, false);
     }
 
+    /** Метод ничего не делает, так как сервер запускается в конструкторе. */
     @Override
     public void start() throws IOException {
-        // none
+        // no-op
     }
 
     @Override

--- a/observability/src/test/java/io/lonmstalker/observability/MetricsServerLifecycleTest.java
+++ b/observability/src/test/java/io/lonmstalker/observability/MetricsServerLifecycleTest.java
@@ -11,7 +11,6 @@ class MetricsServerLifecycleTest {
         try (var srv = PrometheusMetricsServer.builder()
                 .port(port)
                 .build()) {
-            srv.start();
            Assertions.assertFalse(isFree(port));
         }
         Assertions.assertTrue(isFree(port));


### PR DESCRIPTION
## Summary
- document that PrometheusMetricsServer auto-starts on creation
- adjust lifecycle test accordingly
- update README example

## Testing
- `mvn -o verify` *(fails: PluginResolutionException for spotless-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68548068c29c83259d4043155aaf7b71