### PR TITLE
Fix body reading in TelegramMockServer

### DIFF
--- a/telegram-bot-testkit/src/main/java/io/lonmstalker/tgkit/testkit/TelegramMockServer.java
+++ b/telegram-bot-testkit/src/main/java/io/lonmstalker/tgkit/testkit/TelegramMockServer.java
@@ -28,8 +28,8 @@ public final class TelegramMockServer implements AutoCloseable {
                 .addHttpListener(port, "localhost")
                 .setHandler(exchange -> {
                     exchange.startBlocking();
-                    String body = exchange.getInputStream().readAllBytes().length == 0 ? "" :
-                            new String(exchange.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+                    byte[] bytes = exchange.getInputStream().readAllBytes();
+                    String body = bytes.length == 0 ? "" : new String(bytes, StandardCharsets.UTF_8);
                     requests.add(new RecordedRequest(
                             exchange.getRequestMethod().toString(),
                             exchange.getRequestPath(),

--- a/telegram-bot-testkit/src/test/java/io/lonmstalker/tgkit/testkit/TelegramMockServerTest.java
+++ b/telegram-bot-testkit/src/test/java/io/lonmstalker/tgkit/testkit/TelegramMockServerTest.java
@@ -30,4 +30,22 @@ class TelegramMockServerTest {
             assertThat(recorded.body()).isEqualTo("{}");
         }
     }
+
+    @Test
+    void recordsEmptyBodyWhenNoContent() throws Exception {
+        try (TelegramMockServer server = new TelegramMockServer()) {
+            HttpClient client = HttpClient.newHttpClient();
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(server.baseUrl() + "TEST/getMe"))
+                    .GET()
+                    .build();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            assertThat(response.body()).contains("\"ok\":true");
+            RecordedRequest recorded = server.takeRequest(1, TimeUnit.SECONDS);
+            assertThat(recorded).isNotNull();
+            assertThat(recorded.method()).isEqualTo("GET");
+            assertThat(recorded.path()).endsWith("/getMe");
+            assertThat(recorded.body()).isEmpty();
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- correct request body reading in TelegramMockServer
- add unit test for empty body handling

## Testing
- `mvn -q -pl telegram-bot-testkit -DskipTests=false test` *(fails: Could not resolve com.diffplug.spotless:spotless-maven-plugin)*
- `mvn -q spotless:apply verify` *(fails: No plugin found for prefix 'spotless')*

------
https://chatgpt.com/codex/tasks/task_e_68549225a81483258138414395839189