### PR TITLE
Support Vault address override via env

### DIFF
--- a/security/README.md
+++ b/security/README.md
@@ -51,3 +51,16 @@ SecurityGlobalConfig.INSTANCE
         .audit(a -> a.bus(KafkaAuditBus.create("sec-events")));
 
 ```
+
+### SecretStore с HashiCorp Vault
+
+```bash
+export VAULT_TOKEN=***
+# переопределить URL Vault
+export VAULT_ADDR=https://vault.example.com:8200
+```
+
+```java
+SecretStore secrets = new VaultSecretStore();
+secrets.get("bot-token");
+```

--- a/security/src/main/java/io/lonmstalker/tgkit/security/secret/VaultSecretStore.java
+++ b/security/src/main/java/io/lonmstalker/tgkit/security/secret/VaultSecretStore.java
@@ -29,10 +29,11 @@ public final class VaultSecretStore implements SecretStore {
   private transient Vault vault;
 
   public VaultSecretStore() {
-    this(
-        new VaultConfig()
-            .token(System.getenv("VAULT_TOKEN"))
-            .address(System.getenv().getOrDefault("VAULT_ADDR", "http://localhost:8200")));
+    String addr = System.getenv("VAULT_ADDR");
+    if (addr == null) {
+      addr = "https://localhost:8200";
+    }
+    this(new VaultConfig().token(System.getenv("VAULT_TOKEN")).address(addr));
   }
 
   public VaultSecretStore(@NonNull VaultConfig config) {

--- a/security/src/test/java/io/lonmstalker/tgkit/security/TestUtils.java
+++ b/security/src/test/java/io/lonmstalker/tgkit/security/TestUtils.java
@@ -44,6 +44,19 @@ public final class TestUtils {
     }
   }
 
+  public static void setEnv(String key, String value) {
+    try {
+      var env = System.getenv();
+      Field m = env.getClass().getDeclaredField("m");
+      m.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      var map = (java.util.Map<String, String>) m.get(env);
+      if (value == null) map.remove(key); else map.put(key, value);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   public static Update message(long chat, long user) {
     Update u = new Update();
     Message m = new Message();

--- a/security/src/test/java/io/lonmstalker/tgkit/security/secret/VaultSecretStoreTest.java
+++ b/security/src/test/java/io/lonmstalker/tgkit/security/secret/VaultSecretStoreTest.java
@@ -1,0 +1,40 @@
+package io.lonmstalker.tgkit.security.secret;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.lonmstalker.tgkit.security.TestUtils;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("VaultSecretStore – env config")
+class VaultSecretStoreTest implements WithAssertions {
+
+  @AfterEach
+  void cleanup() {
+    TestUtils.setEnv("VAULT_ADDR", null);
+    TestUtils.setEnv("VAULT_TOKEN", null);
+  }
+
+  @Test
+  @DisplayName("default https localhost")
+  void defaultAddress() {
+    TestUtils.setEnv("VAULT_TOKEN", "t");
+    VaultSecretStore store = new VaultSecretStore();
+    var vault = TestUtils.extract(store, "vault");
+    var cfg = TestUtils.extract(vault, "vaultConfig");
+    assertThat(cfg.getAddress()).isEqualTo("https://localhost:8200");
+  }
+
+  @Test
+  @DisplayName("VAULT_ADDR overrides scheme")
+  void envOverridesScheme() {
+    TestUtils.setEnv("VAULT_TOKEN", "t");
+    TestUtils.setEnv("VAULT_ADDR", "http://vault:8300");
+    VaultSecretStore store = new VaultSecretStore();
+    var vault = TestUtils.extract(store, "vault");
+    var cfg = TestUtils.extract(vault, "vaultConfig");
+    assertThat(cfg.getAddress()).isEqualTo("http://vault:8300");
+  }
+}


### PR DESCRIPTION
## Summary
- default VaultSecretStore URL uses https
- allow override of `VAULT_ADDR`
- document Vault SecretStore usage
- unit tests for VaultSecretStore

## Testing
- `mvn -q -Derrorprone.skip=true -Drevapi.skip=true spotless:apply verify` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_68555067edfc832592e20a46b7ebd2cc