### PR TITLE
Fix BotAdapterImpl checkStarted logic

### DIFF
--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotAdapterImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotAdapterImpl.java
@@ -173,7 +173,7 @@ public class BotAdapterImpl implements BotAdapter, AutoCloseable {
     }
 
     private void checkStarted() {
-        if (currentBot != null && BotState.RUNNING == currentBot.state()) {
+        if (currentBot == null || currentBot.state() != BotState.RUNNING) {
             throw new IllegalStateException("Bot adapter not started");
         }
     }


### PR DESCRIPTION
## Summary
- adjust BotAdapterImpl.checkStarted to verify bot is running

## Testing
- `mvn spotless:apply verify -q` *(fails: could not find google_checks.xml)*
- `mvn -pl :core -q test-compile` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6854a8f7345c832596e528302056790a