### PR TITLE
Remove Lombok from core

### DIFF
--- a/core/src/main/java/io/lonmstalker/tgkit/core/args/Converters.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/args/Converters.java
@@ -4,13 +4,12 @@ import io.lonmstalker.tgkit.core.BotRequest;
 import io.lonmstalker.tgkit.core.reflection.ReflectionUtils;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import lombok.experimental.UtilityClass;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.telegram.telegrambots.meta.api.objects.Update;
 
 /** Утилитарный реестр, где хранятся все кастомные BotArgumentConverter. */
-@UtilityClass
 public final class Converters {
+  private Converters() {}
   private static final Map<Class<?>, BotArgumentConverter<?, ?>> BY_TYPE =
       new ConcurrentHashMap<>();
   private static final Map<Class<?>, BotArgumentConverter<?, ?>> BY_CLASS =

--- a/core/src/main/java/io/lonmstalker/tgkit/core/args/RouteContextHolder.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/args/RouteContextHolder.java
@@ -1,13 +1,11 @@
 package io.lonmstalker.tgkit.core.args;
 
 import java.util.regex.Matcher;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class RouteContextHolder {
+  private RouteContextHolder() {}
   private static final ThreadLocal<@Nullable Matcher> MATCHER = new ThreadLocal<>();
 
   public static void setMatcher(@NonNull Matcher matcher) {

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotDataSourceConfig.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotDataSourceConfig.java
@@ -1,9 +1,6 @@
 package io.lonmstalker.tgkit.core.bot;
 
 import javax.sql.DataSource;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -13,4 +10,40 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class BotDataSourceConfig {
   private @Nullable BotConfig botConfig;
   private @NonNull DataSource dataSource;
+
+  private BotDataSourceConfig(@Nullable BotConfig botConfig, @NonNull DataSource dataSource) {
+    this.botConfig = botConfig;
+    this.dataSource = dataSource;
+  }
+
+  public @Nullable BotConfig getBotConfig() {
+    return botConfig;
+  }
+
+  public @NonNull DataSource getDataSource() {
+    return dataSource;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private BotConfig botConfig;
+    private DataSource dataSource;
+
+    public Builder botConfig(@Nullable BotConfig botConfig) {
+      this.botConfig = botConfig;
+      return this;
+    }
+
+    public Builder dataSource(@NonNull DataSource dataSource) {
+      this.dataSource = dataSource;
+      return this;
+    }
+
+    public BotDataSourceConfig build() {
+      return new BotDataSourceConfig(botConfig, dataSource);
+    }
+  }
 }

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotDataSourceFactory.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotDataSourceFactory.java
@@ -8,18 +8,17 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Objects;
 import javax.sql.DataSource;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.telegram.telegrambots.bots.DefaultBotOptions;
 
 /** Extracts bot information from database. */
-@Slf4j
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class BotDataSourceFactory {
+  private static final Logger log = LoggerFactory.getLogger(BotDataSourceFactory.class);
+  private BotDataSourceFactory() {}
   public static final BotDataSourceFactory INSTANCE = new BotDataSourceFactory();
 
   // language=SQL

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotFactory.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotFactory.java
@@ -5,13 +5,11 @@ import io.lonmstalker.tgkit.core.bot.BotDataSourceFactory.BotData;
 import io.lonmstalker.tgkit.core.bot.loader.AnnotatedCommandLoader;
 import io.lonmstalker.tgkit.core.crypto.TokenCipher;
 import java.util.concurrent.atomic.AtomicLong;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.telegram.telegrambots.meta.api.methods.updates.SetWebhook;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class BotFactory {
+  private BotFactory() {}
   public static final BotFactory INSTANCE = new BotFactory();
   private final AtomicLong nextId = new AtomicLong();
 

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotImpl.java
@@ -12,11 +12,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.telegram.telegrambots.bots.DefaultAbsSender;
@@ -24,13 +21,104 @@ import org.telegram.telegrambots.meta.api.methods.GetMe;
 import org.telegram.telegrambots.meta.api.methods.updates.SetWebhook;
 import org.telegram.telegrambots.meta.api.objects.User;
 
-@Slf4j
-@Getter
-@Builder
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @SuppressWarnings({"dereference.of.nullable", "argument"})
 public final class BotImpl implements Bot {
+  private static final Logger log = LoggerFactory.getLogger(BotImpl.class);
 
+  private BotImpl(
+      long id,
+      @Nullable User user,
+      @Nullable SetWebhook setWebhook,
+      @NonNull String token,
+      @NonNull BotConfig config,
+      @NonNull DefaultAbsSender absSender,
+      @NonNull BotCommandRegistry commandRegistry,
+      @Nullable BotSessionImpl session,
+      long onCompletedActionTimeoutMs) {
+    this.id = id;
+    this.user = user;
+    this.setWebhook = setWebhook;
+    this.token = token;
+    this.config = config;
+    this.absSender = absSender;
+    this.commandRegistry = commandRegistry;
+    this.session = session;
+    this.onCompletedActionTimeoutMs = onCompletedActionTimeoutMs;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private long id;
+    private User user;
+    private SetWebhook setWebhook;
+    private String token;
+    private BotConfig config;
+    private DefaultAbsSender absSender;
+    private BotCommandRegistry commandRegistry;
+    private BotSessionImpl session;
+    private long onCompletedActionTimeoutMs = 10_000;
+
+    public Builder id(long id) {
+      this.id = id;
+      return this;
+    }
+
+    public Builder user(@Nullable User user) {
+      this.user = user;
+      return this;
+    }
+
+    public Builder setWebhook(@Nullable SetWebhook setWebhook) {
+      this.setWebhook = setWebhook;
+      return this;
+    }
+
+    public Builder token(@NonNull String token) {
+      this.token = token;
+      return this;
+    }
+
+    public Builder config(@NonNull BotConfig config) {
+      this.config = config;
+      return this;
+    }
+
+    public Builder absSender(@NonNull DefaultAbsSender absSender) {
+      this.absSender = absSender;
+      return this;
+    }
+
+    public Builder commandRegistry(@NonNull BotCommandRegistry registry) {
+      this.commandRegistry = registry;
+      return this;
+    }
+
+    public Builder session(@Nullable BotSessionImpl session) {
+      this.session = session;
+      return this;
+    }
+
+    public Builder onCompletedActionTimeoutMs(long timeout) {
+      this.onCompletedActionTimeoutMs = timeout;
+      return this;
+    }
+
+    public BotImpl build() {
+      return new BotImpl(
+          id,
+          user,
+          setWebhook,
+          token,
+          config,
+          absSender,
+          commandRegistry,
+          session,
+          onCompletedActionTimeoutMs);
+    }
+  }
   private final AtomicReference<BotState> state = new AtomicReference<>(BotState.NEW);
   private final @NonNull List<BotCompleteAction> completeActions = new CopyOnWriteArrayList<>();
   private long id;
@@ -42,7 +130,51 @@ public final class BotImpl implements Bot {
   private @NonNull BotCommandRegistry commandRegistry;
   private @Nullable BotSessionImpl session;
 
-  @Builder.Default private long onCompletedActionTimeoutMs = 10_000;
+  private long onCompletedActionTimeoutMs = 10_000;
+
+  public AtomicReference<BotState> getState() {
+    return state;
+  }
+
+  public List<BotCompleteAction> getCompleteActions() {
+    return completeActions;
+  }
+
+  public long getId() {
+    return id;
+  }
+
+  public @Nullable User getUser() {
+    return user;
+  }
+
+  public @Nullable SetWebhook getSetWebhook() {
+    return setWebhook;
+  }
+
+  public @NonNull String getToken() {
+    return token;
+  }
+
+  public @NonNull BotConfig getConfig() {
+    return config;
+  }
+
+  public @NonNull DefaultAbsSender getAbsSender() {
+    return absSender;
+  }
+
+  public @NonNull BotCommandRegistry getCommandRegistry() {
+    return commandRegistry;
+  }
+
+  public @Nullable BotSessionImpl getSession() {
+    return session;
+  }
+
+  public long getOnCompletedActionTimeoutMs() {
+    return onCompletedActionTimeoutMs;
+  }
 
   @Override
   public long internalId() {

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotRegistryImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotRegistryImpl.java
@@ -5,16 +5,14 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * Реестр активных Bot’ов с хранением WeakReference, чтобы при аварийном незакрытии они не держали
  * память.
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class BotRegistryImpl implements BotRegistry {
+  private BotRegistryImpl() {}
 
   private static final BotRegistryImpl INSTANCE = new BotRegistryImpl();
   private final Map<Long, WeakReference<Bot>> byInternal = new ConcurrentHashMap<>();

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotRequestConverterImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotRequestConverterImpl.java
@@ -6,7 +6,7 @@ import io.lonmstalker.tgkit.core.exception.BotApiException;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.function.Function;
-import lombok.NonNull;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
 import org.telegram.telegrambots.meta.api.objects.Update;
 

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotSessionImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotSessionImpl.java
@@ -18,7 +18,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.telegram.telegrambots.bots.DefaultBotOptions;
 import org.telegram.telegrambots.meta.api.objects.Update;
@@ -62,9 +63,9 @@ import org.telegram.telegrambots.meta.generics.LongPollingBot;
  * executor.shutdown();
  * }</pre>
  */
-@Slf4j
 @SuppressWarnings({"dereference.of.nullable", "argument"})
 public class BotSessionImpl implements BotSession {
+  private static final Logger log = LoggerFactory.getLogger(BotSessionImpl.class);
 
   private final AtomicBoolean running = new AtomicBoolean();
   private final BlockingQueue<Update> updates = new LinkedBlockingQueue<>();

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/LongPollingReceiver.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/LongPollingReceiver.java
@@ -6,8 +6,8 @@ import io.lonmstalker.tgkit.core.BotAdapter;
 import io.lonmstalker.tgkit.core.exception.BotExceptionHandler;
 import io.lonmstalker.tgkit.core.exception.BotExceptionHandlerDefault;
 import io.lonmstalker.tgkit.security.secret.SecretStore;
-import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -15,13 +15,17 @@ import org.telegram.telegrambots.bots.TelegramLongPollingBot;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 
-@Slf4j
 class LongPollingReceiver extends TelegramLongPollingBot implements AutoCloseable {
+  private static final Logger log = LoggerFactory.getLogger(LongPollingReceiver.class);
   private final @NonNull BotAdapter adapter;
   private final @NonNull TelegramSender sender;
   private final @NonNull BotExceptionHandler globalExceptionHandler;
 
-  @Setter private @Nullable String username;
+  private @Nullable String username;
+
+  void setUsername(@Nullable String username) {
+    this.username = username;
+  }
 
   public LongPollingReceiver(
       @NonNull BotConfig options,

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/WebHookReceiver.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/WebHookReceiver.java
@@ -6,8 +6,8 @@ import io.lonmstalker.tgkit.core.BotAdapter;
 import io.lonmstalker.tgkit.core.exception.BotExceptionHandler;
 import io.lonmstalker.tgkit.core.exception.BotExceptionHandlerDefault;
 import io.lonmstalker.tgkit.security.secret.SecretStore;
-import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -15,14 +15,18 @@ import org.telegram.telegrambots.bots.TelegramWebhookBot;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.objects.Update;
 
-@Slf4j
 class WebHookReceiver extends TelegramWebhookBot implements AutoCloseable {
+  private static final Logger log = LoggerFactory.getLogger(WebHookReceiver.class);
   private final @NonNull String token;
   private final @NonNull BotAdapter adapter;
   private final @NonNull TelegramSender sender;
   private final @NonNull BotExceptionHandler globalExceptionHandler;
 
-  @Setter private @Nullable String username;
+  private @Nullable String username;
+
+  void setUsername(@Nullable String username) {
+    this.username = username;
+  }
 
   public WebHookReceiver(
       @NonNull BotConfig options,

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/loader/AnnotatedCommandLoader.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/loader/AnnotatedCommandLoader.java
@@ -28,8 +28,8 @@ import java.lang.reflect.*;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
-import lombok.experimental.UtilityClass;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.reflections.Reflections;
 import org.reflections.scanners.Scanners;
@@ -38,9 +38,9 @@ import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
 import org.telegram.telegrambots.meta.api.objects.Update;
 
 /** Utility to scan packages for {@link BotHandler} methods. */
-@Slf4j
-@UtilityClass
 public final class AnnotatedCommandLoader {
+  private static final Logger log = LoggerFactory.getLogger(AnnotatedCommandLoader.class);
+  private AnnotatedCommandLoader() {}
   private static final List<BotCommandFactory<?>> FACTORIES = new CopyOnWriteArrayList<>();
 
   static {

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/loader/InternalCommandAdapter.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/loader/InternalCommandAdapter.java
@@ -17,8 +17,6 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
-import lombok.AccessLevel;
-import lombok.Builder;
 import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -29,7 +27,6 @@ import org.telegram.telegrambots.meta.api.objects.Update;
  * Адаптер одного метода-хендлера, извлекающий аргументы, конвертирующий запрос и вызывающий
  * рефлективно целевой метод.
  */
-@Builder(access = AccessLevel.PACKAGE)
 class InternalCommandAdapter implements BotCommand<BotApiObject> {
 
   /** Порядок выполнения команды. */
@@ -58,6 +55,85 @@ class InternalCommandAdapter implements BotCommand<BotApiObject> {
 
   /** Интерсепторы до/после вызова метода. */
   private final @NonNull List<BotInterceptor> interceptors = new CopyOnWriteArrayList<>();
+
+  static Builder builder() {
+    return new Builder();
+  }
+
+  InternalCommandAdapter(
+      int order,
+      ParamInfo[] params,
+      @NonNull Method method,
+      @NonNull Object instance,
+      @NonNull String botGroup,
+      @NonNull BotRequestType type,
+      @NonNull BotHandlerConverter<Object> converter,
+      @NonNull CommandMatch<? extends BotApiObject> commandMatch) {
+    this.order = order;
+    this.params = params;
+    this.method = method;
+    this.instance = instance;
+    this.botGroup = botGroup;
+    this.type = type;
+    this.converter = converter;
+    this.commandMatch = commandMatch;
+  }
+
+  static class Builder {
+    private int order;
+    private ParamInfo[] params;
+    private Method method;
+    private Object instance;
+    private String botGroup;
+    private BotRequestType type;
+    private BotHandlerConverter<Object> converter;
+    private CommandMatch<? extends BotApiObject> commandMatch;
+
+    Builder order(int order) {
+      this.order = order;
+      return this;
+    }
+
+    Builder params(ParamInfo[] params) {
+      this.params = params;
+      return this;
+    }
+
+    Builder method(@NonNull Method method) {
+      this.method = method;
+      return this;
+    }
+
+    Builder instance(@NonNull Object instance) {
+      this.instance = instance;
+      return this;
+    }
+
+    Builder botGroup(@NonNull String botGroup) {
+      this.botGroup = botGroup;
+      return this;
+    }
+
+    Builder type(@NonNull BotRequestType type) {
+      this.type = type;
+      return this;
+    }
+
+    Builder converter(@NonNull BotHandlerConverter<Object> converter) {
+      this.converter = converter;
+      return this;
+    }
+
+    Builder commandMatch(@NonNull CommandMatch<? extends BotApiObject> match) {
+      this.commandMatch = match;
+      return this;
+    }
+
+    InternalCommandAdapter build() {
+      return new InternalCommandAdapter(
+          order, params, method, instance, botGroup, type, converter, commandMatch);
+    }
+  }
 
   @Override
   @SuppressWarnings("argument")

--- a/core/src/main/java/io/lonmstalker/tgkit/core/event/InMemoryEventBus.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/event/InMemoryEventBus.java
@@ -4,11 +4,12 @@ import io.lonmstalker.tgkit.core.config.BotGlobalConfig;
 import java.util.Set;
 import java.util.concurrent.*;
 import java.util.function.Consumer;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-@Slf4j
 public final class InMemoryEventBus implements BotEventBus {
+  private static final Logger log = LoggerFactory.getLogger(InMemoryEventBus.class);
 
   private final Thread workingThread;
 

--- a/core/src/main/java/io/lonmstalker/tgkit/core/exception/BotExceptionHandlerDefault.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/exception/BotExceptionHandlerDefault.java
@@ -1,15 +1,16 @@
 package io.lonmstalker.tgkit.core.exception;
 
 import io.lonmstalker.tgkit.core.update.UpdateUtils;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Update;
 
-@Slf4j
 public class BotExceptionHandlerDefault implements BotExceptionHandler {
+  private static final Logger log = LoggerFactory.getLogger(BotExceptionHandlerDefault.class);
   public static final BotExceptionHandler INSTANCE = new BotExceptionHandlerDefault();
 
   @Override

--- a/core/src/main/java/io/lonmstalker/tgkit/core/init/BotCoreInitializer.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/init/BotCoreInitializer.java
@@ -8,8 +8,8 @@ import io.lonmstalker.tgkit.core.event.InMemoryEventBus;
 import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.concurrent.Executors;
-import lombok.experimental.UtilityClass;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Базовая инициализация ядра. <br>
@@ -19,9 +19,10 @@ import lombok.extern.slf4j.Slf4j;
  * <p>👉 Не обязательно использовать этот класс — конфиг можно править вручную. Но он наглядно
  * демонстрирует, как корректно обновлять глобальное состояние.
  */
-@Slf4j
-@UtilityClass
-public class BotCoreInitializer {
+public final class BotCoreInitializer {
+
+  private static final Logger log = LoggerFactory.getLogger(BotCoreInitializer.class);
+  private BotCoreInitializer() {}
 
   private static volatile boolean started;
 

--- a/core/src/main/java/io/lonmstalker/tgkit/core/interceptor/LoggingBotInterceptor.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/interceptor/LoggingBotInterceptor.java
@@ -2,14 +2,15 @@ package io.lonmstalker.tgkit.core.interceptor;
 
 import io.lonmstalker.tgkit.core.BotRequest;
 import io.lonmstalker.tgkit.core.BotResponse;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.telegram.telegrambots.meta.api.objects.Update;
 
 /** Стандартный интерцептор, логирующий этапы обработки обновления. */
-@Slf4j
 public class LoggingBotInterceptor implements BotInterceptor {
+  private static final Logger log = LoggerFactory.getLogger(LoggingBotInterceptor.class);
 
   @Override
   public void preHandle(@NonNull Update update, @NonNull BotRequest<?> request) {

--- a/core/src/main/java/io/lonmstalker/tgkit/core/reflection/ReflectionUtils.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/reflection/ReflectionUtils.java
@@ -6,12 +6,11 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ReflectionUtils {
+  private ReflectionUtils() {}
 
   /** Создаёт экземпляр указанного класса, учитывая возможный метод getInstance(). */
   @SuppressWarnings({"return", "unchecked", "argument"})

--- a/core/src/main/java/io/lonmstalker/tgkit/core/resource/Loaders.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/resource/Loaders.java
@@ -9,11 +9,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-import lombok.experimental.UtilityClass;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-@UtilityClass
-public class Loaders {
+public final class Loaders {
+  private Loaders() {}
 
   public @NonNull ResourceLoader load(@NonNull String path) {
     if (path.startsWith("classpath:")) {

--- a/core/src/main/java/io/lonmstalker/tgkit/core/update/UpdateUtils.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/update/UpdateUtils.java
@@ -8,16 +8,15 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import lombok.experimental.UtilityClass;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.api.objects.User;
 import org.telegram.telegrambots.meta.api.objects.boost.ChatBoostUpdated;
 
-@UtilityClass
 @SuppressWarnings({"method.invocation", "argument", "type.anno.before.modifier", "return"})
-public class UpdateUtils {
+public final class UpdateUtils {
+  private UpdateUtils() {}
 
   /** Таблица, сопоставляющая условие из Update типу запроса. */
   private static final Map<Predicate<Update>, BotRequestType> TYPE_MAP =

--- a/core/src/main/java/io/lonmstalker/tgkit/core/user/SimpleUserProvider.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/user/SimpleUserProvider.java
@@ -2,7 +2,6 @@ package io.lonmstalker.tgkit.core.user;
 
 import io.lonmstalker.tgkit.core.update.UpdateUtils;
 import java.util.Set;
-import lombok.AllArgsConstructor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.telegram.telegrambots.meta.api.objects.Update;
@@ -16,10 +15,14 @@ public class SimpleUserProvider implements BotUserProvider {
     return new SimpleBotUserInfo(userId, chatId);
   }
 
-  @AllArgsConstructor
   static class SimpleBotUserInfo implements BotUserInfo {
     private @Nullable Long userId;
     private @Nullable Long chatId;
+
+    SimpleBotUserInfo(@Nullable Long userId, @Nullable Long chatId) {
+      this.userId = userId;
+      this.chatId = chatId;
+    }
 
     @Override
     public @Nullable Long chatId() {

--- a/core/src/main/java/io/lonmstalker/tgkit/core/user/store/ReadOnlyUserKVStore.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/user/store/ReadOnlyUserKVStore.java
@@ -1,12 +1,14 @@
 package io.lonmstalker.tgkit.core.user.store;
 
 import java.util.Map;
-import lombok.RequiredArgsConstructor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-@RequiredArgsConstructor
 public final class ReadOnlyUserKVStore implements UserKVStore {
   private final @NonNull UserKVStore delegate;
+
+  public ReadOnlyUserKVStore(@NonNull UserKVStore delegate) {
+    this.delegate = delegate;
+  }
 
   @Override
   public String get(long uid, @NonNull String k) {

--- a/core/src/main/java/io/lonmstalker/tgkit/core/validator/MessageValidators.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/validator/MessageValidators.java
@@ -1,14 +1,12 @@
 package io.lonmstalker.tgkit.core.validator;
 
 import io.lonmstalker.tgkit.core.i18n.MessageKey;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.telegram.telegrambots.meta.api.objects.Message;
 
 /** Валидаторы содержимого {@link Message Telegram-сообщения}. */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class MessageValidators {
+  private MessageValidators() {}
 
   public static @NonNull Validator<Message> hasText() {
     return Validator.of(

--- a/core/src/main/java/io/lonmstalker/tgkit/core/validator/RequestValidators.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/validator/RequestValidators.java
@@ -4,12 +4,10 @@ import io.lonmstalker.tgkit.core.BotRequest;
 import io.lonmstalker.tgkit.core.BotRequestType;
 import io.lonmstalker.tgkit.core.exception.ValidationException;
 import io.lonmstalker.tgkit.core.i18n.MessageKey;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 
 /** Утилиты для валидации свойств {@link BotRequest}. */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class RequestValidators {
+  private RequestValidators() {}
 
   /**
    * Валидатор, проверяющий, что тип запроса совпадает с ожидаемым.

--- a/core/src/main/java/io/lonmstalker/tgkit/core/wizard/StepBuilderImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/wizard/StepBuilderImpl.java
@@ -11,8 +11,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -31,8 +29,11 @@ import org.telegram.telegrambots.meta.api.objects.VideoNote;
  * <br>
  * &nbsp;• <em>content-validator</em> — бизнес-ограничения (размер, разрешение и т.д.).
  */
-@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 final class StepBuilderImpl<M, I, O> implements StepBuilder<M, I, O> {
+
+  StepBuilderImpl(@NonNull StepDefinition<M, I, O> def) {
+    this.def = def;
+  }
 
   private final @NonNull StepDefinition<M, I, O> def;
 

--- a/core/src/main/java/io/lonmstalker/tgkit/core/wizard/Wizard.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/wizard/Wizard.java
@@ -7,7 +7,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
-import lombok.Getter;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
@@ -20,10 +19,14 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  */
 public abstract class Wizard<M> {
 
-  @Getter private final String id;
+  private final String id;
   private final Supplier<M> factory;
   private BiConsumer<BotRequest<?>, M> onComplete;
   private final List<StepDefinition<M, ?, ?>> steps = new ArrayList<>();
+
+  public String getId() {
+    return id;
+  }
 
   /**
    * Конструктор.

--- a/core/src/main/java/io/lonmstalker/tgkit/core/wizard/WizardEngineImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/wizard/WizardEngineImpl.java
@@ -10,9 +10,8 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.*;
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
 import org.telegram.telegrambots.meta.api.objects.Update;
@@ -32,9 +31,10 @@ import org.telegram.telegrambots.meta.api.objects.Update;
  *       step по sessionId.
  * </ol>
  */
-@Slf4j
-@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+
 public final class WizardEngineImpl implements WizardEngine {
+
+  private static final Logger log = LoggerFactory.getLogger(WizardEngineImpl.class);
 
   private final @NonNull BotCommandRegistry commandRegistry;
   private final @NonNull StateStore stateStore;
@@ -46,6 +46,15 @@ public final class WizardEngineImpl implements WizardEngine {
 
   /** wizardId → Wizard<?> */
   private final Map<String, Wizard<?>> wizardMap = new HashMap<>();
+
+  WizardEngineImpl(
+      @NonNull BotCommandRegistry commandRegistry,
+      @NonNull StateStore stateStore,
+      @NonNull WizardStepRunner stepRunner) {
+    this.commandRegistry = commandRegistry;
+    this.stateStore = stateStore;
+    this.stepRunner = stepRunner;
+  }
 
   @Override
   public void register(@NonNull Wizard<?> wizard) {


### PR DESCRIPTION
## Summary
- replace Lombok annotations in `core` sources
- add explicit constructors, getters and loggers
- ensure utility classes have private constructors

## Testing
- `mvn -pl :core -DskipTests=true revapi:check`
- `mvn -pl core,observability,plugin,security,examples,api,telegram-bot-testkit,validator spotless:apply verify` *(failed: SuppressWithNearbyTextFilter class not found)*

------
https://chatgpt.com/codex/tasks/task_e_68551e93307c8325858fc283d2297c20