### PR TITLE
Fix Checkstyle config path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,7 +336,7 @@
                     </dependency>
                 </dependencies>
                 <configuration>
-                    <configLocation>${session.executionRootDirectory}/config/checkstyle/google_checks.xml</configLocation>
+                    <configLocation>${maven.multiModuleProjectDirectory}/config/checkstyle/google_checks.xml</configLocation>
                     <consoleOutput>true</consoleOutput>
                     <failOnViolation>true</failOnViolation>
                 </configuration>


### PR DESCRIPTION
## Summary
- fix Checkstyle plugin config path to rely on `maven.multiModuleProjectDirectory`

## Testing
- `mvn -q spotless:apply verify` *(fails: Could not resolve net.ltgt.errorprone:errorprone-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68554484e5848325adc79f2611dd4122