### PR TITLE
Enable NullAway in build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <revapi-maven-plugin.version>0.15.1</revapi-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
         <dependency-check-maven-plugin.version>12.1.3</dependency-check-maven-plugin.version>
+        <nullaway.version>0.12.7</nullaway.version>
         <errorprone-maven-plugin.version>2.30.1</errorprone-maven-plugin.version>
 
         <!-- TEST -->
@@ -266,6 +267,11 @@
                 <version>${compile.testing.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>com.uber.nullaway</groupId>
+                <artifactId>nullaway</artifactId>
+                <version>${nullaway.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -423,13 +429,22 @@
                         </goals>
                         <configuration>
                             <args>
-                                <arg>-XepAllErrorsAsWarnings</arg>
-                                <arg>-XepDisableWarningsInGeneratedCode</arg>
-                            </args>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+                            <arg>-XepAllErrorsAsWarnings</arg>
+                            <arg>-XepDisableWarningsInGeneratedCode</arg>
+                            <arg>-Xep:NullAway</arg>
+                            <arg>-XepOpt:NullAway:AnnotatedPackages=io.lonmstalker.tgkit</arg>
+                        </args>
+                    </configuration>
+                </execution>
+            </executions>
+            <dependencies>
+                <dependency>
+                    <groupId>com.uber.nullaway</groupId>
+                    <artifactId>nullaway</artifactId>
+                    <version>${nullaway.version}</version>
+                </dependency>
+            </dependencies>
+        </plugin>
             <plugin>
                 <groupId>org.revapi</groupId>
                 <artifactId>revapi-maven-plugin</artifactId>


### PR DESCRIPTION
## Summary
- add NullAway version property and dependency in the parent POM
- enable NullAway in errorprone plugin with the project's base package

## Testing
- `./mvnw -pl :core -q test-compile` *(fails: Could not resolve org.jacoco:jacoco-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68555b900a3c832586e1e0fa8b69b826