### PR TITLE
Improve update queue handling

### DIFF
--- a/api/src/main/java/io/lonmstalker/tgkit/core/bot/BotConfig.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/bot/BotConfig.java
@@ -23,6 +23,9 @@ public class BotConfig extends DefaultBotOptions {
   private @NonNull List<BotInterceptor> globalInterceptors;
   private @Nullable BotExceptionHandler globalExceptionHandler;
   private int requestsPerSecond;
+  private int updateQueueCapacity;
+
+  public static final int DEFAULT_UPDATE_QUEUE_CAPACITY = 1000;
 
   @SuppressWarnings({"argument", "method.invocation"})
   private BotConfig(
@@ -43,13 +46,16 @@ public class BotConfig extends DefaultBotOptions {
       @Nullable Integer maxWebhookConnections,
       @Nullable List<String> allowedUpdates,
       @Nullable Integer getUpdatesTimeout,
-      @Nullable Integer getUpdatesLimit) {
+      @Nullable Integer getUpdatesLimit,
+      @Nullable Integer updateQueueCapacity) {
     this.store = store;
     this.globalExceptionHandler = globalExceptionHandler;
     this.globalInterceptors = globalInterceptors == null ? new ArrayList<>() : globalInterceptors;
     this.locale = locale != null ? locale : Locale.getDefault();
     this.botGroup = botGroup != null ? botGroup : "";
     this.requestsPerSecond = requestsPerSecond != null ? requestsPerSecond : 30;
+    this.updateQueueCapacity =
+        updateQueueCapacity != null ? updateQueueCapacity : DEFAULT_UPDATE_QUEUE_CAPACITY;
 
     this.setProxyHost(proxyHost);
     this.setAllowedUpdates(allowedUpdates);
@@ -113,6 +119,14 @@ public class BotConfig extends DefaultBotOptions {
     this.requestsPerSecond = requestsPerSecond;
   }
 
+  public int getUpdateQueueCapacity() {
+    return updateQueueCapacity;
+  }
+
+  public void setUpdateQueueCapacity(int updateQueueCapacity) {
+    this.updateQueueCapacity = updateQueueCapacity;
+  }
+
   public static Builder builder() {
     return new Builder();
   }
@@ -136,6 +150,7 @@ public class BotConfig extends DefaultBotOptions {
     private List<String> allowedUpdates;
     private Integer getUpdatesTimeout;
     private Integer getUpdatesLimit;
+    private Integer updateQueueCapacity;
 
     public Builder globalExceptionHandler(BotExceptionHandler handler) {
       this.globalExceptionHandler = handler;
@@ -232,6 +247,11 @@ public class BotConfig extends DefaultBotOptions {
       return this;
     }
 
+    public Builder updateQueueCapacity(Integer updateQueueCapacity) {
+      this.updateQueueCapacity = updateQueueCapacity;
+      return this;
+    }
+
     public BotConfig build() {
       return new BotConfig(
           globalExceptionHandler,
@@ -251,7 +271,8 @@ public class BotConfig extends DefaultBotOptions {
           maxWebhookConnections,
           allowedUpdates,
           getUpdatesTimeout,
-          getUpdatesLimit);
+          getUpdatesLimit,
+          updateQueueCapacity);
     }
   }
 }

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotFactory.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotFactory.java
@@ -10,6 +10,7 @@ import org.telegram.telegrambots.meta.api.methods.updates.SetWebhook;
 
 public final class BotFactory {
   private BotFactory() {}
+
   public static final BotFactory INSTANCE = new BotFactory();
   private final AtomicLong nextId = new AtomicLong();
 
@@ -18,7 +19,7 @@ public final class BotFactory {
     TelegramSender sender = new TelegramSender(config, token);
     var bot =
         implBuilder(token, config)
-            .session(new BotSessionImpl())
+            .session(new BotSessionImpl(null, null, config.getUpdateQueueCapacity()))
             .absSender(
                 new LongPollingReceiver(
                     config, adapter, token, sender, config.getGlobalExceptionHandler()))

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotImpl.java
@@ -12,10 +12,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.bots.DefaultAbsSender;
 import org.telegram.telegrambots.meta.api.methods.GetMe;
 import org.telegram.telegrambots.meta.api.methods.updates.SetWebhook;
@@ -119,6 +119,7 @@ public final class BotImpl implements Bot {
           onCompletedActionTimeoutMs);
     }
   }
+
   private final AtomicReference<BotState> state = new AtomicReference<>(BotState.NEW);
   private final @NonNull List<BotCompleteAction> completeActions = new CopyOnWriteArrayList<>();
   private long id;
@@ -279,7 +280,7 @@ public final class BotImpl implements Bot {
   private void initLongPolling(@NonNull LongPollingReceiver receiver) throws Exception {
     receiver.clearWebhook();
     if (this.session == null) {
-      this.session = new BotSessionImpl();
+      this.session = new BotSessionImpl(null, null, config.getUpdateQueueCapacity());
     }
     this.session.setOptions(config);
     this.session.setToken(token);

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotSessionImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotSessionImpl.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.lonmstalker.tgkit.core.config.BotGlobalConfig;
 import io.lonmstalker.tgkit.core.exception.BotApiException;
+import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.ProxySelector;
 import java.net.URI;
@@ -18,9 +19,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.telegram.telegrambots.bots.DefaultBotOptions;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.generics.BotOptions;
@@ -66,9 +67,11 @@ import org.telegram.telegrambots.meta.generics.LongPollingBot;
 @SuppressWarnings({"dereference.of.nullable", "argument"})
 public class BotSessionImpl implements BotSession {
   private static final Logger log = LoggerFactory.getLogger(BotSessionImpl.class);
+  private static final long ENQUEUE_TIMEOUT_MS = 100L;
 
   private final AtomicBoolean running = new AtomicBoolean();
-  private final BlockingQueue<Update> updates = new LinkedBlockingQueue<>();
+  private final BlockingQueue<Update> updates;
+  private final int queueCapacity;
 
   private final ObjectMapper mapper;
   private final @Nullable ExecutorService providedExecutor;
@@ -82,12 +85,42 @@ public class BotSessionImpl implements BotSession {
   private int lastUpdateId;
 
   public BotSessionImpl() {
-    this(null, null);
+    this(null, null, BotConfig.DEFAULT_UPDATE_QUEUE_CAPACITY);
   }
 
   public BotSessionImpl(@Nullable ExecutorService executor, @Nullable ObjectMapper mapper) {
+    this(executor, mapper, BotConfig.DEFAULT_UPDATE_QUEUE_CAPACITY);
+  }
+
+  public BotSessionImpl(
+      @Nullable ExecutorService executor, @Nullable ObjectMapper mapper, int queueCapacity) {
     this.providedExecutor = executor;
     this.mapper = mapper != null ? mapper : new ObjectMapper();
+    this.queueCapacity = queueCapacity;
+    this.updates = new LinkedBlockingQueue<>(queueCapacity);
+  }
+
+  /**
+   * Добавляет обновление в очередь, ожидая освободившееся место не дольше {@code
+   * ENQUEUE_TIMEOUT_MS} миллисекунд.
+   *
+   * @param update обновление Telegram
+   * @return {@code true}, если событие помещено в очередь, иначе {@code false}
+   */
+  boolean enqueueUpdate(Update update) {
+    try {
+      if (updates.offer(update, ENQUEUE_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+        return true;
+      }
+      log.warn(
+          "updates queue full ({}), unable to enqueue after {}ms",
+          queueCapacity,
+          ENQUEUE_TIMEOUT_MS);
+      return false;
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      return false;
+    }
   }
 
   @Override
@@ -205,17 +238,17 @@ public class BotSessionImpl implements BotSession {
             .GET()
             .build();
     Objects.requireNonNull(httpClient)
-        .sendAsync(request, HttpResponse.BodyHandlers.ofString())
+        .sendAsync(request, HttpResponse.BodyHandlers.ofInputStream())
         .thenApply(HttpResponse::body)
         .thenAccept(
-            body -> {
-              try {
-                GetUpdatesResponse response = mapper.readValue(body, GetUpdatesResponse.class);
+            stream -> {
+              try (InputStream input = stream) {
+                GetUpdatesResponse response = mapper.readValue(input, GetUpdatesResponse.class);
                 if (response.result != null && !response.result.isEmpty()) {
                   for (Update update : response.result) {
                     if (update.getUpdateId() > lastUpdateId) {
                       lastUpdateId = update.getUpdateId();
-                      updates.put(update);
+                      enqueueUpdate(update);
                     }
                   }
                 }

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotSessionImplTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotSessionImplTest.java
@@ -7,6 +7,7 @@ import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.telegram.telegrambots.bots.DefaultBotOptions;
@@ -23,7 +24,8 @@ public class BotSessionImplTest {
   @Test
   void startAndStop() {
     NoopExecutor executor = new NoopExecutor();
-    BotSessionImpl session = new BotSessionImpl(executor, new ObjectMapper());
+    BotSessionImpl session =
+        new BotSessionImpl(executor, new ObjectMapper(), BotConfig.DEFAULT_UPDATE_QUEUE_CAPACITY);
     DefaultBotOptions options = new DefaultBotOptions();
     session.setOptions(options);
     session.setToken("TOKEN");
@@ -42,6 +44,30 @@ public class BotSessionImplTest {
     long backOff = session.handleError(new IOException("fail"), 1);
     assertEquals(2, backOff);
     assertEquals(30, session.handleError(new IOException("fail"), 32));
+  }
+
+  @Test
+  void rejectOnOverflow() throws Exception {
+    BotSessionImpl session = new BotSessionImpl(null, new ObjectMapper(), 2);
+    var field = BotSessionImpl.class.getDeclaredField("updates");
+    field.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    var queue = (BlockingQueue<Update>) field.get(session);
+    Update u1 = new Update();
+    u1.setUpdateId(1);
+    Update u2 = new Update();
+    u2.setUpdateId(2);
+    Update u3 = new Update();
+    u3.setUpdateId(3);
+
+    assertTrue(session.enqueueUpdate(u1));
+    assertTrue(session.enqueueUpdate(u2));
+    assertFalse(session.enqueueUpdate(u3));
+
+    assertEquals(2, queue.size());
+    assertTrue(queue.contains(u1));
+    assertTrue(queue.contains(u2));
+    assertFalse(queue.contains(u3));
   }
 
   private static class DummyBot implements LongPollingBot {


### PR DESCRIPTION
## Summary
- make update queue bounded and wait with timeout
- parse updates from HTTP InputStream for efficiency

## Testing
- `mvn -q verify -pl core -am` *(fails: maven-checkstyle-plugin can't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6855260860248325b36f99e58d193b77