### PR TITLE
Fix testkit artifact references

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,14 @@ implementation("io.lonmstalker.tgkit:tgkit-core:0.0.1-SNAPSHOT")
 ```xml
 <dependency>
     <groupId>io.lonmstalker.tgkit</groupId>
-    <artifactId>testkit</artifactId>
+    <artifactId>telegram-bot-testkit</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <scope>test</scope>
 </dependency>
 ```
 
 ```kotlin
-testImplementation("io.lonmstalker.tgkit:testkit:0.0.1-SNAPSHOT")
+testImplementation("io.lonmstalker.tgkit:telegram-bot-testkit:0.0.1-SNAPSHOT")
 ```
 </details>
 

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,5 +1,8 @@
 module io.lonmstalker.tgkit.api {
-  requires transitive org.telegram.telegrambots;
+  requires transitive telegrambots;
+  requires telegrambots.meta;
+  requires static lombok;
+  requires static org.checkerframework.checker.qual;
 
   exports io.lonmstalker.tgkit.core;
   exports io.lonmstalker.tgkit.core.annotation;

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -2,7 +2,10 @@ module io.lonmstalker.tgkit.core {
   requires io.lonmstalker.tgkit.api;
   requires org.slf4j;
   requires org.apache.commons.lang3;
-  requires org.telegram.telegrambots;
+  requires telegrambots;
+  requires telegrambots.meta;
+  requires static lombok;
+  requires static org.checkerframework.checker.qual;
   requires com.fasterxml.jackson.databind;
   requires com.fasterxml.jackson.dataformat.yaml;
   requires com.h2database;

--- a/docs/TESTKIT_README.md
+++ b/docs/TESTKIT_README.md
@@ -12,7 +12,7 @@
 ```xml
 <dependency>
     <groupId>io.lonmstalker.tgkit</groupId>
-    <artifactId>testkit</artifactId>
+    <artifactId>telegram-bot-testkit</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <scope>test</scope>
 </dependency>
@@ -22,7 +22,7 @@
 <summary>Gradle Kotlin DSL</summary>
 
 ```kotlin
-testImplementation("io.lonmstalker.tgkit:testkit:0.0.1-SNAPSHOT")
+testImplementation("io.lonmstalker.tgkit:telegram-bot-testkit:0.0.1-SNAPSHOT")
 ```
 </details>
 

--- a/examples/testkit-demo/pom.xml
+++ b/examples/testkit-demo/pom.xml
@@ -19,7 +19,7 @@
         </dependency>
         <dependency>
             <groupId>io.lonmstalker.tgkit</groupId>
-            <artifactId>testkit</artifactId>
+            <artifactId>telegram-bot-testkit</artifactId>
             <version>0.0.1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>

--- a/observability/src/main/java/module-info.java
+++ b/observability/src/main/java/module-info.java
@@ -7,6 +7,8 @@ module io.lonmstalker.tgkit.observability {
   requires ch.qos.logback.classic;
   requires io.micrometer.registry.prometheus;
   requires io.prometheus.simpleclient_httpserver;
+  requires static lombok;
+  requires static org.checkerframework.checker.qual;
 
   exports io.lonmstalker.observability;
   exports io.lonmstalker.observability.impl to

--- a/plugin/src/main/java/module-info.java
+++ b/plugin/src/main/java/module-info.java
@@ -4,6 +4,8 @@ module io.lonmstalker.tgkit.plugin {
   requires io.lonmstalker.tgkit.security;
   requires org.slf4j;
   requires com.fasterxml.jackson.dataformat.yaml;
+  requires static lombok;
+  requires static org.checkerframework.checker.qual;
 
   exports io.lonmstalker.tgkit.plugin;
   exports io.lonmstalker.tgkit.plugin.annotation;

--- a/security/src/main/java/module-info.java
+++ b/security/src/main/java/module-info.java
@@ -4,6 +4,8 @@ module io.lonmstalker.tgkit.security {
   requires com.github.benmanes.caffeine;
   requires io.github.jopenlibs.vault.java.driver;
   requires jedis;
+  requires static lombok;
+  requires static org.checkerframework.checker.qual;
 
   exports io.lonmstalker.tgkit.security;
   exports io.lonmstalker.tgkit.security.antispam;

--- a/validator/src/main/java/module-info.java
+++ b/validator/src/main/java/module-info.java
@@ -1,6 +1,9 @@
 module io.lonmstalker.tgkit.validator {
   requires io.lonmstalker.tgkit.api;
-  requires org.telegram.telegrambots;
+  requires telegrambots;
+  requires telegrambots.meta;
+  requires static lombok;
+  requires static org.checkerframework.checker.qual;
   requires language.detector;
   requires org.apache.tika.langdetect.optimaize;
   requires com.google.common;


### PR DESCRIPTION
## Summary
- update documentation to use `telegram-bot-testkit`
- fix example `testkit-demo` pom dependency
- adjust module descriptors to depend on correct artifacts

## Testing
- `mvn -q -Dproject.parent.basedir=$(pwd) -Dcheckstyle.skip=true spotless:apply verify` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854b55e139c832596ec54071ec9dfe0