### PR TITLE
Remove Lombok from security module

### DIFF
--- a/security/src/main/java/io/lonmstalker/tgkit/security/BotSecurity.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/BotSecurity.java
@@ -10,13 +10,10 @@ import io.lonmstalker.tgkit.security.ratelimit.impl.InMemoryRateLimiter;
 import io.lonmstalker.tgkit.security.ratelimit.impl.RedisRateLimiter;
 import java.time.Duration;
 import java.util.Set;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.Range;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import redis.clients.jedis.JedisPool;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 /**
  * Утилита для создания типовых компонентов безопасности: проверка на дубликаты, CAPTCHA и
  * ограничители скорости.
@@ -29,6 +26,8 @@ import redis.clients.jedis.JedisPool;
  * }</pre>
  */
 public final class BotSecurity {
+
+  private BotSecurity() {}
 
   /** Создаёт хранитель дубликатов сообщений в памяти. */
   public static @NonNull DuplicateProvider inMemoryDuplicateProvider(

--- a/security/src/main/java/io/lonmstalker/tgkit/security/antispam/InMemoryDuplicateProvider.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/antispam/InMemoryDuplicateProvider.java
@@ -6,15 +6,36 @@ import java.time.Duration;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import lombok.Builder;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class InMemoryDuplicateProvider implements DuplicateProvider {
   private final Cache<Long, Set<Integer>> cache;
 
-  @Builder
-  public InMemoryDuplicateProvider(@NonNull Duration ttl, long maxSize) {
+  private InMemoryDuplicateProvider(@NonNull Duration ttl, long maxSize) {
     this.cache = Caffeine.newBuilder().expireAfterWrite(ttl).maximumSize(maxSize).build();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    private Duration ttl;
+    private long maxSize;
+
+    public Builder ttl(@NonNull Duration ttl) {
+      this.ttl = ttl;
+      return this;
+    }
+
+    public Builder maxSize(long maxSize) {
+      this.maxSize = maxSize;
+      return this;
+    }
+
+    public InMemoryDuplicateProvider build() {
+      return new InMemoryDuplicateProvider(ttl, maxSize);
+    }
   }
 
   @Override

--- a/security/src/main/java/io/lonmstalker/tgkit/security/audit/AuditBotCommandFactory.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/audit/AuditBotCommandFactory.java
@@ -7,12 +7,13 @@ import io.lonmstalker.tgkit.core.reflection.ReflectionUtils;
 import io.lonmstalker.tgkit.security.config.BotSecurityGlobalConfig;
 import java.lang.reflect.*;
 import java.util.*;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-@Slf4j
 public final class AuditBotCommandFactory implements BotCommandFactory<Audit> {
+  private static final Logger log = LoggerFactory.getLogger(AuditBotCommandFactory.class);
   private static final AuditConverter DEFAULT = new UpdateAuditConverter();
 
   @Override

--- a/security/src/main/java/io/lonmstalker/tgkit/security/audit/DelegatingAuditInterceptor.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/audit/DelegatingAuditInterceptor.java
@@ -3,14 +3,16 @@ package io.lonmstalker.tgkit.security.audit;
 import io.lonmstalker.tgkit.core.BotRequest;
 import io.lonmstalker.tgkit.core.BotResponse;
 import io.lonmstalker.tgkit.core.interceptor.BotInterceptor;
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.telegram.telegrambots.meta.api.objects.Update;
 
-@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 final class DelegatingAuditInterceptor implements BotInterceptor {
+
+  DelegatingAuditInterceptor(@NonNull AuditBus auditBus, @NonNull AuditConverter conv) {
+    this.auditBus = auditBus;
+    this.conv = conv;
+  }
 
   private final @NonNull AuditBus auditBus;
   private final @NonNull AuditConverter conv;

--- a/security/src/main/java/io/lonmstalker/tgkit/security/captcha/provider/MathCaptchaProvider.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/captcha/provider/MathCaptchaProvider.java
@@ -8,7 +8,6 @@ import io.lonmstalker.tgkit.security.captcha.MathCaptchaProviderStore;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.util.*;
-import lombok.Builder;
 import org.apache.commons.lang3.Range;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -25,8 +24,7 @@ public final class MathCaptchaProvider implements CaptchaProvider {
   private final List<MathCaptchaOperations> allowedOps;
   private final MathCaptchaProviderStore answersStore;
 
-  @Builder
-  public MathCaptchaProvider(
+  private MathCaptchaProvider(
       @NonNull Duration ttl,
       @NonNull Range<Integer> numberRange,
       int wrongCount,
@@ -38,6 +36,47 @@ public final class MathCaptchaProvider implements CaptchaProvider {
     this.wrongCount = Math.max(wrongCount, 1);
     this.allowedOps = List.copyOf(allowedOps);
     this.answersStore = store != null ? store : new InMemoryMathCaptchaProviderStore(ttl, 1000);
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    private Duration ttl;
+    private Range<Integer> numberRange;
+    private int wrongCount;
+    private MathCaptchaProviderStore store;
+    private List<MathCaptchaOperations> allowedOps;
+
+    public Builder ttl(@NonNull Duration ttl) {
+      this.ttl = ttl;
+      return this;
+    }
+
+    public Builder numberRange(@NonNull Range<Integer> range) {
+      this.numberRange = range;
+      return this;
+    }
+
+    public Builder wrongCount(int count) {
+      this.wrongCount = count;
+      return this;
+    }
+
+    public Builder store(@Nullable MathCaptchaProviderStore store) {
+      this.store = store;
+      return this;
+    }
+
+    public Builder allowedOps(@NonNull List<MathCaptchaOperations> ops) {
+      this.allowedOps = ops;
+      return this;
+    }
+
+    public MathCaptchaProvider build() {
+      return new MathCaptchaProvider(ttl, numberRange, wrongCount, store, allowedOps);
+    }
   }
 
   @Override

--- a/security/src/main/java/io/lonmstalker/tgkit/security/captcha/provider/RecaptchaWebProvider.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/captcha/provider/RecaptchaWebProvider.java
@@ -14,23 +14,23 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Map;
-import lombok.Builder;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 
 /** Google reCAPTCHA v3: тихий fallback-провайдер. */
-@Slf4j
 public final class RecaptchaWebProvider implements CaptchaProvider {
+
+  private static final Logger log = LoggerFactory.getLogger(RecaptchaWebProvider.class);
   private final @NonNull String verifyUrl;
   private final @NonNull String domain;
   private final @NonNull String secretKey;
   private final @NonNull ObjectMapper mapper;
   private final @NonNull HttpClient httpClient;
 
-  @Builder
-  public RecaptchaWebProvider(
+  private RecaptchaWebProvider(
       @NonNull String domain,
       @Nullable String secretKey,
       @Nullable SecretStore secretStore,
@@ -56,6 +56,53 @@ public final class RecaptchaWebProvider implements CaptchaProvider {
     this.mapper = mapper != null ? mapper : new ObjectMapper();
     this.verifyUrl =
         verifyUrl != null ? verifyUrl : "https://www.google.com/recaptcha/api/siteverify";
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    private String domain;
+    private String secretKey;
+    private SecretStore secretStore;
+    private String verifyUrl;
+    private ObjectMapper mapper;
+    private HttpClient httpClient;
+
+    public Builder domain(@NonNull String domain) {
+      this.domain = domain;
+      return this;
+    }
+
+    public Builder secretKey(@Nullable String secretKey) {
+      this.secretKey = secretKey;
+      return this;
+    }
+
+    public Builder secretStore(@Nullable SecretStore secretStore) {
+      this.secretStore = secretStore;
+      return this;
+    }
+
+    public Builder verifyUrl(@Nullable String verifyUrl) {
+      this.verifyUrl = verifyUrl;
+      return this;
+    }
+
+    public Builder mapper(@Nullable ObjectMapper mapper) {
+      this.mapper = mapper;
+      return this;
+    }
+
+    public Builder httpClient(@Nullable HttpClient client) {
+      this.httpClient = client;
+      return this;
+    }
+
+    public RecaptchaWebProvider build() {
+      return new RecaptchaWebProvider(domain, secretKey, secretStore, verifyUrl, mapper, httpClient);
+    }
   }
 
   @Override

--- a/security/src/main/java/io/lonmstalker/tgkit/security/captcha/provider/SliderCaptchaProvider.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/captcha/provider/SliderCaptchaProvider.java
@@ -18,7 +18,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.WeakHashMap;
 import javax.imageio.ImageIO;
-import lombok.SneakyThrows;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.telegram.telegrambots.meta.api.methods.send.SendPhoto;
 import org.telegram.telegrambots.meta.api.objects.InputFile;
@@ -72,7 +71,6 @@ public final class SliderCaptchaProvider implements CaptchaProvider {
   }
 
   /* — helpers — */
-  @SneakyThrows
   private static BufferedImage cutPiece(BufferedImage src, int x) {
     int w = 60, h = 60, y = 50;
     BufferedImage dst = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);

--- a/security/src/main/java/io/lonmstalker/tgkit/security/init/BotSecurityInitializer.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/init/BotSecurityInitializer.java
@@ -10,17 +10,19 @@ import io.lonmstalker.tgkit.security.ratelimit.impl.InMemoryRateLimiter;
 import io.lonmstalker.tgkit.security.secret.EnvSecretStore;
 import java.time.Duration;
 import java.util.Set;
-import lombok.experimental.UtilityClass;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.commons.lang3.Range;
 
 /**
  * Базовая инициализация security-модуля.<br>
  * Аналогично {@link io.lonmstalker.tgkit.core.init.BotCoreInitializer}.
  */
-@Slf4j
-@UtilityClass
-public class BotSecurityInitializer {
+public final class BotSecurityInitializer {
+
+  private static final Logger log = LoggerFactory.getLogger(BotSecurityInitializer.class);
+
+  private BotSecurityInitializer() {}
 
   private static volatile boolean started;
 

--- a/security/src/main/java/io/lonmstalker/tgkit/security/ratelimit/RateLimitInterceptor.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/ratelimit/RateLimitInterceptor.java
@@ -5,8 +5,6 @@ import io.lonmstalker.tgkit.core.BotResponse;
 import io.lonmstalker.tgkit.core.interceptor.BotInterceptor;
 import io.lonmstalker.tgkit.core.update.UpdateUtils;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.telegram.telegrambots.meta.api.objects.Update;
@@ -15,8 +13,12 @@ import org.telegram.telegrambots.meta.api.objects.Update;
  * Runtime-cheap rate-limit guard. Heavy computations delegated to {@link
  * RateLimitBotCommandFactory}.
  */
-@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public final class RateLimitInterceptor implements BotInterceptor {
+
+  RateLimitInterceptor(RateLimiter backend, List<Meta> metas) {
+    this.backend = backend;
+    this.metas = metas;
+  }
 
   /** immutable meta per annotation */
   record Meta(LimiterKey key, int permits, int seconds, String prefix) {}

--- a/security/src/main/java/io/lonmstalker/tgkit/security/ratelimit/impl/RedisRateLimiter.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/ratelimit/impl/RedisRateLimiter.java
@@ -1,7 +1,6 @@
 package io.lonmstalker.tgkit.security.ratelimit.impl;
 
 import io.lonmstalker.tgkit.security.ratelimit.RateLimiter;
-import lombok.RequiredArgsConstructor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
@@ -45,11 +44,14 @@ import redis.clients.jedis.JedisPool;
  * RateLimiterBackend limiter = new RedisRateLimiter(pool);
  * }</pre>
  */
-@RequiredArgsConstructor
 public final class RedisRateLimiter implements RateLimiter {
 
   /** Jedis connection pool, injected by DI framework. */
   private final JedisPool pool;
+
+  public RedisRateLimiter(@NonNull JedisPool pool) {
+    this.pool = pool;
+  }
 
   /*───────────────────────────────────────────────────────────────*
    *  Atomic Lua (INCR + optional EXPIRE)                           *

--- a/security/src/main/java/io/lonmstalker/tgkit/security/secret/PropertyFileSecretStore.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/secret/PropertyFileSecretStore.java
@@ -2,11 +2,12 @@ package io.lonmstalker.tgkit.security.secret;
 
 import java.util.Optional;
 import java.util.Properties;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-@Slf4j
 public final class PropertyFileSecretStore implements SecretStore {
+  private static final Logger log = LoggerFactory.getLogger(PropertyFileSecretStore.class);
   private volatile Properties props;
 
   public PropertyFileSecretStore(@NonNull String classPath) {

--- a/security/src/main/java/io/lonmstalker/tgkit/security/secret/VaultSecretStore.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/secret/VaultSecretStore.java
@@ -3,11 +3,13 @@ package io.lonmstalker.tgkit.security.secret;
 import io.github.jopenlibs.vault.Vault;
 import io.github.jopenlibs.vault.VaultConfig;
 import java.util.Optional;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-@Slf4j
 public final class VaultSecretStore implements SecretStore {
+
+  private static final Logger log = LoggerFactory.getLogger(VaultSecretStore.class);
 
   private transient Vault vault;
 


### PR DESCRIPTION
## Summary
- drop all Lombok annotations in `security` package
- add explicit constructors and builder implementations
- define `Logger` fields instead of using `@Slf4j`

## Testing
- `mvn spotless:apply verify` *(failed: could not find Checkstyle config)*

------
https://chatgpt.com/codex/tasks/task_e_68551e9362808325aeb6bd45f18fc489