### PR TITLE
Add centralized webhook server

### DIFF
--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -5,7 +5,6 @@ module io.lonmstalker.tgkit.api {
   requires transitive java.net.http;
   requires transitive org.apache.httpcomponents.httpclient;
   requires transitive org.apache.httpcomponents.httpcore;
-  requires static lombok;
   requires static com.fasterxml.jackson.annotation;
   requires static org.checkerframework.checker.qual;
 

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotBuilder.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotBuilder.java
@@ -29,7 +29,6 @@ public final class BotBuilder {
     private final List<Supplier<BotPlugin>> plugins = new ArrayList<>();
     private String token;
     private boolean polling = true;
-    private int webhookPort = -1;
     private boolean started;
 
     @CheckReturnValue
@@ -41,14 +40,12 @@ public final class BotBuilder {
     @CheckReturnValue
     public @NonNull BotBuilderImpl withPolling() {
       this.polling = true;
-      this.webhookPort = -1;
       return this;
     }
 
     @CheckReturnValue
-    public @NonNull BotBuilderImpl withWebhook(int port) {
+    public @NonNull BotBuilderImpl withWebhook() {
       this.polling = false;
-      this.webhookPort = port;
       return this;
     }
 
@@ -79,7 +76,6 @@ public final class BotBuilder {
         bot = BotFactory.INSTANCE.from(token, config, adapter);
       } else {
         SetWebhook hook = new SetWebhook();
-        hook.setUrl("http://localhost:" + webhookPort);
         bot = BotFactory.INSTANCE.from(token, config, adapter, hook);
       }
 

--- a/core/src/main/java/io/lonmstalker/tgkit/core/init/BotCoreInitializer.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/init/BotCoreInitializer.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 public final class BotCoreInitializer {
 
   private static final Logger log = LoggerFactory.getLogger(BotCoreInitializer.class);
+
   private BotCoreInitializer() {}
 
   private static volatile boolean started;
@@ -57,6 +58,9 @@ public final class BotCoreInitializer {
 
     // ── Events ────────────────────────────────────────────────────────
     BotGlobalConfig.INSTANCE.events().bus(new InMemoryEventBus());
+
+    // ── Webhook server ─────────────────────────────────────────────────────-
+    BotGlobalConfig.INSTANCE.webhook().start();
 
     log.info("[core-init] Ядро TGKIT успешно инициализировано ✅");
     started = true;

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -4,7 +4,6 @@ module io.lonmstalker.tgkit.core {
   requires org.apache.commons.lang3;
   requires telegrambots;
   requires telegrambots.meta;
-  requires static lombok;
   requires static org.checkerframework.checker.qual;
   requires static com.fasterxml.jackson.annotation;
   requires transitive com.fasterxml.jackson.databind;

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <module>examples</module>
         <module>api</module>
         <module>testkit</module>
+        <module>webhook</module>
         <module>validator</module>
     </modules>
 
@@ -45,6 +46,8 @@
         <undertow.version>2.3.9.Final</undertow.version>
         <vault.version>6.2.0</vault.version>
         <tika.version>3.2.0</tika.version>
+        <jetty.version>12.0.22</jetty.version>
+        <jakarta.servlet.version>6.0.0</jakarta.servlet.version>
         <guava.version>33.4.8-jre</guava.version>
         <language.detector.version>0.6</language.detector.version>
 
@@ -157,6 +160,22 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport</artifactId>
                 <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-server</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-servlet</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>${jakarta.servlet.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>io.undertow</groupId>

--- a/validator/src/main/java/module-info.java
+++ b/validator/src/main/java/module-info.java
@@ -2,7 +2,6 @@ module io.lonmstalker.tgkit.validator {
   requires io.lonmstalker.tgkit.api;
   requires telegrambots;
   requires telegrambots.meta;
-  requires static lombok;
   requires static org.checkerframework.checker.qual;
   requires language.detector;
   requires org.apache.tika.langdetect.optimaize;

--- a/webhook/pom.xml
+++ b/webhook/pom.xml
@@ -1,0 +1,69 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.lonmstalker.tgkit</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>webhook</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.lonmstalker.tgkit</groupId>
+            <artifactId>core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>${jakarta.servlet.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+
+        <!-- TEST -->
+        <dependency>
+            <groupId>io.lonmstalker.tgkit</groupId>
+            <artifactId>testkit</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/webhook/src/main/java/io/lonmstalker/tgkit/webhook/WebhookServer.java
+++ b/webhook/src/main/java/io/lonmstalker/tgkit/webhook/WebhookServer.java
@@ -1,0 +1,315 @@
+package io.lonmstalker.tgkit.webhook;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.lonmstalker.tgkit.core.bot.WebHookReceiver;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.LastHttpContent;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.FilterHolder;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+/**
+ * Минималистичный HTTP-сервер для Telegram WebHook.
+ *
+ * <p>Поддерживает Jetty и Netty. Сервер проверяет секретный токен и добавляет заголовок HSTS во все
+ * ответы.
+ *
+ * <p>Пример инициализации и регистрации бота:
+ *
+ * <pre>{@code
+ * BotGlobalConfig.INSTANCE.webhook()
+ *     .port(8080)
+ *     .secret("SECRET")
+ *     .engine(WebhookServer.Engine.JETTY);
+ * BotCoreInitializer.init();
+ * Bot bot = BotFactory.INSTANCE.from("TOKEN", config, adapter, new SetWebhook());
+ * }</pre>
+ */
+public final class WebhookServer implements AutoCloseable {
+  private static final Logger log = LoggerFactory.getLogger(WebhookServer.class);
+  private static final String SECRET_HEADER = "X-Telegram-Bot-Api-Secret-Token";
+  private static final String HSTS_VALUE = "max-age=31536000; includeSubDomains";
+
+  /** Варианты реализации HTTP-сервера. */
+  public enum Engine {
+    JETTY,
+    NETTY
+  }
+
+  private final ServerEngine engine;
+  private final ObjectMapper mapper = new ObjectMapper();
+  private final String secret;
+
+  public WebhookServer(int port, @NonNull String secretToken, @NonNull Engine engine) {
+    this.secret = secretToken;
+    this.engine = engine == Engine.JETTY ? new JettyEngine(port) : new NettyEngine(port);
+  }
+
+  /** Запуск сервера. */
+  public void start() throws Exception {
+    engine.start();
+    log.info("Webhook server started on port {}", port());
+  }
+
+  /**
+   * Регистрирует нового получателя обновлений.
+   *
+   * @param receiver бот-получатель
+   */
+  public void register(@NonNull WebHookReceiver receiver) {
+    engine.register(receiver);
+  }
+
+  /**
+   * @return фактический порт сервера.
+   */
+  public int port() {
+    return engine.port();
+  }
+
+  @Override
+  public void close() throws Exception {
+    engine.close();
+  }
+
+  private static class HstsFilter implements Filter {
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+        throws IOException, ServletException {
+      if (response instanceof HttpServletResponse resp) {
+        resp.setHeader("Strict-Transport-Security", HSTS_VALUE);
+      }
+      chain.doFilter(request, response);
+    }
+  }
+
+  private interface ServerEngine extends AutoCloseable {
+    void start() throws Exception;
+
+    void register(@NonNull WebHookReceiver receiver);
+
+    int port();
+  }
+
+  private final class JettyEngine implements ServerEngine {
+    private final Server server;
+    private final Map<String, WebHookReceiver> receivers = new ConcurrentHashMap<>();
+
+    JettyEngine(int port) {
+      this.server = new Server(new InetSocketAddress("localhost", port));
+      ServletContextHandler context = new ServletContextHandler();
+      context.addServlet(new ServletHolder(new UpdateServlet()), "/*");
+      context.addFilter(
+          new FilterHolder(new HstsFilter()), "/*", EnumSet.of(DispatcherType.REQUEST));
+      server.setHandler(context);
+    }
+
+    @Override
+    public void start() throws Exception {
+      server.start();
+    }
+
+    @Override
+    public void register(@NonNull WebHookReceiver receiver) {
+      receivers.put("/" + receiver.getBotPath(), receiver);
+    }
+
+    @Override
+    public int port() {
+      return ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+    }
+
+    @Override
+    public void close() throws Exception {
+      server.stop();
+    }
+
+    private class UpdateServlet extends HttpServlet {
+      @Override
+      protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        String header = req.getHeader(SECRET_HEADER);
+        if (!secret.equals(header)) {
+          resp.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+          return;
+        }
+        WebHookReceiver receiver = receivers.get(req.getRequestURI());
+        if (receiver == null) {
+          resp.setStatus(HttpServletResponse.SC_NOT_FOUND);
+          return;
+        }
+        Update update;
+        try {
+          update = mapper.readValue(req.getInputStream(), Update.class);
+        } catch (IOException e) {
+          resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+          return;
+        }
+        try {
+          BotApiMethod<?> method = receiver.onWebhookUpdateReceived(update);
+          if (method != null) {
+            receiver.execute(method);
+          }
+        } catch (Exception e) {
+          log.error("Webhook handling failed", e);
+          resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+          return;
+        }
+        resp.setStatus(HttpServletResponse.SC_OK);
+      }
+    }
+  }
+
+  private final class NettyEngine implements ServerEngine {
+    private final EventLoopGroup boss = new NioEventLoopGroup(1);
+    private final EventLoopGroup worker = new NioEventLoopGroup();
+    private final int port;
+    private Channel serverChannel;
+    private final Map<String, WebHookReceiver> receivers = new ConcurrentHashMap<>();
+
+    NettyEngine(int port) {
+      this.port = port;
+    }
+
+    @Override
+    public void start() throws InterruptedException {
+      ServerBootstrap b =
+          new ServerBootstrap()
+              .group(boss, worker)
+              .channel(NioServerSocketChannel.class)
+              .childHandler(
+                  new ChannelInitializer<SocketChannel>() {
+                    @Override
+                    protected void initChannel(SocketChannel ch) {
+                      ch.pipeline().addLast(new HttpServerCodec());
+                      ch.pipeline().addLast(new NettyHandler());
+                    }
+                  })
+              .childOption(ChannelOption.SO_KEEPALIVE, true);
+      ChannelFuture f = b.bind(new InetSocketAddress("localhost", port)).sync();
+      serverChannel = f.channel();
+    }
+
+    @Override
+    public void register(@NonNull WebHookReceiver receiver) {
+      receivers.put("/" + receiver.getBotPath(), receiver);
+    }
+
+    @Override
+    public int port() {
+      return ((InetSocketAddress) serverChannel.localAddress()).getPort();
+    }
+
+    @Override
+    public void close() {
+      if (serverChannel != null) {
+        serverChannel.close();
+      }
+      boss.shutdownGracefully();
+      worker.shutdownGracefully();
+    }
+
+    private final class NettyHandler extends SimpleChannelInboundHandler<HttpObject> {
+      private HttpRequest request;
+      private final ByteBuf body = Unpooled.buffer();
+
+      @Override
+      protected void channelRead0(ChannelHandlerContext ctx, HttpObject msg) throws Exception {
+        if (msg instanceof HttpRequest httpRequest) {
+          this.request = httpRequest;
+        }
+        if (msg instanceof HttpContent content) {
+          body.writeBytes(content.content());
+          if (content instanceof LastHttpContent) {
+            handle(ctx);
+          }
+        }
+      }
+
+      private void handle(ChannelHandlerContext ctx) throws IOException {
+        HttpHeaders headers = request.headers();
+        if (!HttpMethod.POST.equals(request.method())
+            || !secret.equals(headers.get(SECRET_HEADER))) {
+          send(ctx, HttpResponseStatus.UNAUTHORIZED);
+          return;
+        }
+        URI uri = URI.create(request.uri());
+        WebHookReceiver receiver = receivers.get(uri.getPath());
+        if (receiver == null) {
+          send(ctx, HttpResponseStatus.NOT_FOUND);
+          return;
+        }
+        Update update;
+        try {
+          update = mapper.readValue(new ByteBufInputStream(body, true), Update.class);
+        } catch (IOException e) {
+          send(ctx, HttpResponseStatus.BAD_REQUEST);
+          return;
+        }
+        try {
+          BotApiMethod<?> method = receiver.onWebhookUpdateReceived(update);
+          if (method != null) {
+            receiver.execute(method);
+          }
+        } catch (Exception e) {
+          log.error("Webhook handling failed", e);
+          send(ctx, HttpResponseStatus.INTERNAL_SERVER_ERROR);
+          return;
+        }
+        send(ctx, HttpResponseStatus.OK);
+      }
+
+      private void send(ChannelHandlerContext ctx, HttpResponseStatus status) {
+        DefaultFullHttpResponse resp =
+            new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, status, Unpooled.EMPTY_BUFFER);
+        resp.headers().set(HttpHeaderNames.CONTENT_LENGTH, 0);
+        resp.headers().set("Strict-Transport-Security", HSTS_VALUE);
+        ctx.writeAndFlush(resp).addListener(f -> ctx.close());
+      }
+    }
+  }
+}

--- a/webhook/src/test/java/io/lonmstalker/tgkit/webhook/WebhookServerTest.java
+++ b/webhook/src/test/java/io/lonmstalker/tgkit/webhook/WebhookServerTest.java
@@ -1,0 +1,144 @@
+package io.lonmstalker.tgkit.webhook;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.lonmstalker.tgkit.core.BotCommand;
+import io.lonmstalker.tgkit.core.BotRequest;
+import io.lonmstalker.tgkit.core.BotRequestType;
+import io.lonmstalker.tgkit.core.BotResponse;
+import io.lonmstalker.tgkit.core.bot.Bot;
+import io.lonmstalker.tgkit.core.bot.BotAdapterImpl;
+import io.lonmstalker.tgkit.core.bot.BotConfig;
+import io.lonmstalker.tgkit.core.bot.BotFactory;
+import io.lonmstalker.tgkit.core.config.BotGlobalConfig;
+import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
+import io.lonmstalker.tgkit.core.matching.CommandMatch;
+import io.lonmstalker.tgkit.testkit.RecordedRequest;
+import io.lonmstalker.tgkit.testkit.TelegramMockServer;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.concurrent.TimeUnit;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Chat;
+import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.User;
+
+/** Tests for {@link WebhookServer}. */
+class WebhookServerTest {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Test
+  void dispatchesUpdateToBotAndAddsHsts() throws Exception {
+    BotGlobalConfig.INSTANCE.webhook().engine(WebhookServer.Engine.JETTY).port(0).secret("SECRET");
+    BotCoreInitializer.init();
+    WebhookServer server = BotGlobalConfig.INSTANCE.webhook().server();
+    try (TelegramMockServer tgServer = new TelegramMockServer()) {
+      tgServer.enqueue("{\"ok\":true,\"result\":{\"id\":1,\"is_bot\":true,\"username\":\"bot\"}}");
+      BotConfig config = BotConfig.builder().baseUrl(tgServer.baseUrl()).build();
+      BotAdapterImpl adapter =
+          BotAdapterImpl.builder()
+              .internalId(1L)
+              .sender(new io.lonmstalker.tgkit.core.bot.TelegramSender(config, "TOKEN"))
+              .config(config)
+              .build();
+      adapter.registry().add(new PingCommand());
+      var hook = new org.telegram.telegrambots.meta.api.methods.updates.SetWebhook();
+      Bot bot = BotFactory.INSTANCE.from("TOKEN", config, adapter, hook);
+      hook.setUrl("http://localhost:" + server.port() + "/TOKEN");
+      hook.setSecretToken("SECRET");
+      bot.start();
+      tgServer.takeRequest(1, TimeUnit.SECONDS); // getMe
+
+      Update update = new Update();
+      Message msg = new Message();
+      msg.setText("/ping");
+      Chat chat = new Chat();
+      chat.setId(42L);
+      msg.setChat(chat);
+      User user = new User();
+      user.setId(42L);
+      msg.setFrom(user);
+      update.setMessage(msg);
+      update.setUpdateId(1);
+
+      String body = MAPPER.writeValueAsString(update);
+      HttpClient client = HttpClient.newHttpClient();
+      HttpRequest req =
+          HttpRequest.newBuilder()
+              .uri(URI.create("http://localhost:" + server.port() + "/TOKEN"))
+              .header("Content-Type", "application/json")
+              .header("X-Telegram-Bot-Api-Secret-Token", "SECRET")
+              .POST(HttpRequest.BodyPublishers.ofString(body))
+              .build();
+      HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+      assertThat(resp.statusCode()).isEqualTo(200);
+      assertThat(resp.headers().firstValue("Strict-Transport-Security"))
+          .hasValueSatisfying(h -> assertThat(h).contains("max-age"));
+
+      RecordedRequest r = tgServer.takeRequest(1, TimeUnit.SECONDS);
+      assertThat(r).isNotNull();
+      assertThat(r.path()).endsWith("/sendMessage");
+      bot.stop();
+    }
+  }
+
+  @Test
+  void rejectsRequestWithWrongToken() throws Exception {
+    BotGlobalConfig.INSTANCE.webhook().engine(WebhookServer.Engine.JETTY).port(0).secret("SECRET");
+    BotCoreInitializer.init();
+    WebhookServer server = BotGlobalConfig.INSTANCE.webhook().server();
+    try (TelegramMockServer tgServer = new TelegramMockServer()) {
+      tgServer.enqueue("{\"ok\":true,\"result\":{\"id\":1,\"is_bot\":true,\"username\":\"bot\"}}");
+      BotConfig config = BotConfig.builder().baseUrl(tgServer.baseUrl()).build();
+      BotAdapterImpl adapter =
+          BotAdapterImpl.builder()
+              .internalId(1L)
+              .sender(new io.lonmstalker.tgkit.core.bot.TelegramSender(config, "TOKEN"))
+              .config(config)
+              .build();
+      var hook = new org.telegram.telegrambots.meta.api.methods.updates.SetWebhook();
+      Bot bot = BotFactory.INSTANCE.from("TOKEN", config, adapter, hook);
+      hook.setUrl("http://localhost:" + server.port() + "/TOKEN");
+      hook.setSecretToken("SECRET");
+      bot.start();
+      tgServer.takeRequest(1, TimeUnit.SECONDS); // getMe
+
+      HttpClient client = HttpClient.newHttpClient();
+      HttpRequest req =
+          HttpRequest.newBuilder()
+              .uri(URI.create("http://localhost:" + server.port() + "/TOKEN"))
+              .header("X-Telegram-Bot-Api-Secret-Token", "WRONG")
+              .POST(HttpRequest.BodyPublishers.ofString("{}"))
+              .build();
+      HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+      assertThat(resp.statusCode()).isEqualTo(401);
+      RecordedRequest r = tgServer.takeRequest(1, TimeUnit.SECONDS);
+      assertThat(r).isNull();
+      bot.stop();
+    }
+  }
+
+  private static class PingCommand implements BotCommand<Message> {
+    @Override
+    public BotResponse handle(@NonNull BotRequest<Message> request) {
+      SendMessage msg = new SendMessage(request.msg().getChatId().toString(), "pong");
+      return BotResponse.builder().method(msg).build();
+    }
+
+    @Override
+    public @NonNull BotRequestType type() {
+      return BotRequestType.MESSAGE;
+    }
+
+    @Override
+    public @NonNull CommandMatch<Message> matcher() {
+      return m -> "/ping".equals(m.getText());
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create `WebhookGlobalConfig` for shared webhook server
- start webhook server during core initialization
- register webhook bots via `BotFactory` and update hook URLs
- refactor server to handle multiple bots and provide Jetty/Netty engines
- update tests for new global webhook setup

## Testing
- `mvn -q spotless:apply -pl api,core,webhook` *(passes)*
- `mvn -q -pl webhook -Dcheckstyle.skip=true -Drevapi.skip=true -Djacoco.skip=true test` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68552622ae3083258d659a51377d4dec