### PR TITLE
Add RedisStateStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,9 @@ TelegramBot.run(Path.of("bot.yaml"));
 
 ### 2 — Работа с StateStore
 ```java
+JedisPool pool = new JedisPool("localhost", 6379);
 BotConfig cfg = BotConfig.builder()
-        .store(new InMemoryStateStore())    // можно RedisStateStore, JdbcStateStore…
+        .store(new RedisStateStore(pool))    // можно InMemoryStateStore, JdbcStateStore…
         .build();
 
 TelegramBot.run(Path.of("bot.yaml"));
@@ -122,9 +123,9 @@ public void quiz(BotRequest<Message> req) {
     var store = req.botInfo().store();
     long chat = req.user().chatId();
 
-    String step = store.get(chat, "step");            // чтение
+    String step = store.get(String.valueOf(chat));     // чтение
     // … бизнес-логика …
-    store.set(chat, "step", "NEXT");                  // запись
+    store.set(String.valueOf(chat), "NEXT");           // запись
 }
 ```
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -48,6 +48,10 @@
             <artifactId>reflections</artifactId>
         </dependency>
         <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>

--- a/core/src/main/java/io/lonmstalker/tgkit/core/state/RedisStateStore.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/state/RedisStateStore.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lonmstalker.tgkit.core.state;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+/**
+ * Redis-based implementation of {@link StateStore}.
+ *
+ * <p>Uses simple GET/SET operations. Example usage:
+ *
+ * <pre>{@code
+ * JedisPool pool = new JedisPool("localhost", 6379);
+ * StateStore store = new RedisStateStore(pool);
+ * }</pre>
+ */
+public class RedisStateStore implements StateStore {
+
+  private final JedisPool pool;
+
+  public RedisStateStore(@NonNull JedisPool pool) {
+    this.pool = pool;
+  }
+
+  @Override
+  public @Nullable String get(@NonNull String chatId) {
+    try (Jedis jedis = pool.getResource()) {
+      return jedis.get(chatId);
+    }
+  }
+
+  @Override
+  public void set(@NonNull String chatId, @NonNull String value) {
+    try (Jedis jedis = pool.getResource()) {
+      jedis.set(chatId, value);
+    }
+  }
+}

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -10,6 +10,7 @@ module io.lonmstalker.tgkit.core {
   requires com.fasterxml.jackson.dataformat.yaml;
   requires com.h2database;
   requires org.reflections;
+  requires jedis;
   requires io.netty.transport;
 
   exports io.lonmstalker.tgkit.core.bot;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/state/RedisStateStoreTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/state/RedisStateStoreTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lonmstalker.tgkit.core.state;
+
+import static org.mockito.Mockito.*;
+
+import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+class RedisStateStoreTest implements WithAssertions {
+  static {
+    BotCoreInitializer.init();
+  }
+
+  private JedisPool pool;
+  private Jedis jedis;
+  private RedisStateStore store;
+
+  @BeforeEach
+  void init() {
+    pool = mock(JedisPool.class);
+    jedis = mock(Jedis.class);
+    when(pool.getResource()).thenReturn(jedis);
+    store = new RedisStateStore(pool);
+  }
+
+  @Test
+  void get_reads_value_from_redis() {
+    when(jedis.get("42")).thenReturn("STEP");
+
+    assertThat(store.get("42")).isEqualTo("STEP");
+    verify(jedis).close();
+  }
+
+  @Test
+  void set_writes_value_to_redis() {
+    store.set("77", "NEXT");
+
+    verify(jedis).set("77", "NEXT");
+    verify(jedis).close();
+  }
+}


### PR DESCRIPTION
## Summary
- implement `RedisStateStore` using JedisPool
- expose jedis module in core
- document Redis-based store
- add unit tests for RedisStateStore

## Testing
- `mvn -q -pl :core spotless:apply` *(fails: could not download errorprone plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68554c1fdc80832597b4465bce725093