### PR TITLE
Fix module names for Telegrambots

### DIFF
--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,5 +1,13 @@
 module io.lonmstalker.tgkit.api {
-  requires transitive org.telegram.telegrambots;
+  requires transitive telegrambots;
+  requires transitive telegrambots.meta;
+  requires transitive org.slf4j;
+  requires transitive java.net.http;
+  requires transitive org.apache.httpcomponents.httpclient;
+  requires transitive org.apache.httpcomponents.httpcore;
+  requires static lombok;
+  requires static com.fasterxml.jackson.annotation;
+  requires static org.checkerframework.checker.qual;
 
   exports io.lonmstalker.tgkit.core;
   exports io.lonmstalker.tgkit.core.annotation;
@@ -25,7 +33,8 @@ module io.lonmstalker.tgkit.api {
   exports io.lonmstalker.tgkit.core.user;
   exports io.lonmstalker.tgkit.core.user.store;
   exports io.lonmstalker.tgkit.core.wizard;
-  exports io.lonmstalker.tgkit.core.wizard.annotation;
+  exports io.lonmstalker.tgkit.core.validator;
+  exports io.lonmstalker.tgkit.core.annotation.wizard;
   exports io.lonmstalker.tgkit.observability;
   exports io.lonmstalker.tgkit.plugin;
   exports io.lonmstalker.tgkit.security.antispam;

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -2,8 +2,12 @@ module io.lonmstalker.tgkit.core {
   requires io.lonmstalker.tgkit.api;
   requires org.slf4j;
   requires org.apache.commons.lang3;
-  requires org.telegram.telegrambots;
-  requires com.fasterxml.jackson.databind;
+  requires telegrambots;
+  requires telegrambots.meta;
+  requires static lombok;
+  requires static org.checkerframework.checker.qual;
+  requires static com.fasterxml.jackson.annotation;
+  requires transitive com.fasterxml.jackson.databind;
   requires com.fasterxml.jackson.dataformat.yaml;
   requires com.h2database;
   requires org.reflections;

--- a/validator/src/main/java/module-info.java
+++ b/validator/src/main/java/module-info.java
@@ -1,6 +1,9 @@
 module io.lonmstalker.tgkit.validator {
   requires io.lonmstalker.tgkit.api;
-  requires org.telegram.telegrambots;
+  requires telegrambots;
+  requires telegrambots.meta;
+  requires static lombok;
+  requires static org.checkerframework.checker.qual;
   requires language.detector;
   requires org.apache.tika.langdetect.optimaize;
   requires com.google.common;


### PR DESCRIPTION
## Summary
- update JPMS module names to `telegrambots` and `telegrambots.meta`
- list transitive and static dependencies for JPMS

## Testing
- `mvn -pl api test-compile`
- `mvn spotless:apply verify` *(fails: Unable to find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6854b541b54c8325beabb636a50c3c58