### PR TITLE
Add Spring Boot starter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@ telegram-bot-lib/
 | testkit  | 21          | —                  | incubating         | ≥ 95 %    | JUnit 5         |
 | telegram-bot-plugins  | 21          | разные             | incubating         | ≥ 80 %    | SPI loader      |
 | validator             | 21          | io.lonmstalker.tgkit.validator | public     | ≥ 90 %    | —               |
+| boot                  | 21          | io.lonmstalker.tgkit.boot | incubating     | ≥ 90 %    | Spring Boot |
 
 ## 8. Проверка качества ✅
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ testImplementation("io.lonmstalker.tgkit:testkit:0.0.1-SNAPSHOT")
 ```
 </details>
 
+<details>
+<summary>Spring Boot</summary>
+
+```xml
+<dependency>
+    <groupId>io.lonmstalker.tgkit</groupId>
+    <artifactId>boot</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+</dependency>
+```
+</details>
+
 ### 1 — Минимальный эхо-бот
 ```java
 public class EchoCommands {

--- a/boot/README.md
+++ b/boot/README.md
@@ -1,0 +1,26 @@
+# 📦 tgkit-boot
+*Spring Boot интеграция для **tgkit***
+
+---
+
+## Подключение
+
+```xml
+<dependency>
+    <groupId>io.lonmstalker.tgkit</groupId>
+    <artifactId>boot</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+</dependency>
+```
+
+После добавления зависимости создайте файл `application.yml`:
+
+```yaml
+tgkit:
+  bot:
+    token: "TOKEN"
+    packages:
+      - com.example.bot
+```
+
+И просто пометьте класс как `@SpringBootApplication` — бот запустится вместе с приложением.

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -1,0 +1,54 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.lonmstalker.tgkit</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>boot</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.lonmstalker.tgkit</groupId>
+            <artifactId>core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.lonmstalker.tgkit</groupId>
+            <artifactId>security</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.lonmstalker.tgkit</groupId>
+            <artifactId>observability</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+
+        <!-- TEST -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/boot/src/main/java/io/lonmstalker/tgkit/boot/BotAutoConfiguration.java
+++ b/boot/src/main/java/io/lonmstalker/tgkit/boot/BotAutoConfiguration.java
@@ -1,0 +1,58 @@
+package io.lonmstalker.tgkit.boot;
+
+import io.lonmstalker.observability.BotObservability;
+import io.lonmstalker.observability.MetricsCollector;
+import io.lonmstalker.tgkit.security.init.BotSecurityInitializer;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Автоконфигурация TgKit для Spring Boot.
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(BotProperties.class)
+public class BotAutoConfiguration {
+
+  @Bean
+  TelegramBotRunner telegramBotRunner(BotProperties properties) {
+    return new TelegramBotRunner(properties);
+  }
+
+  @Bean
+  @ConditionalOnClass(BotSecurityInitializer.class)
+  InitializingBean securityInitializer() {
+    return BotSecurityInitializer::init;
+  }
+
+  @Bean
+  @ConditionalOnClass(BotObservability.class)
+  ObservabilityInitializer observabilityInitializer(BotProperties properties) {
+    return new ObservabilityInitializer(properties);
+  }
+
+  static final class ObservabilityInitializer
+      implements InitializingBean, DisposableBean {
+    private final BotProperties properties;
+    private MetricsCollector collector;
+
+    ObservabilityInitializer(BotProperties properties) {
+      this.properties = properties;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+      collector = BotObservability.micrometer(properties.getMetricsPort());
+    }
+
+    @Override
+    public void destroy() throws Exception {
+      if (collector != null) {
+        collector.close();
+      }
+    }
+  }
+}

--- a/boot/src/main/java/io/lonmstalker/tgkit/boot/BotProperties.java
+++ b/boot/src/main/java/io/lonmstalker/tgkit/boot/BotProperties.java
@@ -1,0 +1,67 @@
+package io.lonmstalker.tgkit.boot;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Настройки бота для использования вместе со Spring Boot.
+ */
+@ConfigurationProperties("tgkit.bot")
+public class BotProperties {
+
+  private String token;
+  private String baseUrl;
+  private List<String> packages = new ArrayList<>();
+  private String botGroup;
+  private Integer requestsPerSecond;
+  private int metricsPort = 9180;
+
+  public String getToken() {
+    return token;
+  }
+
+  public void setToken(String token) {
+    this.token = token;
+  }
+
+  public String getBaseUrl() {
+    return baseUrl;
+  }
+
+  public void setBaseUrl(String baseUrl) {
+    this.baseUrl = baseUrl;
+  }
+
+  public List<String> getPackages() {
+    return packages;
+  }
+
+  public void setPackages(List<String> packages) {
+    this.packages = packages == null ? List.of() : new ArrayList<>(packages);
+  }
+
+  public String getBotGroup() {
+    return botGroup;
+  }
+
+  public void setBotGroup(String botGroup) {
+    this.botGroup = botGroup;
+  }
+
+  public Integer getRequestsPerSecond() {
+    return requestsPerSecond;
+  }
+
+  public void setRequestsPerSecond(Integer requestsPerSecond) {
+    this.requestsPerSecond = requestsPerSecond;
+  }
+
+  public int getMetricsPort() {
+    return metricsPort;
+  }
+
+  public void setMetricsPort(int metricsPort) {
+    this.metricsPort = metricsPort;
+  }
+}

--- a/boot/src/main/java/io/lonmstalker/tgkit/boot/TelegramBotRunner.java
+++ b/boot/src/main/java/io/lonmstalker/tgkit/boot/TelegramBotRunner.java
@@ -1,0 +1,56 @@
+package io.lonmstalker.tgkit.boot;
+
+import io.lonmstalker.tgkit.core.bot.Bot;
+import io.lonmstalker.tgkit.core.bot.BotAdapter;
+import io.lonmstalker.tgkit.core.bot.BotAdapterImpl;
+import io.lonmstalker.tgkit.core.bot.BotConfig;
+import io.lonmstalker.tgkit.core.bot.BotFactory;
+import io.lonmstalker.tgkit.core.bot.TelegramSender;
+import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
+import java.util.List;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+
+/**
+ * Компонент для запуска Telegram-бота при старте Spring Boot приложения.
+ */
+public final class TelegramBotRunner implements ApplicationRunner {
+
+  private final BotProperties props;
+  private @Nullable Bot bot;
+
+  public TelegramBotRunner(BotProperties props) {
+    this.props = props;
+  }
+
+  @Override
+  public void run(ApplicationArguments args) throws Exception {
+    BotCoreInitializer.init();
+
+    BotConfig cfg =
+        BotConfig.builder()
+            .baseUrl(props.getBaseUrl())
+            .botGroup(props.getBotGroup())
+            .requestsPerSecond(props.getRequestsPerSecond())
+            .build();
+
+    TelegramSender sender = new TelegramSender(cfg, props.getToken());
+    BotAdapter adapter = BotAdapterImpl.builder().sender(sender).config(cfg).build();
+    List<String> pkgs = props.getPackages();
+    bot = BotFactory.INSTANCE.from(props.getToken(), cfg, adapter, pkgs.toArray(new String[0]));
+    bot.start();
+  }
+
+  /** Останавливает запущенного бота. */
+  public void stop() {
+    if (bot != null) {
+      bot.stop();
+    }
+  }
+
+  /** Возвращает запущенный экземпляр бота или {@code null}. */
+  public @Nullable Bot bot() {
+    return bot;
+  }
+}

--- a/boot/src/main/java/module-info.java
+++ b/boot/src/main/java/module-info.java
@@ -1,0 +1,11 @@
+module io.lonmstalker.tgkit.boot {
+  requires io.lonmstalker.tgkit.core;
+  requires spring.boot;
+  requires spring.boot.autoconfigure;
+  requires spring.context;
+  requires spring.beans;
+  requires static io.lonmstalker.tgkit.security;
+  requires static io.lonmstalker.tgkit.observability;
+
+  exports io.lonmstalker.tgkit.boot;
+}

--- a/boot/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/boot/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.lonmstalker.tgkit.boot.BotAutoConfiguration

--- a/boot/src/test/java/io/lonmstalker/tgkit/boot/BotAutoConfigurationTest.java
+++ b/boot/src/test/java/io/lonmstalker/tgkit/boot/BotAutoConfigurationTest.java
@@ -1,0 +1,32 @@
+package io.lonmstalker.tgkit.boot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.lonmstalker.tgkit.security.init.BotSecurityInitializer;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.context.runner.FilteredClassLoader;
+
+class BotAutoConfigurationTest {
+
+  private final ApplicationContextRunner runner =
+      new ApplicationContextRunner()
+          .withConfiguration(AutoConfigurations.of(BotAutoConfiguration.class))
+          .withPropertyValues(
+              "tgkit.bot.token=T",
+              "tgkit.bot.base-url=http://localhost",
+              "tgkit.bot.packages=io.test");
+
+  @Test
+  void createsRunnerBean() {
+    runner.run(ctx -> assertThat(ctx).hasSingleBean(TelegramBotRunner.class));
+  }
+
+  @Test
+  void securityConditional() {
+    runner
+        .withClassLoader(new FilteredClassLoader(BotSecurityInitializer.class))
+        .run(context -> assertThat(context.containsBean("securityInitializer")).isFalse());
+  }
+}

--- a/boot/src/test/java/io/lonmstalker/tgkit/boot/TelegramBotRunnerTest.java
+++ b/boot/src/test/java/io/lonmstalker/tgkit/boot/TelegramBotRunnerTest.java
@@ -1,0 +1,38 @@
+package io.lonmstalker.tgkit.boot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.lonmstalker.tgkit.core.bot.Bot;
+import io.lonmstalker.tgkit.core.init.BotCoreInitializer;
+import io.lonmstalker.tgkit.testkit.TelegramMockServer;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.DefaultApplicationArguments;
+
+class TelegramBotRunnerTest {
+
+  @BeforeAll
+  static void init() {
+    BotCoreInitializer.init();
+  }
+
+  @Test
+  void runAndStop() throws Exception {
+    try (TelegramMockServer server = new TelegramMockServer()) {
+      BotProperties props = new BotProperties();
+      props.setToken("T");
+      props.setBaseUrl(server.baseUrl());
+      props.setPackages(List.of("io.test"));
+      props.setRequestsPerSecond(1);
+
+      TelegramBotRunner runner = new TelegramBotRunner(props);
+      runner.run(new DefaultApplicationArguments(new String[0]));
+      assertThat(server.takeRequest(1, TimeUnit.SECONDS).path()).endsWith("/getMe");
+      Bot bot = runner.bot();
+      assertThat(bot).isNotNull();
+      runner.stop();
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <module>testkit</module>
         <module>webhook</module>
         <module>validator</module>
+        <module>boot</module>
     </modules>
 
     <properties>
@@ -50,6 +51,7 @@
         <jakarta.servlet.version>6.0.0</jakarta.servlet.version>
         <guava.version>33.4.8-jre</guava.version>
         <language.detector.version>0.6</language.detector.version>
+        <spring.boot.version>3.2.5</spring.boot.version>
 
         <!-- PLUGINS -->
         <checkerframework.version>3.49.4</checkerframework.version>
@@ -209,6 +211,22 @@
                 <groupId>com.optimaize.languagedetector</groupId>
                 <artifactId>language-detector</artifactId>
                 <version>${language.detector.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot</artifactId>
+                <version>${spring.boot.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-autoconfigure</artifactId>
+                <version>${spring.boot.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-test</artifactId>
+                <version>${spring.boot.version}</version>
+                <scope>test</scope>
             </dependency>
 
             <!-- CHECKS -->


### PR DESCRIPTION
## Summary
- add new `boot` module with Spring Boot autoconfiguration
- run bot via `TelegramBotRunner`
- update parent `pom.xml` and module matrix
- document boot module usage

## Testing
- `./mvnw spotless:apply verify` *(fails: No plugin found for prefix 'spotless')*
- `./mvnw -pl :boot test` *(fails: jacoco-maven-plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6855555829488325b793087311a511c4