### PR TITLE
Fix Checkstyle config path and update engine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
         <checkstyle-maven-plugin.version>3.6.0</checkstyle-maven-plugin.version>
+        <checkstyle.version>10.25.0</checkstyle.version>
         <spotless-maven-plugin.version>2.44.5</spotless-maven-plugin.version>
         <revapi.version>0.28.2</revapi.version>
         <revapi-maven-plugin.version>0.15.1</revapi-maven-plugin.version>
@@ -326,8 +327,15 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${checkstyle-maven-plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>${checkstyle.version}</version>
+                    </dependency>
+                </dependencies>
                 <configuration>
-                    <configLocation>${project.parent.basedir}/config/checkstyle/google_checks.xml</configLocation>
+                    <configLocation>${session.executionRootDirectory}/config/checkstyle/google_checks.xml</configLocation>
                     <consoleOutput>true</consoleOutput>
                     <failOnViolation>true</failOnViolation>
                 </configuration>


### PR DESCRIPTION
## Summary
- configure Maven Checkstyle plugin to use Checkstyle 10.25.0
- reference config via `${session.executionRootDirectory}` so all modules locate it

## Testing
- `mvn -q spotless:apply verify` *(fails: Could not resolve project dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6855256f0d5c8325b06d4e3c24b1d868