### PR TITLE
Add Russian Javadoc for BotSessionImpl

### DIFF
--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotSessionImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotSessionImpl.java
@@ -28,6 +28,39 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+/**
+ * Сессия бота, получающая обновления через HTTP long polling и передающая их
+ * реализованному {@link LongPollingBot}.
+ *
+ * <p>Класс поддерживает два фоновых цикла:
+ * <ul>
+ *   <li>read loop отправляет запрос {@code getUpdates} и кладёт полученные обновления в очередь</li>
+ *   <li>handle loop берёт их из очереди и передаёт в бот</li>
+ * </ul>
+ * Циклы работают на переданном или стандартном executor.
+ *
+ * <p>Жизненный цикл:
+ * <ol>
+ *   <li>создайте сессию, укажите опции, токен и callback</li>
+ *   <li>однократно вызовите {@link #start()} для запуска опроса</li>
+ *   <li>завершите работу через {@link #stop()}</li>
+ * </ol>
+ *
+ * <p>Пример использования:
+ * <pre>{@code
+ * ExecutorService executor = Executors.newSingleThreadExecutor();
+ * BotSessionImpl session = new BotSessionImpl(executor, new ObjectMapper());
+ * DefaultBotOptions opts = new DefaultBotOptions();
+ * session.setOptions(opts);
+ * session.setToken("123456:ABC-DEF");
+ * session.setCallback(new MyLongPollingBot(opts));
+ * session.start();
+ * // ...
+ * session.stop();
+ * executor.shutdown();
+ * }</pre>
+ */
+
 @Slf4j
 @SuppressWarnings({"dereference.of.nullable", "argument"})
 public class BotSessionImpl implements BotSession {


### PR DESCRIPTION
## Summary
- localize BotSessionImpl Javadoc to Russian per review comments

## Testing
- `mvn -q -DskipTests=false -pl :core -Dinvoker.skip=true spotless:apply verify` *(failed: plugin could not be resolved)*
- `mvn -q -pl :core test-compile` *(failed: plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6854999154d48325ba5a32253f9baa35