### PR TITLE
Add lifecycle and converter tests

### DIFF
--- a/core/src/test/java/io/lonmstalker/tgkit/core/args/ConvertersTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/args/ConvertersTest.java
@@ -1,6 +1,6 @@
 package io.lonmstalker.tgkit.core.args;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 import io.lonmstalker.tgkit.core.exception.BotApiException;
 import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
@@ -14,10 +14,40 @@ public class ConvertersTest {
         BotCoreInitializer.init();
     }
 
+    enum Color { RED, BLUE }
+
+    static class UpperConverter implements BotArgumentConverter<String> {
+        @Override
+        public String convert(String raw, Context ctx) { return raw.toUpperCase(); }
+    }
+
     @Test
     void unsupported_number_converter() {
         var converter = Converters.getByType(BigDecimal.class);
         assertThrows(BotApiException.class,
                 () -> converter.convert("1", new Context(null, null)));
+    }
+
+    @Test
+    void primitive_and_boxed_conversion() {
+        var intConv = Converters.getByType(int.class);
+        assertEquals(5, intConv.convert("5", new Context(null, null)));
+        var boolConv = Converters.getByType(Boolean.class);
+        assertTrue(boolConv.convert("true", new Context(null, null)));
+    }
+
+    @Test
+    void enum_conversion() {
+        var conv = Converters.getByType(Color.class);
+        assertEquals(Color.BLUE, conv.convert("BLUE", new Context(null, null)));
+    }
+
+    @Test
+    void getByClass_caches_instances() {
+        var first = Converters.getByClass(UpperConverter.class);
+        var second = Converters.getByClass(UpperConverter.class);
+        assertSame(first, second);
+        assertEquals("ABC", ((BotArgumentConverter<String>) first)
+                .convert("abc", new Context(null, null)));
     }
 }


### PR DESCRIPTION
## Summary
- add lifecycle tests for `BotImpl` covering start/stop scenarios
- expand argument conversion tests to verify primitive, enum and caching cases

## Testing
- `mvn -q -pl core test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6854805cb4bc8325bcdeb38cbc2b51d2