### PR TITLE
Fix Checkstyle path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,7 +327,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${checkstyle-maven-plugin.version}</version>
                 <configuration>
-                    <configLocation>${project.parent.basedir}/config/checkstyle/google_checks.xml</configLocation>
+                    <configLocation>${maven.multiModuleProjectDirectory}/config/checkstyle/google_checks.xml</configLocation>
                     <consoleOutput>true</consoleOutput>
                     <failOnViolation>true</failOnViolation>
                 </configuration>


### PR DESCRIPTION
## Summary
- fix Checkstyle config location so build tools see the config

## Testing
- `mvn spotless:apply verify -q` *(fails: cannot initialize module SuppressWithNearbyTextFilter)*

------
https://chatgpt.com/codex/tasks/task_e_68552562d2e48325aa6ab527ec0c43da