### PR TITLE
Implement async BotSession backoff

### DIFF
--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotSessionImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotSessionImpl.java
@@ -141,35 +141,57 @@ public class BotSessionImpl implements BotSession {
 
     @SuppressWarnings("argument")
     private void readLoop() {
-        long backOff = 1;
-        while (running.get()) {
-            try {
-                HttpRequest request = HttpRequest.newBuilder()
-                        .uri(URI.create(buildUrl()))
-                        .timeout(Duration.ofSeconds(Objects.requireNonNull(options).getGetUpdatesTimeout() + 5))
-                        .GET()
-                        .build();
-                String body = Objects.requireNonNull(httpClient)
-                        .send(request, HttpResponse.BodyHandlers.ofString()).body();
-                GetUpdatesResponse response = mapper.readValue(body, GetUpdatesResponse.class);
-                if (response.result != null && !response.result.isEmpty()) {
-                    for (Update update : response.result) {
-                        if (update.getUpdateId() > lastUpdateId) {
-                            lastUpdateId = update.getUpdateId();
-                            updates.put(update);
-                        }
-                    }
-                }
-            } catch (IOException | InterruptedException e) {
-                log.warn("Error in readLoop: {}, backing off {}s", e.getMessage(), backOff);
-                try {
-                    TimeUnit.SECONDS.sleep(1);
-                } catch (InterruptedException ex) {
-                    Thread.currentThread().interrupt();
-                }
-                backOff = Math.min(backOff * 2, 30);
-            }
+        scheduleRead(1);
+    }
+
+    @SuppressWarnings("argument")
+    void scheduleRead(long backOff) {
+        if (!running.get()) {
+            return;
         }
+        BotGlobalConfig.INSTANCE.executors().getScheduledExecutorService()
+                .schedule(() -> sendRequest(backOff), backOff, TimeUnit.SECONDS);
+    }
+
+    @SuppressWarnings("argument")
+    private void sendRequest(long backOff) {
+        if (!running.get()) {
+            return;
+        }
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(buildUrl()))
+                .timeout(Duration.ofSeconds(Objects.requireNonNull(options).getGetUpdatesTimeout() + 5))
+                .GET()
+                .build();
+        Objects.requireNonNull(httpClient)
+                .sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .thenApply(HttpResponse::body)
+                .thenAccept(body -> {
+                    try {
+                        GetUpdatesResponse response = mapper.readValue(body, GetUpdatesResponse.class);
+                        if (response.result != null && !response.result.isEmpty()) {
+                            for (Update update : response.result) {
+                                if (update.getUpdateId() > lastUpdateId) {
+                                    lastUpdateId = update.getUpdateId();
+                                    updates.put(update);
+                                }
+                            }
+                        }
+                        scheduleRead(1);
+                    } catch (Exception ex) {
+                        scheduleRead(handleError(ex, backOff));
+                    }
+                })
+                .exceptionally(ex -> {
+                    Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
+                    scheduleRead(handleError(cause, backOff));
+                    return null;
+                });
+    }
+
+    long handleError(Throwable ex, long backOff) {
+        log.warn("Error in readLoop: {}, backing off {}s", ex.getMessage(), backOff);
+        return Math.min(backOff * 2, 30);
     }
 
     @SuppressWarnings("argument")

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotSessionImplTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotSessionImplTest.java
@@ -10,6 +10,7 @@ import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.generics.BotOptions;
 import org.telegram.telegrambots.meta.generics.LongPollingBot;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -34,6 +35,14 @@ public class BotSessionImplTest {
         session.stop();
         assertFalse(session.isRunning());
         assertThrows(IllegalStateException.class, session::stop);
+    }
+
+    @Test
+    void networkErrorBackoff() {
+        BotSessionImpl session = new BotSessionImpl();
+        long backOff = session.handleError(new IOException("fail"), 1);
+        assertEquals(2, backOff);
+        assertEquals(30, session.handleError(new IOException("fail"), 32));
     }
 
     private static class DummyBot implements LongPollingBot {


### PR DESCRIPTION
## Summary
- use non-blocking `sendAsync` in `BotSessionImpl`
- factor out backoff handling
- test backoff on network errors

## Testing
- `mvn -q com.diffplug.spotless:spotless-maven-plugin:2.44.5:apply verify -pl core,api` *(fails: PluginResolutionException)*
- `mvn -q -pl core test-compile` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_685499a7dd3c8325b6bfa993f404ddb7