### PR TITLE
Use SemVer for plugin API validation

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -37,6 +37,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.zafarkhaja</groupId>
+            <artifactId>java-semver</artifactId>
+            <version>0.10.2</version>
+        </dependency>
 
         <!-- TEST -->
         <dependency>

--- a/plugin/src/test/java/io/lonmstalker/tgkit/plugin/BotPluginManagerTest.java
+++ b/plugin/src/test/java/io/lonmstalker/tgkit/plugin/BotPluginManagerTest.java
@@ -99,13 +99,13 @@ public class BotPluginManagerTest {
     }
 
     @Test
-    void testApiCompatibility() throws Exception {
-        // плагин с несовместимым api
+    void testApiVersionAboveSupported() throws Exception {
+        // плагин требует более новую версию API
         Path jar = tempDir.resolve("ver.jar");
         createPluginJar(jar,
                 "id",
                 String.valueOf(CURRENT_VERSION),
-                "9.9",
+                "1.0.0",
                 TestPlugin.class.getName(),
                 null);
 
@@ -133,6 +133,24 @@ public class BotPluginManagerTest {
         verify(auditBus).publish(argThat((AuditEvent evt) ->
                 "plugin-scan".equals(evt.getActor()) &&
                         evt.getAction().contains("Checksum mismatch")
+        ));
+    }
+
+    @Test
+    void testApiInvalidFormat() throws Exception {
+        Path jar = tempDir.resolve("badapi.jar");
+        createPluginJar(jar,
+                "bad",
+                String.valueOf(CURRENT_VERSION),
+                "one.two",
+                TestPlugin.class.getName(),
+                null);
+
+        manager.loadAll(tempDir);
+
+        verify(auditBus).publish(argThat((AuditEvent evt) ->
+                "plugin-scan".equals(evt.getActor()) &&
+                        evt.getAction().contains("Invalid API version")
         ));
     }
 


### PR DESCRIPTION
## Summary
- parse plugin API version with `java-semver`
- fail on invalid API versions or versions newer than supported
- test valid, invalid and high API versions

## Testing
- `mvn -q -pl plugin test -DskipITs=true` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6854a599fb448325bae0099c398b47cf