### PR TITLE
Add testkit module with TelegramMockServer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,4 @@ jobs:
           java-version: 21
 
       - name: Maven verify
-        run: mvn -B spotless:check checkstyle:check verify
+        run: mvn -B -pl telegram-bot-testkit,core,observability,plugin,security,examples,api spotless:check checkstyle:check verify

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <module>security</module>
         <module>examples</module>
         <module>api</module>
+        <module>telegram-bot-testkit</module>
     </modules>
 
     <properties>
@@ -40,6 +41,7 @@
         <jedis.version>6.0.0</jedis.version>
         <http-simple-client.version>0.16.0</http-simple-client.version>
         <netty.version>4.2.2.Final</netty.version>
+        <undertow.version>2.3.9.Final</undertow.version>
         <vault.version>6.2.0</vault.version>
 
         <!-- PLUGINS -->
@@ -155,6 +157,11 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport</artifactId>
                 <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.undertow</groupId>
+                <artifactId>undertow-core</artifactId>
+                <version>${undertow.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.github.jopenlibs</groupId>

--- a/telegram-bot-testkit/pom.xml
+++ b/telegram-bot-testkit/pom.xml
@@ -1,0 +1,31 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.lonmstalker.tgkit</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>telegram-bot-testkit</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.lonmstalker.tgkit</groupId>
+            <artifactId>api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/telegram-bot-testkit/src/main/java/io/lonmstalker/tgkit/testkit/BotTestExtension.java
+++ b/telegram-bot-testkit/src/main/java/io/lonmstalker/tgkit/testkit/BotTestExtension.java
@@ -1,0 +1,69 @@
+package io.lonmstalker.tgkit.testkit;
+
+import io.lonmstalker.tgkit.core.bot.BotConfig;
+import io.lonmstalker.tgkit.core.bot.TelegramSender;
+import io.lonmstalker.tgkit.core.bot.BotAdapterImpl;
+import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+/**
+ * JUnit extension, подготавливающий {@link TelegramMockServer} и утилиты.
+ */
+public final class BotTestExtension implements BeforeEachCallback, AfterEachCallback, ParameterResolver {
+
+    private TelegramMockServer server;
+    private TelegramSender sender;
+    private UpdateInjector injector;
+    private BotAdapterImpl adapter;
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        BotCoreInitializer.init();
+        server = new TelegramMockServer();
+        BotConfig config = BotConfig.builder().baseUrl(server.baseUrl()).build();
+        sender = new TelegramSender(config, "TEST_TOKEN");
+        adapter = BotAdapterImpl.builder()
+                .internalId(1L)
+                .sender(sender)
+                .config(config)
+                .build();
+        injector = new UpdateInjector(adapter, sender);
+        // ответ для getMe
+        server.enqueue("{\"ok\":true,\"result\":{\"id\":1,\"is_bot\":true,\"username\":\"bot\"}}");
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        try {
+            if (sender != null) {
+                sender.close();
+            }
+        } catch (Exception ignored) {
+        }
+        if (server != null) {
+            server.close();
+        }
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        Class<?> type = parameterContext.getParameter().getType();
+        return type == TelegramMockServer.class || type == UpdateInjector.class || type == BotAdapterImpl.class;
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        Class<?> type = parameterContext.getParameter().getType();
+        if (type == TelegramMockServer.class) {
+            return server;
+        } else if (type == UpdateInjector.class) {
+            return injector;
+        } else {
+            return adapter;
+        }
+    }
+}

--- a/telegram-bot-testkit/src/main/java/io/lonmstalker/tgkit/testkit/RecordedRequest.java
+++ b/telegram-bot-testkit/src/main/java/io/lonmstalker/tgkit/testkit/RecordedRequest.java
@@ -1,0 +1,13 @@
+package io.lonmstalker.tgkit.testkit;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Информация о запросе, полученном {@link TelegramMockServer}.
+ */
+public record RecordedRequest(
+        String method,
+        String path,
+        Map<String, List<String>> headers,
+        String body) {}

--- a/telegram-bot-testkit/src/main/java/io/lonmstalker/tgkit/testkit/TelegramBotTest.java
+++ b/telegram-bot-testkit/src/main/java/io/lonmstalker/tgkit/testkit/TelegramBotTest.java
@@ -1,0 +1,15 @@
+package io.lonmstalker.tgkit.testkit;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Упрощённая аннотация для подключения {@link BotTestExtension}.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(BotTestExtension.class)
+public @interface TelegramBotTest {}

--- a/telegram-bot-testkit/src/main/java/io/lonmstalker/tgkit/testkit/TelegramMockServer.java
+++ b/telegram-bot-testkit/src/main/java/io/lonmstalker/tgkit/testkit/TelegramMockServer.java
@@ -1,0 +1,78 @@
+package io.lonmstalker.tgkit.testkit;
+
+import io.undertow.Undertow;
+import io.undertow.util.Headers;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Минимальный HTTP-сервер, имитирующий Telegram API для тестов.
+ */
+public final class TelegramMockServer implements AutoCloseable {
+
+    private final Undertow server;
+    private final int port;
+    private final BlockingQueue<RecordedRequest> requests = new LinkedBlockingQueue<>();
+    private final Queue<String> responses = new LinkedBlockingQueue<>();
+
+    /** Создаёт и запускает сервер на свободном порту. */
+    public TelegramMockServer() {
+        this.port = findFreePort();
+        this.server = Undertow.builder()
+                .addHttpListener(port, "localhost")
+                .setHandler(exchange -> {
+                    exchange.startBlocking();
+                    String body = exchange.getInputStream().readAllBytes().length == 0 ? "" :
+                            new String(exchange.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+                    requests.add(new RecordedRequest(
+                            exchange.getRequestMethod().toString(),
+                            exchange.getRequestPath(),
+                            exchange.getRequestHeaders().getHeaderNames().stream()
+                                    .collect(java.util.stream.Collectors.toMap(
+                                            Object::toString,
+                                            h -> exchange.getRequestHeaders().get(h))),
+                            body));
+                    String response = Objects.requireNonNullElse(responses.poll(),
+                            "{\"ok\":true}");
+                    exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
+                    exchange.getResponseSender().send(response);
+                })
+                .build();
+        this.server.start();
+    }
+
+    /** Базовый URL для передачи в {@link io.lonmstalker.tgkit.core.bot.BotConfig#setBaseUrl(String)}. */
+    public String baseUrl() {
+        return "http://localhost:" + port + "/bot";
+    }
+
+    /** Добавляет ответ, который будет отправлен при следующем запросе. */
+    public void enqueue(String json) {
+        responses.add(json);
+    }
+
+    /** Возвращает следующий записанный запрос или {@code null}, если таймаут истёк. */
+    public RecordedRequest takeRequest(long timeout, TimeUnit unit) throws InterruptedException {
+        return requests.poll(timeout, unit);
+    }
+
+    private static int findFreePort() {
+        try (ServerSocket socket = new ServerSocket()) {
+            socket.bind(new InetSocketAddress(0));
+            return socket.getLocalPort();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to allocate port", e);
+        }
+    }
+
+    @Override
+    public void close() {
+        server.stop();
+    }
+}

--- a/telegram-bot-testkit/src/main/java/io/lonmstalker/tgkit/testkit/UpdateInjector.java
+++ b/telegram-bot-testkit/src/main/java/io/lonmstalker/tgkit/testkit/UpdateInjector.java
@@ -1,0 +1,66 @@
+package io.lonmstalker.tgkit.testkit;
+
+import io.lonmstalker.tgkit.core.BotAdapter;
+import io.lonmstalker.tgkit.core.bot.TelegramSender;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.objects.Chat;
+import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.User;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Утилита для инъекции тестовых {@link Update} в {@link BotAdapter}.
+ */
+public final class UpdateInjector {
+
+    private final BotAdapter adapter;
+    private final TelegramSender sender;
+    private final AtomicInteger nextId = new AtomicInteger();
+
+    public UpdateInjector(@NonNull BotAdapter adapter, @NonNull TelegramSender sender) {
+        this.adapter = adapter;
+        this.sender = sender;
+    }
+
+    /** Создаёт Update с текстовым сообщением. */
+    public Builder text(String text) {
+        Message msg = new Message();
+        msg.setText(text);
+        Update update = new Update();
+        update.setMessage(msg);
+        return new Builder(update);
+    }
+
+    /** Билдер для указания параметров Update. */
+    public final class Builder {
+        private final Update update;
+
+        private Builder(Update update) {
+            this.update = update;
+        }
+
+        /** Устанавливает отправителя и чат. */
+        public Builder from(long id) {
+            Chat chat = new Chat();
+            chat.setId(id);
+            User user = new User();
+            user.setId(id);
+            Objects.requireNonNull(update.getMessage()).setChat(chat);
+            update.getMessage().setFrom(user);
+            return this;
+        }
+
+        /** Отправляет Update в бота. */
+        public void dispatch() {
+            update.setUpdateId(nextId.incrementAndGet());
+            BotApiMethod<?> method = adapter.handle(update);
+            if (method != null) {
+                sender.execute(method);
+            }
+        }
+    }
+}

--- a/telegram-bot-testkit/src/test/java/io/lonmstalker/tgkit/testkit/TelegramMockServerTest.java
+++ b/telegram-bot-testkit/src/test/java/io/lonmstalker/tgkit/testkit/TelegramMockServerTest.java
@@ -1,0 +1,33 @@
+package io.lonmstalker.tgkit.testkit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+class TelegramMockServerTest {
+
+    @Test
+    void recordsRequestAndReturnsEnqueuedResponse() throws Exception {
+        try (TelegramMockServer server = new TelegramMockServer()) {
+            server.enqueue("{\"ok\":true,\"result\":42}");
+            HttpClient client = HttpClient.newHttpClient();
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(server.baseUrl() + "TEST/sendMessage"))
+                    .POST(HttpRequest.BodyPublishers.ofString("{}"))
+                    .build();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            assertThat(response.body()).contains("\"result\":42");
+            RecordedRequest recorded = server.takeRequest(1, TimeUnit.SECONDS);
+            assertThat(recorded).isNotNull();
+            assertThat(recorded.path()).endsWith("/sendMessage");
+            assertThat(recorded.method()).isEqualTo("POST");
+            assertThat(recorded.body()).isEqualTo("{}");
+        }
+    }
+}

--- a/telegram-bot-testkit/src/test/java/io/lonmstalker/tgkit/testkit/WelcomeFlowTest.java
+++ b/telegram-bot-testkit/src/test/java/io/lonmstalker/tgkit/testkit/WelcomeFlowTest.java
@@ -1,0 +1,50 @@
+package io.lonmstalker.tgkit.testkit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.lonmstalker.tgkit.core.BotCommand;
+import io.lonmstalker.tgkit.core.BotRequest;
+import io.lonmstalker.tgkit.core.BotRequestType;
+import io.lonmstalker.tgkit.core.BotResponse;
+import io.lonmstalker.tgkit.core.bot.BotAdapterImpl;
+import io.lonmstalker.tgkit.core.matching.CommandMatch;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.objects.Message;
+
+import java.util.concurrent.TimeUnit;
+
+@TelegramBotTest
+class WelcomeFlowTest {
+
+    @Test
+    void startCommandSendsWelcome(UpdateInjector injector,
+                                  TelegramMockServer server,
+                                  BotAdapterImpl adapter) throws Exception {
+        adapter.registry().add(new StartCommand());
+        injector.text("/start").from(42L).dispatch();
+        RecordedRequest req = server.takeRequest(1, TimeUnit.SECONDS);
+        assertThat(req).isNotNull();
+        assertThat(req.path()).endsWith("/sendMessage");
+        assertThat(req.body()).contains("Welcome");
+    }
+
+    private static class StartCommand implements BotCommand<Message> {
+        @Override
+        public BotResponse handle(@NonNull BotRequest<Message> request) {
+            return BotResponse.builder()
+                    .method(request.msg("Welcome").build())
+                    .build();
+        }
+
+        @Override
+        public @NonNull BotRequestType type() {
+            return BotRequestType.MESSAGE;
+        }
+
+        @Override
+        public @NonNull CommandMatch<Message> matcher() {
+            return msg -> "/start".equals(msg.getText());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `telegram-bot-testkit` with Undertow-based mock server
- provide `RecordedRequest`, `UpdateInjector`, `BotTestExtension` and `@TelegramBotTest`
- add sample `WelcomeFlowTest`
- integrate module into parent POM and CI workflow

## Testing
- `mvn -q -pl telegram-bot-testkit test` *(fails: Plugin com.diffplug.spotless:spotless-maven-plugin:2.44.5 or one of its dependencies could not be resolved)*
- `mvn -q spotless:apply verify` *(fails: No plugin found for prefix 'spotless')*

------
https://chatgpt.com/codex/tasks/task_e_6854808453e88325a91fe29c4ce370ec