### PR TITLE
Remove Lombok from validators

### DIFF
--- a/validator/src/main/java/io/lonmstalker/tgkit/validator/impl/AdvancedValidators.java
+++ b/validator/src/main/java/io/lonmstalker/tgkit/validator/impl/AdvancedValidators.java
@@ -16,14 +16,13 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.telegram.telegrambots.meta.api.objects.Message;
 
 /** Валидации, выходящие за рамки базовых: спам-фильтры, дата/время, ссылки, валюты и т.п. */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class AdvancedValidators {
+
+  private AdvancedValidators() {}
 
   private static final Pattern URL_PATTERN =
       Pattern.compile("(https?://[^\\s]+)", Pattern.CASE_INSENSITIVE);

--- a/validator/src/main/java/io/lonmstalker/tgkit/validator/impl/ContactValidators.java
+++ b/validator/src/main/java/io/lonmstalker/tgkit/validator/impl/ContactValidators.java
@@ -3,8 +3,6 @@ package io.lonmstalker.tgkit.validator.impl;
 import io.lonmstalker.tgkit.core.i18n.MessageKey;
 import io.lonmstalker.tgkit.core.validator.Validator;
 import java.util.regex.Pattern;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.telegram.telegrambots.meta.api.objects.Contact;
 
@@ -13,8 +11,9 @@ import org.telegram.telegrambots.meta.api.objects.Contact;
  *
  * <p>Проверяют формат телефона по E.164 и длину имени.
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ContactValidators {
+
+  private ContactValidators() {}
 
   private static final Pattern E164 = Pattern.compile("^\\+\\d{1,15}$");
   private static final int MAX_NAME = 255;

--- a/validator/src/main/java/io/lonmstalker/tgkit/validator/impl/DocumentValidators.java
+++ b/validator/src/main/java/io/lonmstalker/tgkit/validator/impl/DocumentValidators.java
@@ -5,8 +5,6 @@ import io.lonmstalker.tgkit.core.validator.Validator;
 import io.lonmstalker.tgkit.validator.moderation.ContentModerationService;
 import java.util.ServiceLoader;
 import java.util.Set;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.telegram.telegrambots.meta.api.objects.Document;
 
@@ -15,8 +13,9 @@ import org.telegram.telegrambots.meta.api.objects.Document;
  *
  * <p>Проверяют размер, MIME-тип и DLP/Cloud-модерацию содержимого.
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class DocumentValidators {
+
+  private DocumentValidators() {}
 
   private static final Set<String> ALLOWED_MIME =
       Set.of(

--- a/validator/src/main/java/io/lonmstalker/tgkit/validator/impl/LocationValidators.java
+++ b/validator/src/main/java/io/lonmstalker/tgkit/validator/impl/LocationValidators.java
@@ -2,8 +2,6 @@ package io.lonmstalker.tgkit.validator.impl;
 
 import io.lonmstalker.tgkit.core.i18n.MessageKey;
 import io.lonmstalker.tgkit.core.validator.Validator;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.telegram.telegrambots.meta.api.objects.Location;
 
@@ -12,8 +10,9 @@ import org.telegram.telegrambots.meta.api.objects.Location;
  *
  * <p>Проверяет, что широта и долгота находятся в допустимых пределах.
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class LocationValidators {
+
+  private LocationValidators() {}
 
   private static final double LAT_MIN = -90.0, LAT_MAX = 90.0;
   private static final double LNG_MIN = -180.0, LNG_MAX = 180.0;

--- a/validator/src/main/java/io/lonmstalker/tgkit/validator/impl/MiscValidators.java
+++ b/validator/src/main/java/io/lonmstalker/tgkit/validator/impl/MiscValidators.java
@@ -4,8 +4,6 @@ import io.lonmstalker.tgkit.core.i18n.MessageKey;
 import io.lonmstalker.tgkit.core.validator.Validator;
 import java.util.Objects;
 import java.util.Set;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.telegram.telegrambots.meta.api.objects.*;
 import org.telegram.telegrambots.meta.api.objects.games.Animation;
@@ -19,8 +17,9 @@ import org.telegram.telegrambots.meta.api.objects.stickers.Sticker;
  * <p>Предполагается, что fileId всегда приходит от Telegram, поэтому его наличие не проверяется
  * здесь.
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class MiscValidators {
+
+  private MiscValidators() {}
 
   /**
    * Стикер должен принадлежать одному из разрешённых наборов.

--- a/validator/src/main/java/io/lonmstalker/tgkit/validator/impl/PaymentValidators.java
+++ b/validator/src/main/java/io/lonmstalker/tgkit/validator/impl/PaymentValidators.java
@@ -2,8 +2,6 @@ package io.lonmstalker.tgkit.validator.impl;
 
 import io.lonmstalker.tgkit.core.i18n.MessageKey;
 import io.lonmstalker.tgkit.core.validator.Validator;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.telegram.telegrambots.meta.api.objects.payments.Invoice;
 
@@ -12,8 +10,9 @@ import org.telegram.telegrambots.meta.api.objects.payments.Invoice;
  *
  * <p>Проверяют корректность суммы и формат валюты.
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class PaymentValidators {
+
+  private PaymentValidators() {}
 
   private static final long MAX_CENTS = 1_000_000L; // $10 000
 

--- a/validator/src/main/java/io/lonmstalker/tgkit/validator/impl/PhotoValidators.java
+++ b/validator/src/main/java/io/lonmstalker/tgkit/validator/impl/PhotoValidators.java
@@ -5,8 +5,6 @@ import io.lonmstalker.tgkit.core.validator.Validator;
 import io.lonmstalker.tgkit.validator.moderation.ContentModerationService;
 import java.util.List;
 import java.util.ServiceLoader;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.telegram.telegrambots.meta.api.objects.PhotoSize;
 
@@ -15,8 +13,9 @@ import org.telegram.telegrambots.meta.api.objects.PhotoSize;
  *
  * <p>Проверяют общий размер, минимальное разрешение и SafeSearch.
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class PhotoValidators {
+
+  private PhotoValidators() {}
 
   private static final ContentModerationService MOD =
       ServiceLoader.load(ContentModerationService.class).findFirst().orElse(null);

--- a/validator/src/main/java/io/lonmstalker/tgkit/validator/impl/PollValidators.java
+++ b/validator/src/main/java/io/lonmstalker/tgkit/validator/impl/PollValidators.java
@@ -3,8 +3,6 @@ package io.lonmstalker.tgkit.validator.impl;
 import io.lonmstalker.tgkit.core.i18n.MessageKey;
 import io.lonmstalker.tgkit.core.validator.Validator;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.telegram.telegrambots.meta.api.objects.polls.Poll;
 
@@ -13,8 +11,9 @@ import org.telegram.telegrambots.meta.api.objects.polls.Poll;
  *
  * <p>Проверяют количество вариантов и длину текста каждого варианта.
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class PollValidators {
+
+  private PollValidators() {}
 
   private static final int MIN_OPTS = 2, MAX_OPTS = 10, MAX_TEXT = 100;
 

--- a/validator/src/main/java/io/lonmstalker/tgkit/validator/impl/TextValidators.java
+++ b/validator/src/main/java/io/lonmstalker/tgkit/validator/impl/TextValidators.java
@@ -5,8 +5,6 @@ import io.lonmstalker.tgkit.core.validator.Validator;
 import io.lonmstalker.tgkit.validator.moderation.ContentModerationService;
 import java.util.ServiceLoader;
 import java.util.regex.Pattern;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
@@ -15,8 +13,9 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  * <p>Содержат проверки на пустоту, максимальную длину, корректное UTF-8 кодирование и опциональную
  * Cloud-модерацию (toxic/profanity).
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class TextValidators {
+
+  private TextValidators() {}
 
   private static final int MAX_LEN = 4096;
   private static final ContentModerationService MOD =

--- a/validator/src/main/java/io/lonmstalker/tgkit/validator/impl/UrlValidators.java
+++ b/validator/src/main/java/io/lonmstalker/tgkit/validator/impl/UrlValidators.java
@@ -5,8 +5,6 @@ import io.lonmstalker.tgkit.core.validator.Validator;
 import io.lonmstalker.tgkit.validator.moderation.ContentModerationService;
 import java.net.URI;
 import java.util.ServiceLoader;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
@@ -14,8 +12,9 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  *
  * <p>Проверяют синтаксис URI и безопасность через Safe Browsing.
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class UrlValidators {
+
+  private UrlValidators() {}
 
   private static final ContentModerationService MOD =
       ServiceLoader.load(ContentModerationService.class).findFirst().orElse(null);

--- a/validator/src/main/java/io/lonmstalker/tgkit/validator/impl/VideoValidators.java
+++ b/validator/src/main/java/io/lonmstalker/tgkit/validator/impl/VideoValidators.java
@@ -4,8 +4,6 @@ import io.lonmstalker.tgkit.core.i18n.MessageKey;
 import io.lonmstalker.tgkit.core.validator.Validator;
 import io.lonmstalker.tgkit.validator.moderation.ContentModerationService;
 import java.util.ServiceLoader;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.telegram.telegrambots.meta.api.objects.Video;
 
@@ -14,8 +12,9 @@ import org.telegram.telegrambots.meta.api.objects.Video;
  *
  * <p>Проверяют размер, продолжительность и SafeSearch.
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class VideoValidators {
+
+  private VideoValidators() {}
 
   private static final ContentModerationService MOD =
       ServiceLoader.load(ContentModerationService.class).findFirst().orElse(null);


### PR DESCRIPTION
## Summary
- replace Lombok `@NoArgsConstructor` in validator implementations with explicit private constructors
- remove Lombok imports

## Testing
- `mvn -Dproject.parent.basedir=$(pwd) -q -pl validator spotless:apply`
- `mvn -Dproject.parent.basedir=$(pwd) -pl validator -am -DskipTests verify` *(fails: cannot initialize SuppressWithNearbyTextFilter)*

------
https://chatgpt.com/codex/tasks/task_e_68551e92fdcc83258c54df77fa2b45b9