### PR TITLE
Add missing license headers

### DIFF
--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 module io.lonmstalker.tgkit.api {
   requires transitive telegrambots;
   requires transitive telegrambots.meta;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/TelegramBot.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/TelegramBot.java
@@ -1,11 +1,26 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core;
 
 import io.lonmstalker.tgkit.core.bot.Bot;
 import io.lonmstalker.tgkit.core.bot.BotAdapter;
 import io.lonmstalker.tgkit.core.bot.BotAdapterImpl;
-import io.lonmstalker.tgkit.core.bot.TelegramSender;
 import io.lonmstalker.tgkit.core.bot.BotConfig;
 import io.lonmstalker.tgkit.core.bot.BotFactory;
+import io.lonmstalker.tgkit.core.bot.TelegramSender;
 import io.lonmstalker.tgkit.core.config.BotConfigLoader;
 import io.lonmstalker.tgkit.core.config.BotConfigLoader.Settings;
 import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
@@ -13,9 +28,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-/**
- * Вспомогательный класс для запуска бота по конфигурационному файлу.
- */
+/** Вспомогательный класс для запуска бота по конфигурационному файлу. */
 public final class TelegramBot {
 
   private TelegramBot() {}

--- a/core/src/main/java/io/lonmstalker/tgkit/core/config/BotConfigLoader.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/config/BotConfigLoader.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.config;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
@@ -12,9 +27,7 @@ import java.nio.file.Path;
 import java.util.List;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-/**
- * Утилита для чтения конфигурации бота из YAML или JSON.
- */
+/** Утилита для чтения конфигурации бота из YAML или JSON. */
 public final class BotConfigLoader {
 
   private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 module io.lonmstalker.tgkit.core {
   requires io.lonmstalker.tgkit.api;
   requires org.slf4j;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/config/BotConfigLoaderTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/config/BotConfigLoaderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.config;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/config/TelegramBotRunTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/config/TelegramBotRunTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.lonmstalker.tgkit.core.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,7 +41,9 @@ class TelegramBotRunTest {
       Path f = tmp.resolve("bot.yaml");
       String yaml =
           "token: T\n"
-              + "base-url: " + server.baseUrl() + "\n"
+              + "base-url: "
+              + server.baseUrl()
+              + "\n"
               + "bot-group: g\n"
               + "requests-per-second: 20\n"
               + "packages:\n  - io.test\n";

--- a/observability/src/main/java/module-info.java
+++ b/observability/src/main/java/module-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 module io.lonmstalker.tgkit.observability {
   requires io.lonmstalker.tgkit.core;
   requires io.micrometer.core;

--- a/plugin/src/main/java/module-info.java
+++ b/plugin/src/main/java/module-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 module io.lonmstalker.tgkit.plugin {
   requires io.lonmstalker.tgkit.core;
   requires io.lonmstalker.tgkit.observability;

--- a/security/src/main/java/module-info.java
+++ b/security/src/main/java/module-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 module io.lonmstalker.tgkit.security {
   requires io.lonmstalker.tgkit.core;
   requires org.slf4j;

--- a/validator/src/main/java/module-info.java
+++ b/validator/src/main/java/module-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 module io.lonmstalker.tgkit.validator {
   requires io.lonmstalker.tgkit.api;
   requires telegrambots;


### PR DESCRIPTION
## Summary
- add TgKit license header to `BotConfigLoader`
- add TgKit license header to `TelegramBot`
- add license header to all `module-info.java`
- format code via Spotless

## Testing
- `mvn spotless:apply`
- `mvn verify` *(fails: Plugin net.ltgt.errorprone:errorprone-maven-plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_685550464f00832597ea03dc0751a328