### PR TITLE
Remove Lombok usage

### DIFF
--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -5,7 +5,6 @@ module io.lonmstalker.tgkit.api {
   requires transitive java.net.http;
   requires transitive org.apache.httpcomponents.httpclient;
   requires transitive org.apache.httpcomponents.httpcore;
-  requires static lombok;
   requires static com.fasterxml.jackson.annotation;
   requires static org.checkerframework.checker.qual;
 

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotDataSourceConfig.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotDataSourceConfig.java
@@ -4,9 +4,6 @@ import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-@Getter
-@Builder
-@AllArgsConstructor
 public class BotDataSourceConfig {
   private @Nullable BotConfig botConfig;
   private @NonNull DataSource dataSource;

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -4,7 +4,6 @@ module io.lonmstalker.tgkit.core {
   requires org.apache.commons.lang3;
   requires telegrambots;
   requires telegrambots.meta;
-  requires static lombok;
   requires static org.checkerframework.checker.qual;
   requires static com.fasterxml.jackson.annotation;
   requires transitive com.fasterxml.jackson.databind;

--- a/validator/src/main/java/module-info.java
+++ b/validator/src/main/java/module-info.java
@@ -2,7 +2,6 @@ module io.lonmstalker.tgkit.validator {
   requires io.lonmstalker.tgkit.api;
   requires telegrambots;
   requires telegrambots.meta;
-  requires static lombok;
   requires static org.checkerframework.checker.qual;
   requires language.detector;
   requires org.apache.tika.langdetect.optimaize;


### PR DESCRIPTION
## Summary
- strip Lombok from module-info descriptors
- clean up `BotDataSourceConfig` annotations

## Testing
- `mvn -Dproject.parent.basedir=$(pwd) spotless:apply verify -q` *(fails: cannot initialize SuppressWithNearbyTextFilter)*

------
https://chatgpt.com/codex/tasks/task_e_68552593f4d48325870b2383b8a9e462