### PR TITLE
Enable JaCoCo coverage reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,12 @@ jobs:
 
       - name: Maven verify
         run: mvn -B -pl telegram-bot-testkit,core,observability,plugin,security,examples,api spotless:check checkstyle:check verify
+
+      - name: JaCoCo report
+        run: mvn -B jacoco:report
+
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: '**/target/site/jacoco'

--- a/README.md
+++ b/README.md
@@ -174,6 +174,13 @@ mvn clean install
 mvn test
 ```
 
+Для генерации отчёта по покрытию:
+
+```bash
+mvn verify jacoco:report
+```
+Результат ищите в `target/site/jacoco/index.html`.
+
 ## 🤝 Contributing
 PR-ы и идеи приветствуются! Перед отправкой ознакомьтесь с [CONTRIBUTING.md](CONTRIBUTING.md) и [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <spotless-maven-plugin.version>2.44.5</spotless-maven-plugin.version>
         <revapi.version>0.28.2</revapi.version>
         <revapi-maven-plugin.version>0.15.1</revapi-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
 
         <!-- TEST -->
         <h2.version>2.3.232</h2.version>
@@ -280,6 +281,41 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.90</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary
- configure `jacoco-maven-plugin` for 90% line coverage
- generate coverage in CI and upload reports
- document how to run coverage locally

## Testing
- `mvn -B spotless:apply verify` *(fails: No plugin found for prefix 'spotless')*
- `mvn -B jacoco:report` *(fails: No plugin found for prefix 'jacoco')*

------
https://chatgpt.com/codex/tasks/task_e_685492180e9c8325beeab932335fcafe