### PR TITLE
Add shared bootstrap for core tests

### DIFF
--- a/core/src/test/java/io/lonmstalker/tgkit/core/args/ArgBindingTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/args/ArgBindingTest.java
@@ -15,6 +15,7 @@
  */
 package io.lonmstalker.tgkit.core.args;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.lonmstalker.tgkit.core.*;
@@ -29,7 +30,6 @@ import io.lonmstalker.tgkit.core.bot.BotConfig;
 import io.lonmstalker.tgkit.core.bot.TelegramSender;
 import io.lonmstalker.tgkit.core.bot.loader.AnnotatedCommandLoader;
 import io.lonmstalker.tgkit.core.i18n.MessageLocalizerImpl;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import io.lonmstalker.tgkit.core.state.InMemoryStateStore;
 import io.lonmstalker.tgkit.core.user.BotUserInfo;
 import io.lonmstalker.tgkit.core.user.store.InMemoryUserKVStore;
@@ -43,7 +43,7 @@ import org.telegram.telegrambots.meta.api.objects.Message;
 public class ArgBindingTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   public static class Commands {

--- a/core/src/test/java/io/lonmstalker/tgkit/core/args/ConvertersTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/args/ConvertersTest.java
@@ -15,17 +15,17 @@
  */
 package io.lonmstalker.tgkit.core.args;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.lonmstalker.tgkit.core.exception.BotApiException;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import java.math.BigDecimal;
 import org.junit.jupiter.api.Test;
 
 public class ConvertersTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   enum Color {

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotBuilderTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotBuilderTest.java
@@ -15,13 +15,13 @@
  */
 package io.lonmstalker.tgkit.core.bot;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.lonmstalker.tgkit.core.BotCommand;
 import io.lonmstalker.tgkit.core.BotRequest;
 import io.lonmstalker.tgkit.core.BotRequestType;
 import io.lonmstalker.tgkit.core.BotResponse;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import io.lonmstalker.tgkit.plugin.BotPlugin;
 import io.lonmstalker.tgkit.plugin.BotPluginContext;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -31,7 +31,7 @@ import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
 public class BotBuilderTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @io.lonmstalker.tgkit.core.annotation.BotCommand

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotCommandRegistryImplTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotCommandRegistryImplTest.java
@@ -15,6 +15,7 @@
  */
 package io.lonmstalker.tgkit.core.bot;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.lonmstalker.tgkit.core.BotCommand;
@@ -22,7 +23,6 @@ import io.lonmstalker.tgkit.core.BotRequest;
 import io.lonmstalker.tgkit.core.BotRequestType;
 import io.lonmstalker.tgkit.core.BotResponse;
 import io.lonmstalker.tgkit.core.exception.BotApiException;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import io.lonmstalker.tgkit.core.interceptor.BotInterceptor;
 import io.lonmstalker.tgkit.core.matching.CommandMatch;
 import java.util.List;
@@ -34,7 +34,7 @@ import org.telegram.telegrambots.meta.api.objects.Update;
 class BotCommandRegistryImplTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @Test

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotDataSourceFactoryTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotDataSourceFactoryTest.java
@@ -15,11 +15,11 @@
  */
 package io.lonmstalker.tgkit.core.bot;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.lonmstalker.tgkit.core.crypto.TokenCipherImpl;
 import io.lonmstalker.tgkit.core.exception.BotApiException;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import java.sql.Connection;
 import java.sql.Statement;
 import javax.sql.DataSource;
@@ -31,7 +31,7 @@ public class BotDataSourceFactoryTest {
   private DataSource ds;
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @BeforeEach

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotFactoryTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotFactoryTest.java
@@ -15,11 +15,11 @@
  */
 package io.lonmstalker.tgkit.core.bot;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.lonmstalker.tgkit.core.BotAdapter;
 import io.lonmstalker.tgkit.core.crypto.TokenCipherImpl;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import java.sql.Connection;
 import java.sql.Statement;
 import javax.sql.DataSource;
@@ -30,7 +30,7 @@ import org.telegram.telegrambots.meta.api.methods.updates.SetWebhook;
 public class BotFactoryTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @Test

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotImplLifecycleTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotImplLifecycleTest.java
@@ -15,11 +15,11 @@
  */
 package io.lonmstalker.tgkit.core.bot;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.lonmstalker.tgkit.core.BotAdapter;
 import io.lonmstalker.tgkit.core.exception.BotApiException;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import java.io.Serializable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,7 +32,7 @@ import org.telegram.telegrambots.meta.api.objects.User;
 public class BotImplLifecycleTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   private BotImpl bot;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotSessionImplTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotSessionImplTest.java
@@ -15,10 +15,10 @@
  */
 package io.lonmstalker.tgkit.core.bot;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.AbstractExecutorService;
@@ -33,7 +33,7 @@ import org.telegram.telegrambots.meta.generics.LongPollingBot;
 public class BotSessionImplTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @Test

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/TelegramSenderRateLimiterTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/TelegramSenderRateLimiterTest.java
@@ -15,9 +15,9 @@
  */
 package io.lonmstalker.tgkit.core.bot;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.junit.jupiter.api.Assertions.*;
 
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import java.lang.reflect.Field;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 class TelegramSenderRateLimiterTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @Test

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/TelegramSenderTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/TelegramSenderTest.java
@@ -15,10 +15,10 @@
  */
 package io.lonmstalker.tgkit.core.bot;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.lonmstalker.tgkit.core.exception.BotApiException;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.Test;
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 public class TelegramSenderTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @Test

--- a/core/src/test/java/io/lonmstalker/tgkit/core/config/BotConfigLoaderTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/config/BotConfigLoaderTest.java
@@ -15,9 +15,9 @@
  */
 package io.lonmstalker.tgkit.core.config;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.junit.jupiter.api.Assertions.*;
 
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -29,7 +29,7 @@ class BotConfigLoaderTest {
   @TempDir Path tmp;
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @Test

--- a/core/src/test/java/io/lonmstalker/tgkit/core/config/TelegramBotRunTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/config/TelegramBotRunTest.java
@@ -15,11 +15,11 @@
  */
 package io.lonmstalker.tgkit.core.config;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.lonmstalker.tgkit.core.TelegramBot;
 import io.lonmstalker.tgkit.core.bot.Bot;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import io.lonmstalker.tgkit.testkit.TelegramMockServer;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -32,7 +32,7 @@ class TelegramBotRunTest {
   @TempDir Path tmp;
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @Test

--- a/core/src/test/java/io/lonmstalker/tgkit/core/crypto/TokenCipherImplTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/crypto/TokenCipherImplTest.java
@@ -15,16 +15,16 @@
  */
 package io.lonmstalker.tgkit.core.crypto;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.lonmstalker.tgkit.core.exception.BotApiException;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import org.junit.jupiter.api.Test;
 
 public class TokenCipherImplTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @Test

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/BuilderFlagTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/BuilderFlagTest.java
@@ -15,6 +15,7 @@
  */
 package io.lonmstalker.tgkit.core.dsl;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -24,7 +25,6 @@ import io.lonmstalker.tgkit.core.BotService;
 import io.lonmstalker.tgkit.core.config.BotGlobalConfig;
 import io.lonmstalker.tgkit.core.dsl.context.DSLContext;
 import io.lonmstalker.tgkit.core.dsl.feature_flags.InMemoryFeatureFlags;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import io.lonmstalker.tgkit.core.user.BotUserInfo;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 class BuilderFlagTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @BeforeEach

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/ConditionalBranchesTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/ConditionalBranchesTest.java
@@ -15,6 +15,7 @@
  */
 package io.lonmstalker.tgkit.core.dsl;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
@@ -23,7 +24,6 @@ import io.lonmstalker.tgkit.core.config.BotGlobalConfig;
 import io.lonmstalker.tgkit.core.dsl.common.MockCtx;
 import io.lonmstalker.tgkit.core.dsl.context.DSLContext;
 import io.lonmstalker.tgkit.core.dsl.feature_flags.InMemoryFeatureFlags;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import org.junit.jupiter.api.Test;
@@ -33,7 +33,7 @@ import org.telegram.telegrambots.meta.api.methods.PartialBotApiMethod;
 class ConditionalBranchesTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @Test

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/CustomStrategyReuseTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/CustomStrategyReuseTest.java
@@ -15,13 +15,13 @@
  */
 package io.lonmstalker.tgkit.core.dsl;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import io.lonmstalker.tgkit.core.bot.TelegramSender;
 import io.lonmstalker.tgkit.core.dsl.common.MockCtx;
 import io.lonmstalker.tgkit.core.dsl.context.DSLContext;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -32,7 +32,7 @@ import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 class CustomStrategyReuseTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @Test

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/DslContextValidationTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/DslContextValidationTest.java
@@ -15,6 +15,7 @@
  */
 package io.lonmstalker.tgkit.core.dsl;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -22,14 +23,13 @@ import io.lonmstalker.tgkit.core.BotInfo;
 import io.lonmstalker.tgkit.core.BotService;
 import io.lonmstalker.tgkit.core.dsl.context.DSLContext.SimpleDSLContext;
 import io.lonmstalker.tgkit.core.exception.BotApiException;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import io.lonmstalker.tgkit.core.user.BotUserInfo;
 import org.junit.jupiter.api.Test;
 
 class DslContextValidationTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @Test

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/DslTtlIntegrationTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/DslTtlIntegrationTest.java
@@ -15,6 +15,7 @@
  */
 package io.lonmstalker.tgkit.core.dsl;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.*;
@@ -23,7 +24,6 @@ import io.lonmstalker.tgkit.core.BotInfo;
 import io.lonmstalker.tgkit.core.BotService;
 import io.lonmstalker.tgkit.core.bot.TelegramSender;
 import io.lonmstalker.tgkit.core.dsl.context.DSLContext;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import io.lonmstalker.tgkit.core.user.BotUserInfo;
 import java.io.Serializable;
 import java.time.Duration;
@@ -43,7 +43,7 @@ class DslTtlIntegrationTest {
   DSLContext ctx;
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @BeforeEach

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/EditBuilderTypingTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/EditBuilderTypingTest.java
@@ -15,6 +15,7 @@
  */
 package io.lonmstalker.tgkit.core.dsl;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.times;
@@ -23,7 +24,6 @@ import io.lonmstalker.tgkit.core.bot.TelegramSender;
 import io.lonmstalker.tgkit.core.config.BotGlobalConfig;
 import io.lonmstalker.tgkit.core.dsl.common.MockCtx;
 import io.lonmstalker.tgkit.core.dsl.context.DSLContext;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -33,7 +33,7 @@ import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 class EditBuilderTypingTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @Test

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/InMemoryFeatureFlagsTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/InMemoryFeatureFlagsTest.java
@@ -15,16 +15,16 @@
  */
 package io.lonmstalker.tgkit.core.dsl;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.assertj.core.api.Assertions.*;
 
 import io.lonmstalker.tgkit.core.dsl.feature_flags.InMemoryFeatureFlags;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import org.junit.jupiter.api.Test;
 
 class InMemoryFeatureFlagsTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @Test

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/KbBuilderTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/KbBuilderTest.java
@@ -15,18 +15,18 @@
  */
 package io.lonmstalker.tgkit.core.dsl;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import io.lonmstalker.tgkit.core.i18n.MessageLocalizer;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import org.junit.jupiter.api.Test;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
 
 class KbBuilderTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @Test

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/MediaGroupChunkingTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/MediaGroupChunkingTest.java
@@ -15,13 +15,13 @@
  */
 package io.lonmstalker.tgkit.core.dsl;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import io.lonmstalker.tgkit.core.bot.TelegramSender;
 import io.lonmstalker.tgkit.core.dsl.common.MockCtx;
 import io.lonmstalker.tgkit.core.dsl.context.DSLContext;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -33,7 +33,7 @@ import org.telegram.telegrambots.meta.api.objects.InputFile;
 class MediaGroupChunkingTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @Test

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/MessageBuilderTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/MessageBuilderTest.java
@@ -15,6 +15,7 @@
  */
 package io.lonmstalker.tgkit.core.dsl;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -22,7 +23,6 @@ import io.lonmstalker.tgkit.core.BotInfo;
 import io.lonmstalker.tgkit.core.BotService;
 import io.lonmstalker.tgkit.core.config.BotGlobalConfig;
 import io.lonmstalker.tgkit.core.dsl.context.DSLContext;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import io.lonmstalker.tgkit.core.parse_mode.ParseMode;
 import io.lonmstalker.tgkit.core.user.BotUserInfo;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,7 +34,7 @@ class MessageBuilderTest {
   private DSLContext ctx;
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @BeforeEach

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/MissingIdStrategyTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/MissingIdStrategyTest.java
@@ -15,6 +15,7 @@
  */
 package io.lonmstalker.tgkit.core.dsl;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -22,14 +23,13 @@ import io.lonmstalker.tgkit.core.BotInfo;
 import io.lonmstalker.tgkit.core.BotService;
 import io.lonmstalker.tgkit.core.dsl.context.DSLContext;
 import io.lonmstalker.tgkit.core.exception.BotApiException;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import io.lonmstalker.tgkit.core.user.BotUserInfo;
 import org.junit.jupiter.api.Test;
 
 class MissingIdStrategyTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @Test

--- a/core/src/test/java/io/lonmstalker/tgkit/core/dsl/QuizBuilderEdgeTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/dsl/QuizBuilderEdgeTest.java
@@ -15,6 +15,7 @@
  */
 package io.lonmstalker.tgkit.core.dsl;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
@@ -23,7 +24,6 @@ import io.lonmstalker.tgkit.core.bot.TelegramSender;
 import io.lonmstalker.tgkit.core.dsl.common.MockCtx;
 import io.lonmstalker.tgkit.core.dsl.context.DSLContext;
 import io.lonmstalker.tgkit.core.exception.BotApiException;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.telegram.telegrambots.meta.api.methods.PartialBotApiMethod;
@@ -33,7 +33,7 @@ import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 class QuizBuilderEdgeTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @Test

--- a/core/src/test/java/io/lonmstalker/tgkit/core/event/InMemoryEventBusTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/event/InMemoryEventBusTest.java
@@ -15,11 +15,11 @@
  */
 package io.lonmstalker.tgkit.core.event;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.lonmstalker.tgkit.core.event.impl.StartStatusBotEvent;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 class InMemoryEventBusTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @Test

--- a/core/src/test/java/io/lonmstalker/tgkit/core/i18n/MessageLocalizerTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/i18n/MessageLocalizerTest.java
@@ -15,16 +15,16 @@
  */
 package io.lonmstalker.tgkit.core.i18n;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import java.util.Locale;
 import org.junit.jupiter.api.Test;
 
 public class MessageLocalizerTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @Test

--- a/core/src/test/java/io/lonmstalker/tgkit/core/interceptor/LoggingBotInterceptorTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/interceptor/LoggingBotInterceptorTest.java
@@ -15,13 +15,13 @@
  */
 package io.lonmstalker.tgkit.core.interceptor;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.junit.jupiter.api.Assertions.*;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -35,7 +35,7 @@ public class LoggingBotInterceptorTest {
   private final ListAppender<ILoggingEvent> appender = new ListAppender<>();
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @AfterEach

--- a/core/src/test/java/io/lonmstalker/tgkit/core/matching/MatchersTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/matching/MatchersTest.java
@@ -15,9 +15,9 @@
  */
 package io.lonmstalker.tgkit.core.matching;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.junit.jupiter.api.Assertions.*;
 
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import io.lonmstalker.tgkit.core.storage.BotRequestContextHolder;
 import io.lonmstalker.tgkit.core.user.BotUserInfo;
 import io.lonmstalker.tgkit.core.user.BotUserProvider;
@@ -35,7 +35,7 @@ import org.telegram.telegrambots.meta.api.objects.User;
 public class MatchersTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @AfterEach

--- a/core/src/test/java/io/lonmstalker/tgkit/core/resource/ResourceLoaderTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/resource/ResourceLoaderTest.java
@@ -15,13 +15,13 @@
  */
 package io.lonmstalker.tgkit.core.resource;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpServer;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import java.io.*;
 import java.net.*;
 import java.nio.file.*;
@@ -40,7 +40,7 @@ class ResourceLoaderTest {
   @TempDir Path tmp;
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   /* ───────────────── classpath loader ──────────────────────────── */

--- a/core/src/test/java/io/lonmstalker/tgkit/core/state/RedisStateStoreTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/state/RedisStateStoreTest.java
@@ -15,9 +15,9 @@
  */
 package io.lonmstalker.tgkit.core.state;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.mockito.Mockito.*;
 
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,7 +26,7 @@ import redis.clients.jedis.JedisPool;
 
 class RedisStateStoreTest implements WithAssertions {
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   private JedisPool pool;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/storage/BotRequestContextHolderTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/storage/BotRequestContextHolderTest.java
@@ -15,18 +15,18 @@
  */
 package io.lonmstalker.tgkit.core.storage;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.lonmstalker.tgkit.core.bot.BotConfig;
 import io.lonmstalker.tgkit.core.bot.TelegramSender;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import org.junit.jupiter.api.Test;
 import org.telegram.telegrambots.meta.api.objects.Update;
 
 public class BotRequestContextHolderTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @Test

--- a/core/src/test/java/io/lonmstalker/tgkit/core/store/UserKVStoreTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/store/UserKVStoreTest.java
@@ -15,7 +15,7 @@
  */
 package io.lonmstalker.tgkit.core.store;
 
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import io.lonmstalker.tgkit.core.user.store.InMemoryUserKVStore;
 import io.lonmstalker.tgkit.core.user.store.JdbcUserKVStore;
 import io.lonmstalker.tgkit.core.user.store.ReadOnlyUserKVStore;
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.*;
 class UserKVStoreTest implements WithAssertions {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   /* ---------- shared test data ---------- */

--- a/core/src/test/java/io/lonmstalker/tgkit/core/ttl/TtlSchedulerTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/ttl/TtlSchedulerTest.java
@@ -15,10 +15,10 @@
  */
 package io.lonmstalker.tgkit.core.ttl;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.lonmstalker.tgkit.core.config.BotGlobalConfig;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import java.time.Duration;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.*;
 class TtlSchedulerTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @Test

--- a/core/src/test/java/io/lonmstalker/tgkit/core/update/UpdateUtilsTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/update/UpdateUtilsTest.java
@@ -15,19 +15,19 @@
  */
 package io.lonmstalker.tgkit.core.update;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.lonmstalker.tgkit.core.BotRequestType;
 import io.lonmstalker.tgkit.core.exception.BotApiException;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import org.junit.jupiter.api.Test;
 import org.telegram.telegrambots.meta.api.objects.*;
 
 public class UpdateUtilsTest {
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @Test

--- a/observability/src/test/java/io/lonmstalker/observability/BotAdapterCleanupTest.java
+++ b/observability/src/test/java/io/lonmstalker/observability/BotAdapterCleanupTest.java
@@ -15,6 +15,7 @@
  */
 package io.lonmstalker.observability;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -31,7 +32,6 @@ import io.lonmstalker.tgkit.core.bot.BotConfig;
 import io.lonmstalker.tgkit.core.bot.BotRegistryImpl;
 import io.lonmstalker.tgkit.core.bot.BotState;
 import io.lonmstalker.tgkit.core.bot.TelegramSender;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import io.lonmstalker.tgkit.core.interceptor.BotInterceptor;
 import io.lonmstalker.tgkit.core.storage.BotRequestContextHolder;
 import io.lonmstalker.tgkit.observability.Span;
@@ -62,7 +62,7 @@ public class BotAdapterCleanupTest {
 
   @BeforeAll
   static void initCore() {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
   }
 
   @BeforeEach

--- a/plugin/src/test/java/io/lonmstalker/tgkit/plugin/BotPluginManagerTest.java
+++ b/plugin/src/test/java/io/lonmstalker/tgkit/plugin/BotPluginManagerTest.java
@@ -15,6 +15,7 @@
  */
 package io.lonmstalker.tgkit.plugin;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static io.lonmstalker.tgkit.plugin.internal.BotPluginConstants.CURRENT_VERSION;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -22,7 +23,6 @@ import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import io.lonmstalker.tgkit.plugin.internal.BotPluginDescriptor;
 import io.lonmstalker.tgkit.security.audit.AuditBus;
 import io.lonmstalker.tgkit.security.audit.AuditEvent;
@@ -54,7 +54,7 @@ public class BotPluginManagerTest {
   private BotPluginManager manager;
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
     BotSecurityInitializer.init();
   }
 

--- a/security/src/test/java/io/lonmstalker/tgkit/security/antispam/AntiSpamInterceptorTest.java
+++ b/security/src/test/java/io/lonmstalker/tgkit/security/antispam/AntiSpamInterceptorTest.java
@@ -15,6 +15,7 @@
  */
 package io.lonmstalker.tgkit.security.antispam;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -22,7 +23,6 @@ import static org.mockito.Mockito.*;
 import io.lonmstalker.tgkit.core.BotRequest;
 import io.lonmstalker.tgkit.core.BotService;
 import io.lonmstalker.tgkit.core.i18n.MessageLocalizerImpl;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import io.lonmstalker.tgkit.security.captcha.CaptchaProvider;
 import io.lonmstalker.tgkit.security.init.BotSecurityInitializer;
 import io.lonmstalker.tgkit.security.ratelimit.RateLimiter;
@@ -47,7 +47,7 @@ class AntiSpamInterceptorTest implements WithAssertions {
   AntiSpamInterceptor isp;
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
     BotSecurityInitializer.init();
   }
 

--- a/security/src/test/java/io/lonmstalker/tgkit/security/audit/AuditBusTest.java
+++ b/security/src/test/java/io/lonmstalker/tgkit/security/audit/AuditBusTest.java
@@ -15,12 +15,12 @@
  */
 package io.lonmstalker.tgkit.security.audit;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.assertj.core.api.Assertions.*;
 
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import io.lonmstalker.tgkit.security.config.BotSecurityGlobalConfig;
 import io.lonmstalker.tgkit.security.init.BotSecurityInitializer;
 import java.time.Duration;
@@ -42,7 +42,7 @@ class AuditBusTest {
   private final ListAppender<ILoggingEvent> appender = new ListAppender<>();
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
     BotSecurityInitializer.init();
   }
 

--- a/security/src/test/java/io/lonmstalker/tgkit/security/captcha/MathCaptchaProviderServiceTest.java
+++ b/security/src/test/java/io/lonmstalker/tgkit/security/captcha/MathCaptchaProviderServiceTest.java
@@ -15,6 +15,7 @@
  */
 package io.lonmstalker.tgkit.security.captcha;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
@@ -22,7 +23,6 @@ import io.lonmstalker.tgkit.core.BotRequest;
 import io.lonmstalker.tgkit.core.BotService;
 import io.lonmstalker.tgkit.core.i18n.MessageLocalizer;
 import io.lonmstalker.tgkit.core.i18n.MessageLocalizerImpl;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import io.lonmstalker.tgkit.core.user.BotUserInfo;
 import io.lonmstalker.tgkit.core.user.store.UserKVStore;
 import io.lonmstalker.tgkit.security.TestUtils;
@@ -54,7 +54,7 @@ class MathCaptchaProviderServiceTest {
   MathCaptchaProviderStore cacheSpy;
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
     BotSecurityInitializer.init();
   }
 

--- a/security/src/test/java/io/lonmstalker/tgkit/security/limiter/InMemoryTelegramSenderRateLimiterTest.java
+++ b/security/src/test/java/io/lonmstalker/tgkit/security/limiter/InMemoryTelegramSenderRateLimiterTest.java
@@ -15,7 +15,7 @@
  */
 package io.lonmstalker.tgkit.security.limiter;
 
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import io.lonmstalker.tgkit.security.init.BotSecurityInitializer;
 import io.lonmstalker.tgkit.security.ratelimit.RateLimiter;
 import io.lonmstalker.tgkit.security.ratelimit.impl.InMemoryRateLimiter;
@@ -62,7 +62,7 @@ class InMemoryTelegramSenderRateLimiterTest implements WithAssertions {
   }
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
     BotSecurityInitializer.init();
   }
 

--- a/security/src/test/java/io/lonmstalker/tgkit/security/limiter/TelegramSenderRateLimiterTest.java
+++ b/security/src/test/java/io/lonmstalker/tgkit/security/limiter/TelegramSenderRateLimiterTest.java
@@ -15,12 +15,12 @@
  */
 package io.lonmstalker.tgkit.security.limiter;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import io.lonmstalker.tgkit.core.interceptor.BotInterceptor;
 import io.lonmstalker.tgkit.security.*;
 import io.lonmstalker.tgkit.security.init.BotSecurityInitializer;
@@ -44,7 +44,7 @@ class TelegramSenderRateLimiterTest {
   RateLimitBotCommandFactory factory;
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
     BotSecurityInitializer.init();
   }
 

--- a/security/src/test/java/io/lonmstalker/tgkit/security/rbac/RoleSecurityTest.java
+++ b/security/src/test/java/io/lonmstalker/tgkit/security/rbac/RoleSecurityTest.java
@@ -15,12 +15,12 @@
  */
 package io.lonmstalker.tgkit.security.rbac;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 import io.lonmstalker.tgkit.core.BotRequest;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import io.lonmstalker.tgkit.core.interceptor.BotInterceptor;
 import io.lonmstalker.tgkit.core.loader.BotCommandFactory;
 import io.lonmstalker.tgkit.security.init.BotSecurityInitializer;
@@ -41,7 +41,7 @@ public class RoleSecurityTest {
   Method handler;
 
   static {
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
     BotSecurityInitializer.init();
   }
 

--- a/testkit/src/main/java/io/lonmstalker/tgkit/testkit/TestBotBootstrap.java
+++ b/testkit/src/main/java/io/lonmstalker/tgkit/testkit/TestBotBootstrap.java
@@ -1,0 +1,28 @@
+package io.lonmstalker.tgkit.testkit;
+
+import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Utility class for test bootstrapping. Ensures {@link BotCoreInitializer} is
+ * initialized only once per JVM.
+ */
+public final class TestBotBootstrap {
+
+  private static final AtomicBoolean INITIALIZED = new AtomicBoolean();
+
+  private TestBotBootstrap() {}
+
+  /**
+   * Initializes tgkit core exactly once.
+   *
+   * <pre>{@code
+   * TestBotBootstrap.initOnce();
+   * }</pre>
+   */
+  public static void initOnce() {
+    if (INITIALIZED.compareAndSet(false, true)) {
+      BotCoreInitializer.init();
+    }
+  }
+}

--- a/webhook/src/test/java/io/lonmstalker/tgkit/webhook/WebhookServerTest.java
+++ b/webhook/src/test/java/io/lonmstalker/tgkit/webhook/WebhookServerTest.java
@@ -1,5 +1,6 @@
 package io.lonmstalker.tgkit.webhook;
 
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -12,7 +13,6 @@ import io.lonmstalker.tgkit.core.bot.BotAdapterImpl;
 import io.lonmstalker.tgkit.core.bot.BotConfig;
 import io.lonmstalker.tgkit.core.bot.BotFactory;
 import io.lonmstalker.tgkit.core.config.BotGlobalConfig;
-import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
 import io.lonmstalker.tgkit.core.matching.CommandMatch;
 import io.lonmstalker.tgkit.testkit.RecordedRequest;
 import io.lonmstalker.tgkit.testkit.TelegramMockServer;
@@ -36,7 +36,7 @@ class WebhookServerTest {
   @Test
   void dispatchesUpdateToBotAndAddsHsts() throws Exception {
     BotGlobalConfig.INSTANCE.webhook().engine(WebhookServer.Engine.JETTY).port(0).secret("SECRET");
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
     WebhookServer server = BotGlobalConfig.INSTANCE.webhook().server();
     try (TelegramMockServer tgServer = new TelegramMockServer()) {
       tgServer.enqueue("{\"ok\":true,\"result\":{\"id\":1,\"is_bot\":true,\"username\":\"bot\"}}");
@@ -91,7 +91,7 @@ class WebhookServerTest {
   @Test
   void rejectsRequestWithWrongToken() throws Exception {
     BotGlobalConfig.INSTANCE.webhook().engine(WebhookServer.Engine.JETTY).port(0).secret("SECRET");
-    BotCoreInitializer.init();
+    TestBotBootstrap.initOnce();
     WebhookServer server = BotGlobalConfig.INSTANCE.webhook().server();
     try (TelegramMockServer tgServer = new TelegramMockServer()) {
       tgServer.enqueue("{\"ok\":true,\"result\":{\"id\":1,\"is_bot\":true,\"username\":\"bot\"}}");


### PR DESCRIPTION
## Summary
- introduce `TestBotBootstrap` that initializes `BotCoreInitializer` only once
- use the new bootstrap in unit tests instead of direct calls

## Testing
- `mvnw -q -DskipTests -pl testkit spotless:apply` *(fails: No plugin found for prefix 'spotless')*
- `mvnw -q -DskipTests verify` *(fails: jacoco-maven-plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_685555670ab083258541b2be972ab01c