### PR TITLE
Improve executor thread naming

### DIFF
--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/BotPluginManager.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/BotPluginManager.java
@@ -48,7 +48,8 @@ public final class BotPluginManager implements AutoCloseable {
 
     private final Lock lock = new ReentrantLock();
     private final ObjectMapper yaml = new ObjectMapper(new YAMLFactory());
-    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private final ExecutorService executor =
+            Executors.newSingleThreadExecutor(r -> new Thread(r, "plugin-manager"));
     private final AuditBus auditBus = BotSecurityGlobalConfig.INSTANCE.audit().bus();
     private final Map<String, BotPluginContainer> plugins = new ConcurrentHashMap<>();
 

--- a/plugin/src/test/java/io/lonmstalker/tgkit/plugin/BotPluginManagerTest.java
+++ b/plugin/src/test/java/io/lonmstalker/tgkit/plugin/BotPluginManagerTest.java
@@ -22,6 +22,7 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 
 import static io.lonmstalker.tgkit.plugin.BotPluginConstants.CURRENT_VERSION;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
@@ -131,6 +132,23 @@ public class BotPluginManagerTest {
         ));
     }
 
+    @Test
+    void testExecutorThreadName() throws Exception {
+        Path jar = tempDir.resolve("thread.jar");
+        createPluginJar(jar,
+                "thread",
+                String.valueOf(CURRENT_VERSION),
+                String.valueOf(CURRENT_VERSION),
+                ThreadNamePlugin.class.getName(),
+                null);
+
+        manager.loadAll(tempDir);
+        manager.unload("thread");
+
+        assertEquals("plugin-manager", ThreadNamePlugin.thread,
+                "Имя потока должно совпадать с factory value");
+    }
+
     private static void createPluginJar(Path path,
                                         String id,
                                         String version,
@@ -171,6 +189,15 @@ public class BotPluginManagerTest {
 
         @Override
         public void onUnload() {
+        }
+    }
+
+    public static class ThreadNamePlugin implements BotPlugin {
+        static volatile String thread;
+
+        @Override
+        public void stop() {
+            thread = Thread.currentThread().getName();
         }
     }
 }


### PR DESCRIPTION
## Summary
- configure BotPluginManager to use single-thread executor with custom name
- verify thread name via unit test

## Testing
- `mvn -q verify` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6854807ba1b4832592bf31ef225fd62a