### PR TITLE
Fix errorprone plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <revapi-maven-plugin.version>0.15.1</revapi-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
         <dependency-check-maven-plugin.version>12.1.3</dependency-check-maven-plugin.version>
-        <errorprone-maven-plugin.version>2.29.1</errorprone-maven-plugin.version>
+        <errorprone-maven-plugin.version>2.30.1</errorprone-maven-plugin.version>
 
         <!-- TEST -->
         <h2.version>2.3.232</h2.version>


### PR DESCRIPTION
## Summary
- bump errorprone-maven-plugin to v2.30.1

## Testing
- `./mvnw -q spotless:apply verify` *(fails: No plugin found for prefix 'spotless')*

------
https://chatgpt.com/codex/tasks/task_e_685554b070c48325bca27618fb9a8cad