### PR TITLE
Fix newline in BotCommandOrder

### DIFF
--- a/api/src/main/java/io/lonmstalker/tgkit/core/BotCommandOrder.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/BotCommandOrder.java
@@ -1,6 +1,5 @@
 package io.lonmstalker.tgkit.core;
 
-
 /** Константы, определяющие порядок выполнения обработчиков команд. */
 public final class BotCommandOrder {
   private BotCommandOrder() {}


### PR DESCRIPTION
## Summary
- remove excess blank line in `BotCommandOrder.java`
- run Spotless and Maven verify (verify failed due to missing Checkstyle configuration)

## Testing
- `mvn -q spotless:apply`
- `mvn -q verify` *(failed: Unable to find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_685525cb505c8325ba9655f2d1d1dae0