### PR TITLE
Add JsonCodec SPI module

### DIFF
--- a/json-codec-spi/pom.xml
+++ b/json-codec-spi/pom.xml
@@ -1,0 +1,27 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.lonmstalker.tgkit</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>json-codec-spi</artifactId>
+
+    <dependencies>
+        <!-- TEST -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/json-codec-spi/src/main/java/io/lonmstalker/tgkit/json/JsonCodec.java
+++ b/json-codec-spi/src/main/java/io/lonmstalker/tgkit/json/JsonCodec.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lonmstalker.tgkit.json;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * SPI для сериализации и десериализации объектов в JSON.
+ *
+ * <p>Интерфейс абстрагирует выбранный JSON‑парсер, позволяя подключать
+ * различные реализации (Jackson, Gson и др.).
+ * Пример использования:
+ *
+ * <pre>{@code
+ * JsonCodec codec = new JacksonJsonCodec();
+ * try (OutputStream out = Files.newOutputStream(Path.of("data.json"))) {
+ *   codec.serialize(data, out);
+ * }
+ * try (InputStream in = Files.newInputStream(Path.of("data.json"))) {
+ *   MyDto dto = codec.deserialize(in, MyDto.class);
+ * }
+ * }
+ * </pre>
+ */
+public interface JsonCodec {
+  /** Сериализует объект в поток. */
+  <T> void serialize(T obj, OutputStream out) throws Exception;
+
+  /** Читает объект указанного типа из потока. */
+  <T> T deserialize(InputStream in, Class<T> type) throws Exception;
+}

--- a/json-codec-spi/src/main/java/module-info.java
+++ b/json-codec-spi/src/main/java/module-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.lonmstalker.tgkit.json {
+    exports io.lonmstalker.tgkit.json;
+}

--- a/json-codec-spi/src/test/java/io/lonmstalker/tgkit/json/JsonCodecTest.java
+++ b/json-codec-spi/src/test/java/io/lonmstalker/tgkit/json/JsonCodecTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lonmstalker.tgkit.json;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import org.junit.jupiter.api.Test;
+
+class JsonCodecTest {
+
+  private static final class JacksonCodec implements JsonCodec {
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public <T> void serialize(T obj, java.io.OutputStream out) throws Exception {
+      mapper.writeValue(out, obj);
+    }
+
+    @Override
+    public <T> T deserialize(java.io.InputStream in, Class<T> type) throws Exception {
+      return mapper.readValue(in, type);
+    }
+  }
+
+  @Test
+  void serializes_and_deserializes() throws Exception {
+    JacksonCodec codec = new JacksonCodec();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    Sample sample = new Sample("test", 42);
+
+    codec.serialize(sample, out);
+
+    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+    Sample copy = codec.deserialize(in, Sample.class);
+
+    assertThat(copy).isEqualTo(sample);
+  }
+
+  private record Sample(String name, int value) {}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <module>testkit</module>
         <module>webhook</module>
         <module>validator</module>
+        <module>json-codec-spi</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
## Summary
- add new `json-codec-spi` module
- define `JsonCodec` interface with usage example
- register module in parent `pom.xml`

## Testing
- `mvn -q -pl :json-codec-spi test` *(fails: Could not resolve Jacoco plugin)*
- `mvn -q -pl :json-codec-spi spotless:apply verify` *(fails: No plugin found)*

------
https://chatgpt.com/codex/tasks/task_e_6855575f4e9c8325b63d2ad6624383d4