### PR TITLE
Add local OWASP scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,14 @@ export MAVEN_OPTS="-Dhttps.proxyHost=proxy -Dhttps.proxyPort=8080 \
 ```
 Результат ищите в `target/site/jacoco/index.html`.
 
+Для локального сканирования зависимостей на уязвимости:
+
+```bash
+./mvnw verify
+```
+Отчёты появятся в `target/dependency-check-report.html` и
+`target/dependency-check-report.sarif`.
+
 ## 🤝 Contributing
 PR-ы и идеи приветствуются! Перед отправкой ознакомьтесь с [CONTRIBUTING.md](CONTRIBUTING.md) и [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <revapi.version>0.28.2</revapi.version>
         <revapi-maven-plugin.version>0.15.1</revapi-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
+        <dependency-check-maven-plugin.version>12.1.3</dependency-check-maven-plugin.version>
         <errorprone-maven-plugin.version>2.29.1</errorprone-maven-plugin.version>
 
         <!-- TEST -->
@@ -411,6 +412,23 @@
                 <executions>
                     <execution>
                         <id>check-api</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>${dependency-check-maven-plugin.version}</version>
+                <configuration>
+                    <formats>HTML,SARIF</formats>
+                    <failBuildOnCVSS>7</failBuildOnCVSS>
+                </configuration>
+                <executions>
+                    <execution>
                         <phase>verify</phase>
                         <goals>
                             <goal>check</goal>


### PR DESCRIPTION
## Summary
- enable OWASP Dependency Check plugin to run during `verify`
- generate HTML and SARIF reports with fail threshold 7
- document how to run the scan via `mvn verify`

## Testing
- `mvn -q spotless:apply`
- `mvn -q verify` *(fails: Plugin net.ltgt.errorprone:errorprone-maven-plugin:2.29.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68555041d47c8325a48ae9cf5dfad5be