### PR TITLE
Add license header enforcement

### DIFF
--- a/api/src/main/java/io/lonmstalker/tgkit/core/BotAdapter.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/BotAdapter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/BotCommand.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/BotCommand.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core;
 
 import io.lonmstalker.tgkit.core.interceptor.BotInterceptor;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/BotCommandOrder.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/BotCommandOrder.java
@@ -1,5 +1,19 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core;
-
 
 /** Константы, определяющие порядок выполнения обработчиков команд. */
 public final class BotCommandOrder {

--- a/api/src/main/java/io/lonmstalker/tgkit/core/BotHandlerConverter.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/BotHandlerConverter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/BotInfo.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/BotInfo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core;
 
 /**

--- a/api/src/main/java/io/lonmstalker/tgkit/core/BotRequest.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/BotRequest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core;
 
 import io.lonmstalker.tgkit.core.dsl.*;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/BotRequestConverter.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/BotRequestConverter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/BotRequestType.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/BotRequestType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core;
 
 import io.lonmstalker.tgkit.core.exception.BotApiException;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/BotResponse.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/BotResponse.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core;
 
 import org.checkerframework.checker.nullness.qual.Nullable;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/BotService.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/BotService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core;
 
 import io.lonmstalker.tgkit.core.bot.TelegramSender;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/annotation/Arg.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/annotation/Arg.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.annotation;
 
 import io.lonmstalker.tgkit.core.args.BotArgumentConverter;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/annotation/BotCommand.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/annotation/BotCommand.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.annotation;
 
 import java.lang.annotation.ElementType;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/annotation/BotHandler.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/annotation/BotHandler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.annotation;
 
 import io.lonmstalker.tgkit.core.BotCommandOrder;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/annotation/CheckReturnValue.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/annotation/CheckReturnValue.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.annotation;
 
 import java.lang.annotation.ElementType;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/annotation/matching/AlwaysMatch.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/annotation/matching/AlwaysMatch.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.annotation.matching;
 
 import java.lang.annotation.ElementType;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/annotation/matching/CustomMatcher.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/annotation/matching/CustomMatcher.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.annotation.matching;
 
 import io.lonmstalker.tgkit.core.matching.CommandMatch;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/annotation/matching/MessageContainsMatch.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/annotation/matching/MessageContainsMatch.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.annotation.matching;
 
 import java.lang.annotation.ElementType;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/annotation/matching/MessageRegexMatch.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/annotation/matching/MessageRegexMatch.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.annotation.matching;
 
 import java.lang.annotation.ElementType;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/annotation/matching/MessageTextMatch.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/annotation/matching/MessageTextMatch.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.annotation.matching;
 
 import java.lang.annotation.ElementType;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/annotation/matching/UserRoleMatch.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/annotation/matching/UserRoleMatch.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.annotation.matching;
 
 import io.lonmstalker.tgkit.core.user.BotUserProvider;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/annotation/wizard/WizardMeta.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/annotation/wizard/WizardMeta.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.annotation.wizard;
 
 import java.lang.annotation.*;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/args/BotArgumentConverter.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/args/BotArgumentConverter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.args;
 
 import io.lonmstalker.tgkit.core.BotRequest;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/args/Context.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/args/Context.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.args;
 
 import java.util.regex.Matcher;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/args/ParamInfo.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/args/ParamInfo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.args;
 
 import io.lonmstalker.tgkit.core.BotRequest;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/bot/Bot.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/bot/Bot.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import io.lonmstalker.tgkit.core.exception.BotApiException;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/bot/BotCommandRegistry.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/bot/BotCommandRegistry.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import io.lonmstalker.tgkit.core.BotCommand;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/bot/BotCompleteAction.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/bot/BotCompleteAction.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 @FunctionalInterface

--- a/api/src/main/java/io/lonmstalker/tgkit/core/bot/BotConfig.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/bot/BotConfig.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import io.lonmstalker.tgkit.core.exception.BotExceptionHandler;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/bot/BotConstants.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/bot/BotConstants.java
@@ -1,6 +1,22 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 public class BotConstants {
   private BotConstants() {}
+
   public static final String BOT_TOKEN_SECRET = "bot_token";
 }

--- a/api/src/main/java/io/lonmstalker/tgkit/core/bot/BotRegistry.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/bot/BotRegistry.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import java.util.Collection;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/bot/BotState.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/bot/BotState.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 public enum BotState {

--- a/api/src/main/java/io/lonmstalker/tgkit/core/bot/ExponentialBackOff.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/bot/ExponentialBackOff.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import org.telegram.telegrambots.meta.generics.BackOff;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/bot/TelegramSender.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/bot/TelegramSender.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import io.lonmstalker.tgkit.core.exception.BotApiException;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/bot/TelegramSenderRateLimiter.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/bot/TelegramSenderRateLimiter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import io.lonmstalker.tgkit.core.config.BotGlobalConfig;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/config/BotGlobalConfig.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/config/BotGlobalConfig.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.config;
 
 import io.lonmstalker.tgkit.core.dsl.MissingIdStrategy;
@@ -10,9 +25,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.checkerframework.checker.nullness.qual.NonNull;
 
 /** Настройки по умолчанию для BotResponse. */
 public class BotGlobalConfig {

--- a/api/src/main/java/io/lonmstalker/tgkit/core/crypto/TokenCipher.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/crypto/TokenCipher.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.crypto;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/dsl/BotDSL.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/dsl/BotDSL.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import io.lonmstalker.tgkit.core.BotInfo;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/dsl/Button.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/dsl/Button.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import io.lonmstalker.tgkit.core.i18n.MessageLocalizer;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/dsl/Common.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/dsl/Common.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import io.lonmstalker.tgkit.core.BotResponse;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/dsl/DeleteBuilder.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/dsl/DeleteBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import io.lonmstalker.tgkit.core.dsl.context.DSLContext;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/dsl/EditBuilder.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/dsl/EditBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import io.lonmstalker.tgkit.core.config.BotGlobalConfig;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/dsl/InlineResultBuilder.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/dsl/InlineResultBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import io.lonmstalker.tgkit.core.dsl.context.DSLContext;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/dsl/KbBuilder.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/dsl/KbBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import io.lonmstalker.tgkit.core.i18n.MessageLocalizer;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/dsl/MediaGroupBuilder.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/dsl/MediaGroupBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import io.lonmstalker.tgkit.core.BotResponse;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/dsl/MessageBuilder.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/dsl/MessageBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import io.lonmstalker.tgkit.core.config.BotGlobalConfig;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/dsl/MissingIdStrategy.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/dsl/MissingIdStrategy.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import io.lonmstalker.tgkit.core.dsl.context.DSLContext;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/dsl/PhotoBuilder.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/dsl/PhotoBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import io.lonmstalker.tgkit.core.config.BotGlobalConfig;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/dsl/PollBuilder.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/dsl/PollBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import io.lonmstalker.tgkit.core.dsl.context.DSLContext;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/dsl/QuizBuilder.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/dsl/QuizBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import io.lonmstalker.tgkit.core.dsl.context.DSLContext;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/dsl/RichText.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/dsl/RichText.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/dsl/WithTtl.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/dsl/WithTtl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import io.lonmstalker.tgkit.core.config.BotGlobalConfig;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/dsl/context/DSLContext.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/dsl/context/DSLContext.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl.context;
 
 import io.lonmstalker.tgkit.core.BotInfo;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/dsl/feature_flags/FeatureFlags.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/dsl/feature_flags/FeatureFlags.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl.feature_flags;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/dsl/feature_flags/InMemoryFeatureFlags.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/dsl/feature_flags/InMemoryFeatureFlags.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl.feature_flags;
 
 import java.util.HashSet;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/dsl/ttl/TtlSchedulerDefault.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/dsl/ttl/TtlSchedulerDefault.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl.ttl;
 
 import io.lonmstalker.tgkit.core.config.BotGlobalConfig;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/dsl/validator/CaptionValidator.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/dsl/validator/CaptionValidator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl.validator;
 
 import io.lonmstalker.tgkit.core.exception.BotApiException;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/dsl/validator/FileSizeValidator.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/dsl/validator/FileSizeValidator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl.validator;
 
 import io.lonmstalker.tgkit.core.exception.BotApiException;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/dsl/validator/MediaGroupSizeValidator.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/dsl/validator/MediaGroupSizeValidator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl.validator;
 
 import io.lonmstalker.tgkit.core.exception.BotApiException;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/dsl/validator/PollSpec.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/dsl/validator/PollSpec.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl.validator;
 
 import java.util.List;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/dsl/validator/PollValidator.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/dsl/validator/PollValidator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl.validator;
 
 import io.lonmstalker.tgkit.core.exception.BotApiException;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/dsl/validator/TextLengthValidator.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/dsl/validator/TextLengthValidator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl.validator;
 
 import io.lonmstalker.tgkit.core.exception.BotApiException;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/event/BotEvent.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/event/BotEvent.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.event;
 
 /** Маркер любого события шины */

--- a/api/src/main/java/io/lonmstalker/tgkit/core/event/BotEventBus.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/event/BotEventBus.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.event;
 
 import java.util.concurrent.CompletableFuture;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/event/BotEventSubscription.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/event/BotEventSubscription.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.event;
 
 public interface BotEventSubscription {}

--- a/api/src/main/java/io/lonmstalker/tgkit/core/exception/BotApiException.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/exception/BotApiException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.exception;
 
 public class BotApiException extends RuntimeException {

--- a/api/src/main/java/io/lonmstalker/tgkit/core/exception/BotException.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/exception/BotException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.exception;
 
 public class BotException extends RuntimeException {

--- a/api/src/main/java/io/lonmstalker/tgkit/core/exception/BotExceptionHandler.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/exception/BotExceptionHandler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.exception;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/exception/ValidationException.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/exception/ValidationException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.exception;
 
 import io.lonmstalker.tgkit.core.i18n.MessageKey;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/i18n/MessageKey.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/i18n/MessageKey.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.i18n;
 
 import java.util.Locale;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/i18n/MessageLocalizer.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/i18n/MessageLocalizer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.i18n;
 
 import java.util.Locale;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/interceptor/BotInterceptor.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/interceptor/BotInterceptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.interceptor;
 
 import io.lonmstalker.tgkit.core.BotRequest;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/loader/BotCommandFactory.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/loader/BotCommandFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.loader;
 
 import io.lonmstalker.tgkit.core.BotCommand;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/matching/CommandMatch.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/matching/CommandMatch.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.matching;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/parse_mode/ParseMode.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/parse_mode/ParseMode.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.parse_mode;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/parse_mode/Sanitizer.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/parse_mode/Sanitizer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.parse_mode;
 
 import java.util.regex.Pattern;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/resource/ResourceLoader.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/resource/ResourceLoader.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.resource;
 
 import java.io.IOException;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/state/StateStore.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/state/StateStore.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.state;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/storage/BotRequestContextHolder.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/storage/BotRequestContextHolder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.storage;
 
 import io.lonmstalker.tgkit.core.bot.Bot;
@@ -10,6 +25,7 @@ import org.telegram.telegrambots.meta.api.objects.Update;
 
 public final class BotRequestContextHolder {
   private BotRequestContextHolder() {}
+
   private static final ThreadLocal<@Nullable Update> UPDATE = new ThreadLocal<>();
   private static final ThreadLocal<@Nullable Bot> CURRENT_BOT = new ThreadLocal<>();
   private static final ThreadLocal<@Nullable String> REQUEST_ID = new ThreadLocal<>();

--- a/api/src/main/java/io/lonmstalker/tgkit/core/ttl/DeleteTask.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/ttl/DeleteTask.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.ttl;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/ttl/TtlPolicy.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/ttl/TtlPolicy.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.ttl;
 
 import java.time.Duration;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/ttl/TtlScheduler.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/ttl/TtlScheduler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.ttl;
 
 import java.time.Duration;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/user/BotUserInfo.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/user/BotUserInfo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.user;
 
 import java.util.Locale;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/user/BotUserProvider.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/user/BotUserProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.user;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/user/store/UserKVStore.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/user/store/UserKVStore.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.user.store;
 
 import java.util.Map;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/validator/Validator.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/validator/Validator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.validator;
 
 import io.lonmstalker.tgkit.core.exception.ValidationException;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/wizard/StepBuilder.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/wizard/StepBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.wizard;
 
 import io.lonmstalker.tgkit.core.BotRequest;

--- a/api/src/main/java/io/lonmstalker/tgkit/observability/ClosableMetricsServer.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/observability/ClosableMetricsServer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.observability;
 
 import java.io.IOException;

--- a/api/src/main/java/io/lonmstalker/tgkit/observability/ImmutableTag.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/observability/ImmutableTag.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.observability;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/api/src/main/java/io/lonmstalker/tgkit/observability/Span.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/observability/Span.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.observability;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/api/src/main/java/io/lonmstalker/tgkit/observability/Tag.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/observability/Tag.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.observability;
 
 public interface Tag extends Comparable<Tag> {

--- a/api/src/main/java/io/lonmstalker/tgkit/observability/Tags.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/observability/Tags.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.observability;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/api/src/main/java/io/lonmstalker/tgkit/observability/Tracer.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/observability/Tracer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.observability;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/api/src/main/java/io/lonmstalker/tgkit/plugin/BotPlugin.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/plugin/BotPlugin.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.plugin;
 
 public interface BotPlugin extends PluginLifecycle {

--- a/api/src/main/java/io/lonmstalker/tgkit/plugin/BotPluginContext.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/plugin/BotPluginContext.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.plugin;
 
 import io.lonmstalker.tgkit.core.bot.BotRegistry;

--- a/api/src/main/java/io/lonmstalker/tgkit/plugin/BotPluginPermission.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/plugin/BotPluginPermission.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.plugin;
 
 public enum BotPluginPermission {

--- a/api/src/main/java/io/lonmstalker/tgkit/plugin/PluginException.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/plugin/PluginException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.plugin;
 
 import io.lonmstalker.tgkit.core.exception.BotApiException;

--- a/api/src/main/java/io/lonmstalker/tgkit/plugin/PluginLifecycle.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/plugin/PluginLifecycle.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.plugin;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/api/src/main/java/io/lonmstalker/tgkit/security/antispam/DropUpdateException.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/security/antispam/DropUpdateException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.antispam;
 
 import io.lonmstalker.tgkit.core.exception.BotApiException;

--- a/api/src/main/java/io/lonmstalker/tgkit/security/antispam/DuplicateProvider.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/security/antispam/DuplicateProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.antispam;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/api/src/main/java/io/lonmstalker/tgkit/security/audit/Audit.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/security/audit/Audit.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.audit;
 
 import java.lang.annotation.ElementType;

--- a/api/src/main/java/io/lonmstalker/tgkit/security/audit/AuditBus.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/security/audit/AuditBus.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.audit;
 
 import java.util.List;

--- a/api/src/main/java/io/lonmstalker/tgkit/security/audit/AuditConverter.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/security/audit/AuditConverter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.audit;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/api/src/main/java/io/lonmstalker/tgkit/security/audit/AuditEvent.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/security/audit/AuditEvent.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.audit;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/api/src/main/java/io/lonmstalker/tgkit/security/audit/AuditSink.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/security/audit/AuditSink.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.audit;
 
 import java.io.Closeable;

--- a/api/src/main/java/io/lonmstalker/tgkit/security/captcha/CaptchaProvider.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/security/captcha/CaptchaProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.captcha;
 
 import io.lonmstalker.tgkit.core.BotRequest;

--- a/api/src/main/java/io/lonmstalker/tgkit/security/captcha/MathCaptchaOperations.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/security/captcha/MathCaptchaOperations.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.captcha;
 
 import java.util.Arrays;

--- a/api/src/main/java/io/lonmstalker/tgkit/security/captcha/MathCaptchaProviderStore.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/security/captcha/MathCaptchaProviderStore.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.captcha;
 
 import java.time.Duration;

--- a/api/src/main/java/io/lonmstalker/tgkit/security/ratelimit/LimiterKey.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/security/ratelimit/LimiterKey.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.ratelimit;
 
 public enum LimiterKey {

--- a/api/src/main/java/io/lonmstalker/tgkit/security/ratelimit/RateLimit.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/security/ratelimit/RateLimit.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.ratelimit;
 
 import java.lang.annotation.ElementType;

--- a/api/src/main/java/io/lonmstalker/tgkit/security/ratelimit/RateLimiter.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/security/ratelimit/RateLimiter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.ratelimit;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/api/src/main/java/io/lonmstalker/tgkit/security/ratelimit/RateLimits.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/security/ratelimit/RateLimits.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.ratelimit;
 
 import java.lang.annotation.ElementType;

--- a/api/src/main/java/io/lonmstalker/tgkit/security/rbac/ForbiddenException.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/security/rbac/ForbiddenException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.rbac;
 
 import io.lonmstalker.tgkit.core.exception.BotApiException;

--- a/api/src/main/java/io/lonmstalker/tgkit/security/rbac/RequiresRoles.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/security/rbac/RequiresRoles.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.rbac;
 
 import java.lang.annotation.ElementType;

--- a/api/src/main/java/io/lonmstalker/tgkit/security/secret/SecretStore.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/security/secret/SecretStore.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.secret;
 
 import java.util.Optional;

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 module io.lonmstalker.tgkit.api {
   requires transitive telegrambots;
   requires transitive telegrambots.meta;
@@ -5,7 +20,6 @@ module io.lonmstalker.tgkit.api {
   requires transitive java.net.http;
   requires transitive org.apache.httpcomponents.httpclient;
   requires transitive org.apache.httpcomponents.httpcore;
-  requires static lombok;
   requires static com.fasterxml.jackson.annotation;
   requires static org.checkerframework.checker.qual;
 

--- a/config/license-header.txt
+++ b/config/license-header.txt
@@ -13,14 +13,3 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.lonmstalker.tgkit.security.rbac;
-
-import java.lang.annotation.*;
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
-@Repeatable(RequiresRoles.class)
-public @interface RequiresRole {
-  /** Одна или несколько ролей; достаточно совпадения любой. */
-  String[] value();
-}

--- a/core/src/main/java/io/lonmstalker/tgkit/core/args/Converters.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/args/Converters.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.args;
 
 import io.lonmstalker.tgkit.core.BotRequest;
@@ -10,6 +25,7 @@ import org.telegram.telegrambots.meta.api.objects.Update;
 /** Утилитарный реестр, где хранятся все кастомные BotArgumentConverter. */
 public final class Converters {
   private Converters() {}
+
   private static final Map<Class<?>, BotArgumentConverter<?, ?>> BY_TYPE =
       new ConcurrentHashMap<>();
   private static final Map<Class<?>, BotArgumentConverter<?, ?>> BY_CLASS =

--- a/core/src/main/java/io/lonmstalker/tgkit/core/args/RouteContextHolder.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/args/RouteContextHolder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.args;
 
 import java.util.regex.Matcher;
@@ -6,6 +21,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class RouteContextHolder {
   private RouteContextHolder() {}
+
   private static final ThreadLocal<@Nullable Matcher> MATCHER = new ThreadLocal<>();
 
   public static void setMatcher(@NonNull Matcher matcher) {

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotAdapterImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotAdapterImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import io.lonmstalker.tgkit.core.*;
@@ -18,11 +33,11 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.apache.commons.lang3.tuple.Pair;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.objects.Update;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotBuilder.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import io.lonmstalker.tgkit.core.BotAdapter;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotCommandRegistryImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotCommandRegistryImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import io.lonmstalker.tgkit.core.BotCommand;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotDataSourceConfig.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotDataSourceConfig.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import javax.sql.DataSource;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotDataSourceFactory.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotDataSourceFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import io.lonmstalker.tgkit.core.crypto.TokenCipher;
@@ -8,17 +23,19 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Objects;
 import javax.sql.DataSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.bots.DefaultBotOptions;
 
 /** Extracts bot information from database. */
 public final class BotDataSourceFactory {
   private static final Logger log = LoggerFactory.getLogger(BotDataSourceFactory.class);
+
   private BotDataSourceFactory() {}
+
   public static final BotDataSourceFactory INSTANCE = new BotDataSourceFactory();
 
   // language=SQL

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotFactory.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import io.lonmstalker.tgkit.core.BotAdapter;
@@ -10,6 +25,7 @@ import org.telegram.telegrambots.meta.api.methods.updates.SetWebhook;
 
 public final class BotFactory {
   private BotFactory() {}
+
   public static final BotFactory INSTANCE = new BotFactory();
   private final AtomicLong nextId = new AtomicLong();
 

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import io.lonmstalker.tgkit.core.config.BotGlobalConfig;
@@ -12,10 +27,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.bots.DefaultAbsSender;
 import org.telegram.telegrambots.meta.api.methods.GetMe;
 import org.telegram.telegrambots.meta.api.methods.updates.SetWebhook;
@@ -119,6 +134,7 @@ public final class BotImpl implements Bot {
           onCompletedActionTimeoutMs);
     }
   }
+
   private final AtomicReference<BotState> state = new AtomicReference<>(BotState.NEW);
   private final @NonNull List<BotCompleteAction> completeActions = new CopyOnWriteArrayList<>();
   private long id;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotRegistryImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotRegistryImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import java.lang.ref.WeakReference;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotRequestConverterImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotRequestConverterImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import io.lonmstalker.tgkit.core.BotRequestConverter;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotSessionImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotSessionImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -18,9 +33,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.telegram.telegrambots.bots.DefaultBotOptions;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.generics.BotOptions;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/LongPollingReceiver.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/LongPollingReceiver.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import static io.lonmstalker.tgkit.core.bot.BotConstants.BOT_TOKEN_SECRET;
@@ -6,11 +21,11 @@ import io.lonmstalker.tgkit.core.BotAdapter;
 import io.lonmstalker.tgkit.core.exception.BotExceptionHandler;
 import io.lonmstalker.tgkit.core.exception.BotExceptionHandlerDefault;
 import io.lonmstalker.tgkit.security.secret.SecretStore;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.bots.TelegramLongPollingBot;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/WebHookReceiver.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/WebHookReceiver.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import static io.lonmstalker.tgkit.core.bot.BotConstants.BOT_TOKEN_SECRET;
@@ -6,11 +21,11 @@ import io.lonmstalker.tgkit.core.BotAdapter;
 import io.lonmstalker.tgkit.core.exception.BotExceptionHandler;
 import io.lonmstalker.tgkit.core.exception.BotExceptionHandlerDefault;
 import io.lonmstalker.tgkit.security.secret.SecretStore;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.bots.TelegramWebhookBot;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.objects.Update;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/loader/AnnotatedCommandLoader.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/loader/AnnotatedCommandLoader.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot.loader;
 
 import static io.lonmstalker.tgkit.core.reflection.ReflectionUtils.newInstance;
@@ -28,19 +43,21 @@ import java.lang.reflect.*;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.reflections.Reflections;
 import org.reflections.scanners.Scanners;
 import org.reflections.util.ConfigurationBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
 import org.telegram.telegrambots.meta.api.objects.Update;
 
 /** Utility to scan packages for {@link BotHandler} methods. */
 public final class AnnotatedCommandLoader {
   private static final Logger log = LoggerFactory.getLogger(AnnotatedCommandLoader.class);
+
   private AnnotatedCommandLoader() {}
+
   private static final List<BotCommandFactory<?>> FACTORIES = new CopyOnWriteArrayList<>();
 
   static {

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/loader/InternalCommandAdapter.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/loader/InternalCommandAdapter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot.loader;
 
 import io.lonmstalker.tgkit.core.BotCommand;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/config/ConfigLoader.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/config/ConfigLoader.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.config;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/crypto/TokenCipherImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/crypto/TokenCipherImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.crypto;
 
 import io.lonmstalker.tgkit.core.exception.BotApiException;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/event/InMemoryEventBus.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/event/InMemoryEventBus.java
@@ -1,12 +1,27 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.event;
 
 import io.lonmstalker.tgkit.core.config.BotGlobalConfig;
 import java.util.Set;
 import java.util.concurrent.*;
 import java.util.function.Consumer;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.checkerframework.checker.nullness.qual.NonNull;
 
 public final class InMemoryEventBus implements BotEventBus {
   private static final Logger log = LoggerFactory.getLogger(InMemoryEventBus.class);

--- a/core/src/main/java/io/lonmstalker/tgkit/core/event/TelegramBotEvent.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/event/TelegramBotEvent.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.event;
 
 import java.time.Instant;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/event/impl/RegisterCommandBotEvent.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/event/impl/RegisterCommandBotEvent.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.event.impl;
 
 import io.lonmstalker.tgkit.core.BotCommand;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/event/impl/StartStatusBotEvent.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/event/impl/StartStatusBotEvent.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.event.impl;
 
 import io.lonmstalker.tgkit.core.event.TelegramBotEvent;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/event/impl/StopStatusBotEvent.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/event/impl/StopStatusBotEvent.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.event.impl;
 
 import io.lonmstalker.tgkit.core.event.TelegramBotEvent;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/exception/BotExceptionHandlerDefault.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/exception/BotExceptionHandlerDefault.java
@@ -1,10 +1,25 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.exception;
 
 import io.lonmstalker.tgkit.core.update.UpdateUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Update;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/experimental/Incubating.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/experimental/Incubating.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.experimental;
 
 import java.lang.annotation.Documented;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/i18n/MessageLocalizerImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/i18n/MessageLocalizerImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.i18n;
 
 import java.text.MessageFormat;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/i18n/NoopMessageLocalizer.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/i18n/NoopMessageLocalizer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.i18n;
 
 import java.util.Locale;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/init/BotCoreInitializer.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/init/BotCoreInitializer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.init;
 
 import io.lonmstalker.tgkit.core.config.BotGlobalConfig;
@@ -22,6 +37,7 @@ import org.slf4j.LoggerFactory;
 public final class BotCoreInitializer {
 
   private static final Logger log = LoggerFactory.getLogger(BotCoreInitializer.class);
+
   private BotCoreInitializer() {}
 
   private static volatile boolean started;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/interceptor/LoggingBotInterceptor.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/interceptor/LoggingBotInterceptor.java
@@ -1,11 +1,26 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.interceptor;
 
 import io.lonmstalker.tgkit.core.BotRequest;
 import io.lonmstalker.tgkit.core.BotResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.meta.api.objects.Update;
 
 /** Стандартный интерцептор, логирующий этапы обработки обновления. */

--- a/core/src/main/java/io/lonmstalker/tgkit/core/loader/ClasspathScanner.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/loader/ClasspathScanner.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.loader;
 
 import java.lang.annotation.Annotation;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/matching/AlwaysMatch.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/matching/AlwaysMatch.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.matching;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/matching/MessageContainsMatch.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/matching/MessageContainsMatch.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.matching;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/matching/MessageRegexMatch.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/matching/MessageRegexMatch.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.matching;
 
 import io.lonmstalker.tgkit.core.args.RouteContextHolder;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/matching/MessageTextMatch.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/matching/MessageTextMatch.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.matching;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/matching/UserRoleMatch.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/matching/UserRoleMatch.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.matching;
 
 import io.lonmstalker.tgkit.core.storage.BotRequestContextHolder;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/processor/BotHandlerProcessor.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/processor/BotHandlerProcessor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.processor;
 
 import io.lonmstalker.tgkit.core.BotRequest;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/reflection/ReflectionUtils.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/reflection/ReflectionUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.reflection;
 
 import io.lonmstalker.tgkit.core.exception.BotApiException;
@@ -6,7 +21,6 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 public final class ReflectionUtils {

--- a/core/src/main/java/io/lonmstalker/tgkit/core/resource/Loaders.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/resource/Loaders.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.resource;
 
 import java.io.FileNotFoundException;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/state/InMemoryStateStore.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/state/InMemoryStateStore.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.state;
 
 import java.util.Map;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/state/JdbcStateStore.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/state/JdbcStateStore.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.state;
 
 import java.sql.Connection;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/update/UpdateUtils.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/update/UpdateUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.update;
 
 import io.lonmstalker.tgkit.core.BotRequestType;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/user/SimpleUserProvider.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/user/SimpleUserProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.user;
 
 import io.lonmstalker.tgkit.core.update.UpdateUtils;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/user/store/InMemoryUserKVStore.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/user/store/InMemoryUserKVStore.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.user.store;
 
 import java.util.Map;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/user/store/JdbcUserKVStore.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/user/store/JdbcUserKVStore.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.user.store;
 
 import io.lonmstalker.tgkit.core.exception.BotApiException;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/user/store/ReadOnlyUserKVStore.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/user/store/ReadOnlyUserKVStore.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.user.store;
 
 import java.util.Map;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/validator/MessageValidators.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/validator/MessageValidators.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.validator;
 
 import io.lonmstalker.tgkit.core.i18n.MessageKey;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/validator/RequestValidators.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/validator/RequestValidators.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.validator;
 
 import io.lonmstalker.tgkit.core.BotRequest;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/wizard/StepBuilderImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/wizard/StepBuilderImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.wizard;
 
 import io.lonmstalker.tgkit.core.BotRequest;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/wizard/StepDefinition.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/wizard/StepDefinition.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.wizard;
 
 import io.lonmstalker.tgkit.core.BotRequest;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/wizard/Wizard.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/wizard/Wizard.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.wizard;
 
 import io.lonmstalker.tgkit.core.BotRequest;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/wizard/WizardEngine.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/wizard/WizardEngine.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.wizard;
 
 import io.lonmstalker.tgkit.core.BotRequest;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/wizard/WizardEngineImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/wizard/WizardEngineImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.wizard;
 
 import io.lonmstalker.tgkit.core.BotCommand;
@@ -10,9 +25,9 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.*;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
 import org.telegram.telegrambots.meta.api.objects.Update;
 
@@ -31,7 +46,6 @@ import org.telegram.telegrambots.meta.api.objects.Update;
  *       step по sessionId.
  * </ol>
  */
-
 public final class WizardEngineImpl implements WizardEngine {
 
   private static final Logger log = LoggerFactory.getLogger(WizardEngineImpl.class);

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -1,10 +1,24 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 module io.lonmstalker.tgkit.core {
   requires io.lonmstalker.tgkit.api;
   requires org.slf4j;
   requires org.apache.commons.lang3;
   requires telegrambots;
   requires telegrambots.meta;
-  requires static lombok;
   requires static org.checkerframework.checker.qual;
   requires static com.fasterxml.jackson.annotation;
   requires transitive com.fasterxml.jackson.databind;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/args/ArgBindingTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/args/ArgBindingTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.args;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/args/ConvertersTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/args/ConvertersTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.args;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotBuilderTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotBuilderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotCommandRegistryImplTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotCommandRegistryImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotDataSourceFactoryTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotDataSourceFactoryTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotFactoryTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotFactoryTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotImplLifecycleTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotImplLifecycleTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotSessionImplTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotSessionImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/TelegramSenderRateLimiterTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/TelegramSenderRateLimiterTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/TelegramSenderTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/TelegramSenderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.bot;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/crypto/TokenCipherImplTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/crypto/TokenCipherImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.crypto;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/BuilderFlagTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/BuilderFlagTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import static org.assertj.core.api.Assertions.*;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/ConditionalBranchesTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/ConditionalBranchesTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/CustomStrategyReuseTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/CustomStrategyReuseTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/DslContextValidationTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/DslContextValidationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import static org.assertj.core.api.Assertions.*;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/DslTtlIntegrationTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/DslTtlIntegrationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/EditBuilderTypingTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/EditBuilderTypingTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/InMemoryFeatureFlagsTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/InMemoryFeatureFlagsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import static org.assertj.core.api.Assertions.*;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/KbBuilderTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/KbBuilderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import static org.assertj.core.api.Assertions.*;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/MediaGroupChunkingTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/MediaGroupChunkingTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/MessageBuilderTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/MessageBuilderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import static org.assertj.core.api.Assertions.*;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/MissingIdStrategyTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/MissingIdStrategyTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import static org.assertj.core.api.Assertions.*;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/QuizBuilderEdgeTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/QuizBuilderEdgeTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/common/DummySender.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/common/DummySender.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl.common;
 
 import io.lonmstalker.tgkit.core.bot.BotConfig;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/common/MockCtx.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/common/MockCtx.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.dsl.common;
 
 import static org.mockito.Mockito.mock;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/experimental/IncubatingTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/experimental/IncubatingTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.experimental;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/i18n/MessageLocalizerTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/i18n/MessageLocalizerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.i18n;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/interceptor/LoggingBotInterceptorTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/interceptor/LoggingBotInterceptorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.interceptor;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/matching/MatchersTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/matching/MatchersTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.matching;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/processor/BotHandlerProcessorTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/processor/BotHandlerProcessorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.processor;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/resource/ResourceLoaderTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/resource/ResourceLoaderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.resource;
 
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/storage/BotRequestContextHolderTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/storage/BotRequestContextHolderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.storage;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/store/UserKVStoreTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/store/UserKVStoreTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.store;
 
 import io.lonmstalker.tgkit.core.init.BotCoreInitializer;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/ttl/TtlSchedulerTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/ttl/TtlSchedulerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.ttl;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/update/UpdateUtilsTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/update/UpdateUtilsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.update;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/examples/observability-demo/src/main/java/io/lonmstalker/tgkit/examples/observability/ObservabilityDemoApplication.java
+++ b/examples/observability-demo/src/main/java/io/lonmstalker/tgkit/examples/observability/ObservabilityDemoApplication.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.examples.observability;
 
 import io.lonmstalker.observability.BotObservability;

--- a/examples/plugin-demo/app/src/main/java/io/lonmstalker/tgkit/app/Main.java
+++ b/examples/plugin-demo/app/src/main/java/io/lonmstalker/tgkit/app/Main.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.app;
 
 import io.lonmstalker.tgkit.core.init.BotCoreInitializer;

--- a/examples/plugin-demo/plugin-example/src/main/java/io/lonmstalker/tgkit/plugin/ExamplePlugin.java
+++ b/examples/plugin-demo/plugin-example/src/main/java/io/lonmstalker/tgkit/plugin/ExamplePlugin.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.plugin;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/examples/simple-bot/src/main/java/io/lonmstalker/examples/simplebot/SimpleBotApplication.java
+++ b/examples/simple-bot/src/main/java/io/lonmstalker/examples/simplebot/SimpleBotApplication.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.examples.simplebot;
 
 import io.lonmstalker.tgkit.core.BotAdapter;

--- a/examples/simple-bot/src/main/java/io/lonmstalker/examples/simplebot/SimpleBotCommands.java
+++ b/examples/simple-bot/src/main/java/io/lonmstalker/examples/simplebot/SimpleBotCommands.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.examples.simplebot;
 
 import io.lonmstalker.tgkit.core.BotRequest;

--- a/examples/simple-bot/src/main/java/io/lonmstalker/examples/simplebot/SimpleRoleProvider.java
+++ b/examples/simple-bot/src/main/java/io/lonmstalker/examples/simplebot/SimpleRoleProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.examples.simplebot;
 
 import static io.lonmstalker.tgkit.core.update.UpdateUtils.resolveChatId;

--- a/observability/src/main/java/io/lonmstalker/observability/BotObservability.java
+++ b/observability/src/main/java/io/lonmstalker/observability/BotObservability.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.observability;
 
 import io.lonmstalker.observability.impl.CompositeTracer;

--- a/observability/src/main/java/io/lonmstalker/observability/LogContext.java
+++ b/observability/src/main/java/io/lonmstalker/observability/LogContext.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.observability;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/observability/src/main/java/io/lonmstalker/observability/MetricsCollector.java
+++ b/observability/src/main/java/io/lonmstalker/observability/MetricsCollector.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.observability;
 
 import io.lonmstalker.tgkit.observability.Tags;

--- a/observability/src/main/java/io/lonmstalker/observability/ObservabilityInterceptor.java
+++ b/observability/src/main/java/io/lonmstalker/observability/ObservabilityInterceptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.observability;
 
 import io.lonmstalker.tgkit.core.BotRequest;

--- a/observability/src/main/java/io/lonmstalker/observability/impl/CompositeTracer.java
+++ b/observability/src/main/java/io/lonmstalker/observability/impl/CompositeTracer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.observability.impl;
 
 import io.lonmstalker.tgkit.observability.Span;

--- a/observability/src/main/java/io/lonmstalker/observability/impl/MicrometerCollector.java
+++ b/observability/src/main/java/io/lonmstalker/observability/impl/MicrometerCollector.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.observability.impl;
 
 import io.lonmstalker.observability.MetricsCollector;

--- a/observability/src/main/java/io/lonmstalker/observability/impl/NoOpTracer.java
+++ b/observability/src/main/java/io/lonmstalker/observability/impl/NoOpTracer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.observability.impl;
 
 import io.lonmstalker.tgkit.observability.Span;

--- a/observability/src/main/java/io/lonmstalker/observability/impl/OTelTracer.java
+++ b/observability/src/main/java/io/lonmstalker/observability/impl/OTelTracer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.observability.impl;
 
 import io.lonmstalker.tgkit.observability.Span;

--- a/observability/src/main/java/io/lonmstalker/observability/impl/PrometheusMetricsServer.java
+++ b/observability/src/main/java/io/lonmstalker/observability/impl/PrometheusMetricsServer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.observability.impl;
 
 import io.lonmstalker.tgkit.observability.ClosableMetricsServer;

--- a/observability/src/main/java/module-info.java
+++ b/observability/src/main/java/module-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 module io.lonmstalker.tgkit.observability {
   requires io.lonmstalker.tgkit.core;
   requires io.micrometer.core;

--- a/observability/src/test/java/io/lonmstalker/observability/CompositeTracerTest.java
+++ b/observability/src/test/java/io/lonmstalker/observability/CompositeTracerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.observability;
 
 import static io.lonmstalker.tgkit.observability.Tags.*;

--- a/observability/src/test/java/io/lonmstalker/observability/MetricsServerLifecycleTest.java
+++ b/observability/src/test/java/io/lonmstalker/observability/MetricsServerLifecycleTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.observability;
 
 import io.lonmstalker.observability.impl.PrometheusMetricsServer;

--- a/observability/src/test/java/io/lonmstalker/observability/ObservabilityInterceptorTest.java
+++ b/observability/src/test/java/io/lonmstalker/observability/ObservabilityInterceptorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.observability;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/BotPluginConstants.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/BotPluginConstants.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.plugin;
 
 /**

--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/BotPluginContainer.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/BotPluginContainer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.plugin;
 
 import java.net.URLClassLoader;

--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/BotPluginContextDefault.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/BotPluginContextDefault.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.plugin;
 
 import io.lonmstalker.tgkit.core.bot.BotRegistry;

--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/BotPluginDescriptor.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/BotPluginDescriptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.plugin;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/BotPluginManager.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/BotPluginManager.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.plugin;
 
 import static io.lonmstalker.tgkit.plugin.BotPluginConstants.CURRENT_VERSION;

--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/ChildFirstURLClassLoader.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/ChildFirstURLClassLoader.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.plugin;
 
 import java.net.URL;

--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/annotation/BotPlugin.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/annotation/BotPlugin.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.plugin.annotation;
 
 import java.lang.annotation.ElementType;

--- a/plugin/src/main/java/io/lonmstalker/tgkit/plugin/sort/TopoSorter.java
+++ b/plugin/src/main/java/io/lonmstalker/tgkit/plugin/sort/TopoSorter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.plugin.sort;
 
 import io.lonmstalker.tgkit.plugin.PluginException;

--- a/plugin/src/main/java/module-info.java
+++ b/plugin/src/main/java/module-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 module io.lonmstalker.tgkit.plugin {
   requires io.lonmstalker.tgkit.core;
   requires io.lonmstalker.tgkit.observability;

--- a/plugin/src/test/java/io/lonmstalker/tgkit/plugin/BotPluginManagerTest.java
+++ b/plugin/src/test/java/io/lonmstalker/tgkit/plugin/BotPluginManagerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.plugin;
 
 import static io.lonmstalker.tgkit.plugin.BotPluginConstants.CURRENT_VERSION;

--- a/plugin/src/test/java/io/lonmstalker/tgkit/plugin/ChildFirstURLClassLoaderTest.java
+++ b/plugin/src/test/java/io/lonmstalker/tgkit/plugin/ChildFirstURLClassLoaderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.plugin;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/plugin/src/test/java/io/lonmstalker/tgkit/plugin/sort/TopoSorterTest.java
+++ b/plugin/src/test/java/io/lonmstalker/tgkit/plugin/sort/TopoSorterTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.plugin.sort;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,22 @@
                     <java>
                         <googleJavaFormat />
                         <removeUnusedImports />
+                        <licenseHeader>
+                            <file>${maven.multiModuleProjectDirectory}/config/license-header.txt</file>
+                            <delimiter>package|module</delimiter>
+                        </licenseHeader>
                     </java>
+                    <formats>
+                        <format>
+                            <includes>
+                                <include>**/module-info.java</include>
+                            </includes>
+                            <licenseHeader>
+                                <file>${maven.multiModuleProjectDirectory}/config/license-header.txt</file>
+                                <delimiter>module</delimiter>
+                            </licenseHeader>
+                        </format>
+                    </formats>
                 </configuration>
                 <executions>
                     <execution>

--- a/security/src/main/java/io/lonmstalker/tgkit/security/BotSecurity.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/BotSecurity.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security;
 
 import io.lonmstalker.tgkit.security.antispam.AntiSpamInterceptor;

--- a/security/src/main/java/io/lonmstalker/tgkit/security/antispam/AntiSpamInterceptor.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/antispam/AntiSpamInterceptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.antispam;
 
 import io.lonmstalker.tgkit.core.BotRequest;

--- a/security/src/main/java/io/lonmstalker/tgkit/security/antispam/InMemoryDuplicateProvider.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/antispam/InMemoryDuplicateProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.antispam;
 
 import com.github.benmanes.caffeine.cache.Cache;

--- a/security/src/main/java/io/lonmstalker/tgkit/security/audit/AsyncAuditBus.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/audit/AsyncAuditBus.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.audit;
 
 import io.lonmstalker.tgkit.core.config.BotGlobalConfig;

--- a/security/src/main/java/io/lonmstalker/tgkit/security/audit/AuditBotCommandFactory.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/audit/AuditBotCommandFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.audit;
 
 import io.lonmstalker.tgkit.core.BotCommand;
@@ -7,10 +22,10 @@ import io.lonmstalker.tgkit.core.reflection.ReflectionUtils;
 import io.lonmstalker.tgkit.security.config.BotSecurityGlobalConfig;
 import java.lang.reflect.*;
 import java.util.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class AuditBotCommandFactory implements BotCommandFactory<Audit> {
   private static final Logger log = LoggerFactory.getLogger(AuditBotCommandFactory.class);

--- a/security/src/main/java/io/lonmstalker/tgkit/security/audit/DelegatingAuditInterceptor.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/audit/DelegatingAuditInterceptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.audit;
 
 import io.lonmstalker.tgkit.core.BotRequest;

--- a/security/src/main/java/io/lonmstalker/tgkit/security/audit/UpdateAuditConverter.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/audit/UpdateAuditConverter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.audit;
 
 import io.lonmstalker.tgkit.core.update.UpdateUtils;

--- a/security/src/main/java/io/lonmstalker/tgkit/security/captcha/InMemoryMathCaptchaProviderStore.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/captcha/InMemoryMathCaptchaProviderStore.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.captcha;
 
 import com.github.benmanes.caffeine.cache.Cache;

--- a/security/src/main/java/io/lonmstalker/tgkit/security/captcha/RedisMathCaptchaProviderStore.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/captcha/RedisMathCaptchaProviderStore.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.captcha;
 
 import java.time.Duration;

--- a/security/src/main/java/io/lonmstalker/tgkit/security/captcha/provider/MathCaptchaProvider.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/captcha/provider/MathCaptchaProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.captcha.provider;
 
 import io.lonmstalker.tgkit.core.BotRequest;

--- a/security/src/main/java/io/lonmstalker/tgkit/security/captcha/provider/RecaptchaWebProvider.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/captcha/provider/RecaptchaWebProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.captcha.provider;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -14,10 +29,10 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 
 /** Google reCAPTCHA v3: тихий fallback-провайдер. */
@@ -101,7 +116,8 @@ public final class RecaptchaWebProvider implements CaptchaProvider {
     }
 
     public RecaptchaWebProvider build() {
-      return new RecaptchaWebProvider(domain, secretKey, secretStore, verifyUrl, mapper, httpClient);
+      return new RecaptchaWebProvider(
+          domain, secretKey, secretStore, verifyUrl, mapper, httpClient);
     }
   }
 

--- a/security/src/main/java/io/lonmstalker/tgkit/security/captcha/provider/SliderCaptchaProvider.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/captcha/provider/SliderCaptchaProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.captcha.provider;
 
 import static java.util.Collections.*;

--- a/security/src/main/java/io/lonmstalker/tgkit/security/event/SecurityBotEvent.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/event/SecurityBotEvent.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.event;
 
 import io.lonmstalker.tgkit.core.BotRequest;

--- a/security/src/main/java/io/lonmstalker/tgkit/security/init/BotSecurityInitializer.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/init/BotSecurityInitializer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.init;
 
 import io.lonmstalker.tgkit.core.config.BotGlobalConfig;
@@ -10,9 +25,9 @@ import io.lonmstalker.tgkit.security.ratelimit.impl.InMemoryRateLimiter;
 import io.lonmstalker.tgkit.security.secret.EnvSecretStore;
 import java.time.Duration;
 import java.util.Set;
+import org.apache.commons.lang3.Range;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.commons.lang3.Range;
 
 /**
  * Базовая инициализация security-модуля.<br>

--- a/security/src/main/java/io/lonmstalker/tgkit/security/ratelimit/RateLimitBotCommandFactory.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/ratelimit/RateLimitBotCommandFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.ratelimit;
 
 import io.lonmstalker.tgkit.core.BotCommand;

--- a/security/src/main/java/io/lonmstalker/tgkit/security/ratelimit/RateLimitInterceptor.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/ratelimit/RateLimitInterceptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.ratelimit;
 
 import io.lonmstalker.tgkit.core.BotRequest;

--- a/security/src/main/java/io/lonmstalker/tgkit/security/ratelimit/impl/InMemoryRateLimiter.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/ratelimit/impl/InMemoryRateLimiter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.ratelimit.impl;
 
 import com.github.benmanes.caffeine.cache.Cache;

--- a/security/src/main/java/io/lonmstalker/tgkit/security/ratelimit/impl/RedisRateLimiter.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/ratelimit/impl/RedisRateLimiter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.ratelimit.impl;
 
 import io.lonmstalker.tgkit.security.ratelimit.RateLimiter;

--- a/security/src/main/java/io/lonmstalker/tgkit/security/rbac/RoleBotCommandFactory.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/rbac/RoleBotCommandFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.rbac;
 
 import io.lonmstalker.tgkit.core.BotCommand;

--- a/security/src/main/java/io/lonmstalker/tgkit/security/rbac/RoleInterceptor.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/rbac/RoleInterceptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.rbac;
 
 import io.lonmstalker.tgkit.core.BotRequest;

--- a/security/src/main/java/io/lonmstalker/tgkit/security/secret/EnvSecretStore.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/secret/EnvSecretStore.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.secret;
 
 import java.util.Optional;

--- a/security/src/main/java/io/lonmstalker/tgkit/security/secret/PropertyFileSecretStore.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/secret/PropertyFileSecretStore.java
@@ -1,10 +1,25 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.secret;
 
 import java.util.Optional;
 import java.util.Properties;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.checkerframework.checker.nullness.qual.NonNull;
 
 public final class PropertyFileSecretStore implements SecretStore {
   private static final Logger log = LoggerFactory.getLogger(PropertyFileSecretStore.class);

--- a/security/src/main/java/io/lonmstalker/tgkit/security/secret/VaultSecretStore.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/secret/VaultSecretStore.java
@@ -1,11 +1,26 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.secret;
 
 import io.github.jopenlibs.vault.Vault;
 import io.github.jopenlibs.vault.VaultConfig;
 import java.util.Optional;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.checkerframework.checker.nullness.qual.NonNull;
 
 public final class VaultSecretStore implements SecretStore {
 

--- a/security/src/main/java/module-info.java
+++ b/security/src/main/java/module-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 module io.lonmstalker.tgkit.security {
   requires io.lonmstalker.tgkit.core;
   requires org.slf4j;

--- a/security/src/test/java/io/lonmstalker/tgkit/security/TestUtils.java
+++ b/security/src/test/java/io/lonmstalker/tgkit/security/TestUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security;
 
 import java.lang.reflect.Field;

--- a/security/src/test/java/io/lonmstalker/tgkit/security/antispam/AntiSpamInterceptorTest.java
+++ b/security/src/test/java/io/lonmstalker/tgkit/security/antispam/AntiSpamInterceptorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.antispam;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/security/src/test/java/io/lonmstalker/tgkit/security/audit/AuditBusTest.java
+++ b/security/src/test/java/io/lonmstalker/tgkit/security/audit/AuditBusTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.audit;
 
 import static org.assertj.core.api.Assertions.*;

--- a/security/src/test/java/io/lonmstalker/tgkit/security/captcha/MathCaptchaProviderServiceTest.java
+++ b/security/src/test/java/io/lonmstalker/tgkit/security/captcha/MathCaptchaProviderServiceTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.captcha;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/security/src/test/java/io/lonmstalker/tgkit/security/limiter/InMemoryTelegramSenderRateLimiterTest.java
+++ b/security/src/test/java/io/lonmstalker/tgkit/security/limiter/InMemoryTelegramSenderRateLimiterTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.limiter;
 
 import io.lonmstalker.tgkit.core.init.BotCoreInitializer;

--- a/security/src/test/java/io/lonmstalker/tgkit/security/limiter/TelegramSenderRateLimiterTest.java
+++ b/security/src/test/java/io/lonmstalker/tgkit/security/limiter/TelegramSenderRateLimiterTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.limiter;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/security/src/test/java/io/lonmstalker/tgkit/security/rbac/RoleSecurityTest.java
+++ b/security/src/test/java/io/lonmstalker/tgkit/security/rbac/RoleSecurityTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.rbac;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/security/src/test/java/io/lonmstalker/tgkit/security/rbac/SimpleUser.java
+++ b/security/src/test/java/io/lonmstalker/tgkit/security/rbac/SimpleUser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.security.rbac;
 
 import io.lonmstalker.tgkit.core.user.BotUserInfo;

--- a/testkit/src/main/java/io/lonmstalker/tgkit/testkit/BotTestExtension.java
+++ b/testkit/src/main/java/io/lonmstalker/tgkit/testkit/BotTestExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.testkit;
 
 import io.lonmstalker.tgkit.core.bot.BotAdapterImpl;

--- a/testkit/src/main/java/io/lonmstalker/tgkit/testkit/RecordedRequest.java
+++ b/testkit/src/main/java/io/lonmstalker/tgkit/testkit/RecordedRequest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.testkit;
 
 import java.util.List;

--- a/testkit/src/main/java/io/lonmstalker/tgkit/testkit/TelegramBotTest.java
+++ b/testkit/src/main/java/io/lonmstalker/tgkit/testkit/TelegramBotTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.testkit;
 
 import java.lang.annotation.ElementType;

--- a/testkit/src/main/java/io/lonmstalker/tgkit/testkit/TelegramMockServer.java
+++ b/testkit/src/main/java/io/lonmstalker/tgkit/testkit/TelegramMockServer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.testkit;
 
 import io.undertow.Undertow;

--- a/testkit/src/main/java/io/lonmstalker/tgkit/testkit/UpdateInjector.java
+++ b/testkit/src/main/java/io/lonmstalker/tgkit/testkit/UpdateInjector.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.testkit;
 
 import io.lonmstalker.tgkit.core.BotAdapter;

--- a/testkit/src/test/java/io/lonmstalker/tgkit/testkit/TelegramMockServerTest.java
+++ b/testkit/src/test/java/io/lonmstalker/tgkit/testkit/TelegramMockServerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.testkit;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/testkit/src/test/java/io/lonmstalker/tgkit/testkit/WelcomeFlowTest.java
+++ b/testkit/src/test/java/io/lonmstalker/tgkit/testkit/WelcomeFlowTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.testkit;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/validator/src/main/java/module-info.java
+++ b/validator/src/main/java/module-info.java
@@ -1,8 +1,22 @@
+/*
+ * Copyright (C) 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 module io.lonmstalker.tgkit.validator {
   requires io.lonmstalker.tgkit.api;
   requires telegrambots;
   requires telegrambots.meta;
-  requires static lombok;
   requires static org.checkerframework.checker.qual;
   requires language.detector;
   requires org.apache.tika.langdetect.optimaize;


### PR DESCRIPTION
## Summary
- add Apache 2.0 license header template
- enforce header via Spotless for all Java files
- apply headers across sources
- clean up module-info declarations

## Testing
- `mvn -q -pl testkit,core,observability,plugin,security,examples,api spotless:apply` *(passed)*
- `mvn -q -pl testkit,core,observability,plugin,security,examples,api spotless:check` *(passed)*
- `mvn -q -pl testkit,core,observability,plugin,security,examples,api verify` *(failed: compilation error)*

------
https://chatgpt.com/codex/tasks/task_e_68552602a4c0832599509e5a5a0bd5e6