### PR TITLE
Add README for api module

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,17 @@
+# tgkit-api
+
+В модуле `api` собраны интерфейсы и базовые DTO, необходимые другим частям библиотеки.
+Он не содержит реализаций и может использоваться для описания контрактов при разработке
+своих компонентов поверх tgkit.
+
+## Подключение
+
+```xml
+<dependency>
+  <groupId>io.lonmstalker.tgkit</groupId>
+  <artifactId>api</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+</dependency>
+```
+
+Более подробная документация расположена в [README](../README.md).


### PR DESCRIPTION
## Summary
- document purpose of `api` module
- show Maven dependency snippet
- link to repo's main documentation

## Testing
- `mvn -q spotless:apply verify` *(fails: Could not find artifact net.ltgt.errorprone:errorprone-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6855504e19e8832580c7134bd9602ae9