### PR TITLE
Fix expected type in processor

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -91,6 +91,11 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.testing.compile</groupId>
+            <artifactId>compile-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/core/src/main/java/io/lonmstalker/tgkit/core/processor/BotHandlerProcessor.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/processor/BotHandlerProcessor.java
@@ -54,7 +54,7 @@ public class BotHandlerProcessor extends AbstractProcessor {
                     if (!processingEnv.getTypeUtils().isSameType(paramErased, botRequestErased)) {
                         error(String.format(
                                 "Неаннотированные параметры должны иметь тип %s, вы передали %s",
-                                processingEnv.getTypeUtils(), p.asType()
+                                botRequest, p.asType()
                         ), p);
                     }
                 } else if (arg.value().isEmpty()) {

--- a/core/src/test/java/io/lonmstalker/tgkit/core/processor/BotHandlerProcessorTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/processor/BotHandlerProcessorTest.java
@@ -1,0 +1,39 @@
+package io.lonmstalker.tgkit.core.processor;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.Compiler;
+import com.google.testing.compile.JavaFileObjects;
+import io.lonmstalker.tgkit.core.BotResponse;
+import io.lonmstalker.tgkit.core.annotation.BotHandler;
+import org.junit.jupiter.api.Test;
+
+import javax.tools.JavaFileObject;
+import java.util.Locale;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+
+class BotHandlerProcessorTest {
+
+    @Test
+    void messageShowsExpectedType() {
+        JavaFileObject source = JavaFileObjects.forSourceLines(
+                "test.Bad",
+                "package test;",
+                "import io.lonmstalker.tgkit.core.BotResponse;",
+                "import io.lonmstalker.tgkit.core.annotation.BotHandler;",
+                "public class Bad {",
+                "  @BotHandler",
+                "  public BotResponse bad(String value) { return null; }",
+                "}"
+        );
+
+        Compilation compilation = Compiler.javac()
+                .withProcessors(new BotHandlerProcessor())
+                .compile(source);
+
+        assertThat(compilation).failed();
+        assertThat(compilation.errors())
+                .anyMatch(d -> d.getMessage(Locale.ROOT).contains("BotRequest") &&
+                        d.getMessage(Locale.ROOT).contains("String"));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
         <assertj.version>3.25.1</assertj.version>
         <awaitility.version>4.3.0</awaitility.version>
         <junit.jupiter.version>5.13.1</junit.jupiter.version>
+        <compile.testing.version>0.21.0</compile.testing.version>
     </properties>
 
     <dependencies>
@@ -212,6 +213,12 @@
                 <groupId>org.awaitility</groupId>
                 <artifactId>awaitility</artifactId>
                 <version>${awaitility.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.google.testing.compile</groupId>
+                <artifactId>compile-testing</artifactId>
+                <version>${compile.testing.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
## Summary
- show actual BotRequest type in BotHandlerProcessor error message
- add compile-testing dependency
- test BotHandlerProcessor message

## Testing
- `mvn -q -Dcheckstyle.skip=true -Dproject.parent.basedir=. -pl :core -am spotless:apply verify` *(fails: module not found org.telegram.telegrambots)*

------
https://chatgpt.com/codex/tasks/task_e_6854a59432b48325b3feef5e4bb839a2