### PR TITLE
Add BotBuilder with classpath scanning

### DIFF
--- a/api/src/main/java/io/lonmstalker/tgkit/core/annotation/BotCommand.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/annotation/BotCommand.java
@@ -1,0 +1,14 @@
+package io.lonmstalker.tgkit.core.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a class as a bot command for classpath scanning.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BotCommand {
+}

--- a/api/src/main/java/io/lonmstalker/tgkit/core/annotation/CheckReturnValue.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/annotation/CheckReturnValue.java
@@ -1,0 +1,14 @@
+package io.lonmstalker.tgkit.core.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks methods whose return value should not be ignored.
+ */
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckReturnValue {
+}

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotBuilder.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotBuilder.java
@@ -1,0 +1,134 @@
+package io.lonmstalker.tgkit.core.bot;
+
+import io.lonmstalker.tgkit.core.BotAdapter;
+import io.lonmstalker.tgkit.core.bot.BotFactory;
+import io.lonmstalker.tgkit.core.annotation.BotCommand;
+import io.lonmstalker.tgkit.core.annotation.CheckReturnValue;
+import io.lonmstalker.tgkit.core.loader.ClasspathScanner;
+import io.lonmstalker.tgkit.core.bot.BotCommandRegistry;
+import io.lonmstalker.tgkit.plugin.BotPlugin;
+import io.lonmstalker.tgkit.plugin.BotPluginContext;
+import io.lonmstalker.tgkit.plugin.BotPluginContextDefault;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.telegram.telegrambots.meta.api.methods.updates.SetWebhook;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * Fluent builder for creating and starting bots.
+ */
+public final class BotBuilder {
+    private BotBuilder() {}
+
+    public static @NonNull BotBuilderImpl builder() {
+        return new BotBuilderImpl();
+    }
+
+    /**
+     * Actual implementation of the builder.
+     */
+    public static final class BotBuilderImpl {
+        private final List<String> packages = new ArrayList<>();
+        private final List<Supplier<BotPlugin>> plugins = new ArrayList<>();
+        private String token;
+        private boolean polling = true;
+        private int webhookPort = -1;
+        private boolean started;
+
+        @CheckReturnValue
+        public @NonNull BotBuilderImpl token(@NonNull String token) {
+            this.token = Objects.requireNonNull(token);
+            return this;
+        }
+
+        @CheckReturnValue
+        public @NonNull BotBuilderImpl withPolling() {
+            this.polling = true;
+            this.webhookPort = -1;
+            return this;
+        }
+
+        @CheckReturnValue
+        public @NonNull BotBuilderImpl withWebhook(int port) {
+            this.polling = false;
+            this.webhookPort = port;
+            return this;
+        }
+
+        @CheckReturnValue
+        public @NonNull BotBuilderImpl scan(@NonNull String pkg) {
+            packages.add(Objects.requireNonNull(pkg));
+            return this;
+        }
+
+        @CheckReturnValue
+        public @NonNull BotBuilderImpl plugin(@NonNull Supplier<BotPlugin> supplier) {
+            plugins.add(Objects.requireNonNull(supplier));
+            return this;
+        }
+
+        @CheckReturnValue
+        public synchronized @NonNull Bot start() {
+            if (started) {
+                throw new IllegalStateException("start() already called");
+            }
+            Objects.requireNonNull(token, "token must be set");
+            started = true;
+
+            BotConfig config = BotConfig.builder().build();
+            BotAdapter adapter = u -> null;
+            Bot bot;
+            if (polling) {
+                bot = BotFactory.INSTANCE.from(token, config, adapter);
+            } else {
+                SetWebhook hook = new SetWebhook();
+                hook.setUrl("http://localhost:" + webhookPort);
+                bot = BotFactory.INSTANCE.from(token, config, adapter, hook);
+            }
+
+            BotCommandRegistry registry = bot.registry();
+            for (String pkg : packages) {
+                Set<Class<?>> cmdClasses =
+                        ClasspathScanner.findAnnotated(BotCommand.class, pkg);
+                for (Class<?> cls : cmdClasses) {
+                    try {
+                        Object instance = cls.getDeclaredConstructor().newInstance();
+                        registry.add((io.lonmstalker.tgkit.core.BotCommand<?>) instance);
+                    } catch (Exception e) {
+                        throw new IllegalStateException("Cannot init command " + cls, e);
+                    }
+                }
+
+                Set<Class<?>> pluginClasses =
+                        ClasspathScanner.findAnnotated(
+                                io.lonmstalker.tgkit.plugin.annotation.BotPlugin.class, pkg);
+                for (Class<?> cls : pluginClasses) {
+                    plugins.add(() -> {
+                        try {
+                            return (BotPlugin) cls.getDeclaredConstructor().newInstance();
+                        } catch (Exception e) {
+                            throw new IllegalStateException("Cannot init plugin " + cls, e);
+                        }
+                    });
+                }
+            }
+
+            BotPluginContext ctx = new BotPluginContextDefault(ClassLoader.getSystemClassLoader());
+            for (Supplier<BotPlugin> supplier : plugins) {
+                BotPlugin p = supplier.get();
+                try {
+                    p.onLoad(ctx);
+                    p.start();
+                } catch (Exception e) {
+                    throw new IllegalStateException("Plugin start failed", e);
+                }
+            }
+
+            return bot;
+        }
+    }
+}

--- a/core/src/main/java/io/lonmstalker/tgkit/core/loader/ClasspathScanner.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/loader/ClasspathScanner.java
@@ -1,0 +1,29 @@
+package io.lonmstalker.tgkit.core.loader;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.reflections.Reflections;
+import org.reflections.scanners.Scanners;
+import org.reflections.util.ConfigurationBuilder;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+/**
+ * Utility for scanning the classpath for annotated classes.
+ */
+public final class ClasspathScanner {
+    private ClasspathScanner() {}
+
+    /**
+     * Finds all classes annotated with the given annotation under the package.
+     */
+    public static @NonNull Set<Class<?>> findAnnotated(
+            @NonNull Class<? extends Annotation> annotation,
+            @NonNull String basePackage) {
+        ConfigurationBuilder cb = new ConfigurationBuilder()
+                .forPackages(basePackage)
+                .addScanners(Scanners.TypesAnnotated);
+        Reflections reflections = new Reflections(cb);
+        return reflections.getTypesAnnotatedWith(annotation);
+    }
+}

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotBuilderTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotBuilderTest.java
@@ -1,0 +1,56 @@
+package io.lonmstalker.tgkit.core.bot;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.lonmstalker.tgkit.core.BotCommand;
+import io.lonmstalker.tgkit.core.BotRequest;
+import io.lonmstalker.tgkit.core.BotRequestType;
+import io.lonmstalker.tgkit.core.BotResponse;
+import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
+import io.lonmstalker.tgkit.plugin.BotPlugin;
+import io.lonmstalker.tgkit.plugin.BotPluginContext;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class BotBuilderTest {
+
+    static {
+        BotCoreInitializer.init();
+    }
+
+    @io.lonmstalker.tgkit.core.annotation.BotCommand
+    public static class TestCommand implements BotCommand<BotApiObject> {
+        @Override public BotResponse handle(BotRequest<BotApiObject> request) { return null; }
+        @Override public BotRequestType type() { return BotRequestType.MESSAGE; }
+        @Override public io.lonmstalker.tgkit.core.matching.CommandMatch<BotApiObject> matcher() { return u -> true; }
+    }
+
+    @io.lonmstalker.tgkit.plugin.annotation.BotPlugin
+    public static class TestPlugin implements BotPlugin {
+        static final AtomicBoolean started = new AtomicBoolean();
+        @Override public void onLoad(BotPluginContext ctx) { }
+        @Override public void start() { started.set(true); }
+    }
+
+    @Test
+    void startRegistersCommandAndPlugin() {
+        BotBuilder.BotBuilderImpl builder = BotBuilder.builder()
+                .token("T")
+                .withPolling()
+                .scan(TestCommand.class.getPackageName());
+
+        Bot bot = builder.start();
+
+        assertNotNull(bot.registry().find(BotRequestType.MESSAGE, "", new BotApiObject() {}));
+        assertTrue(TestPlugin.started.get());
+    }
+
+    @Test
+    void startIsIdempotent() {
+        BotBuilder.BotBuilderImpl builder = BotBuilder.builder().token("T").withPolling();
+        builder.start();
+        assertThrows(IllegalStateException.class, builder::start);
+    }
+}

--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/annotation/BotPlugin.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/annotation/BotPlugin.java
@@ -1,0 +1,14 @@
+package io.lonmstalker.tgkit.plugin.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a class as a plugin for classpath scanning.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BotPlugin {
+}

--- a/plugin/src/main/java/module-info.java
+++ b/plugin/src/main/java/module-info.java
@@ -6,5 +6,6 @@ module io.lonmstalker.tgkit.plugin {
     requires com.fasterxml.jackson.dataformat.yaml;
 
     exports io.lonmstalker.tgkit.plugin;
+    exports io.lonmstalker.tgkit.plugin.annotation;
     exports io.lonmstalker.tgkit.plugin.sort;
 }


### PR DESCRIPTION
## Summary
- introduce annotations `@BotCommand` and `@CheckReturnValue`
- add `@BotPlugin` annotation in plugin module
- implement `ClasspathScanner` utility
- add `BotBuilder` with `BotBuilderImpl` fluent API
- provide unit tests for `BotBuilder`

## Testing
- `mvn com.diffplug.spotless:spotless-maven-plugin:2.44.5:apply verify` *(fails: Could not transfer artifact com.diffplug.spotless:spotless-maven-plugin)*


------
https://chatgpt.com/codex/tasks/task_e_68548086bc0c83258720147ffb5508c4