### PR TITLE
Fix module export for absent wizard annotation package

### DIFF
--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -25,7 +25,6 @@ module io.lonmstalker.tgkit.api {
   exports io.lonmstalker.tgkit.core.user;
   exports io.lonmstalker.tgkit.core.user.store;
   exports io.lonmstalker.tgkit.core.wizard;
-  exports io.lonmstalker.tgkit.core.wizard.annotation;
   exports io.lonmstalker.tgkit.observability;
   exports io.lonmstalker.tgkit.plugin;
   exports io.lonmstalker.tgkit.security.antispam;


### PR DESCRIPTION
## Summary
- remove export for missing `io.lonmstalker.tgkit.core.wizard.annotation`

## Testing
- `mvn -q -pl api -am -DskipTests compile` *(fails: module not found org.telegram.telegrambots)*

------
https://chatgpt.com/codex/tasks/task_e_6854b54245d483258c0b34617d4c0c09