### PR TITLE
Add JMH benchmarks module

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,13 @@ export MAVEN_OPTS="-Dhttps.proxyHost=proxy -Dhttps.proxyPort=8080 \
 Отчёты появятся в `target/dependency-check-report.html` и
 `target/dependency-check-report.sarif`.
 
+### Бенчмарки
+Для запуска JMH-бенчмарков:
+
+```bash
+./mvnw -Pbenchmarks -pl benchmarks test
+```
+
 ## 🤝 Contributing
 PR-ы и идеи приветствуются! Перед отправкой ознакомьтесь с [CONTRIBUTING.md](CONTRIBUTING.md) и [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -1,0 +1,62 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.lonmstalker.tgkit</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>benchmarks</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.lonmstalker.tgkit</groupId>
+            <artifactId>api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.lonmstalker.tgkit</groupId>
+            <artifactId>testkit</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- JMH -->
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- TEST -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.openjdk.jmh</groupId>
+                <artifactId>jmh-generator-maven-plugin</artifactId>
+                <version>${jmh.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-jmh-sources</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/benchmarks/src/jmh/java/io/lonmstalker/tgkit/benchmarks/TelegramSenderBenchmark.java
+++ b/benchmarks/src/jmh/java/io/lonmstalker/tgkit/benchmarks/TelegramSenderBenchmark.java
@@ -1,0 +1,50 @@
+package io.lonmstalker.tgkit.benchmarks;
+
+import io.lonmstalker.tgkit.core.bot.BotConfig;
+import io.lonmstalker.tgkit.core.bot.TelegramSender;
+import io.lonmstalker.tgkit.testkit.TelegramMockServer;
+import io.lonmstalker.tgkit.testkit.TestBotBootstrap;
+import java.util.Locale;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.telegram.telegrambots.meta.api.methods.GetMe;
+
+/** Benchmark measuring TelegramSender#execute against TelegramMockServer. */
+@State(Scope.Benchmark)
+public class TelegramSenderBenchmark {
+
+  private TelegramMockServer server;
+  private TelegramSender sender;
+
+  /** Prepares mock server and sender. */
+  @Setup
+  public void setup() {
+    TestBotBootstrap.initOnce();
+    server = new TelegramMockServer();
+    BotConfig config =
+        BotConfig.builder()
+            .baseUrl(server.baseUrl())
+            .botGroup("bench")
+            .requestsPerSecond(30)
+            .locale(Locale.US)
+            .build();
+    sender = new TelegramSender(config, "TOKEN");
+    server.enqueue("{\"ok\":true,\"result\":{\"id\":1}}");
+  }
+
+  /** Cleans up resources. */
+  @TearDown
+  public void tearDown() {
+    sender.close();
+    server.close();
+  }
+
+  /** Sends GetMe request via {@link TelegramSender#execute}. */
+  @Benchmark
+  public void executeGetMe() throws Exception {
+    sender.execute(new GetMe());
+  }
+}

--- a/benchmarks/src/test/java/io/lonmstalker/tgkit/benchmarks/TelegramSenderBenchmarkTest.java
+++ b/benchmarks/src/test/java/io/lonmstalker/tgkit/benchmarks/TelegramSenderBenchmarkTest.java
@@ -1,0 +1,15 @@
+package io.lonmstalker.tgkit.benchmarks;
+
+import org.junit.jupiter.api.Test;
+
+/** Smoke test for {@link TelegramSenderBenchmark}. */
+class TelegramSenderBenchmarkTest {
+
+  @Test
+  void executeGetMe() throws Exception {
+    TelegramSenderBenchmark bench = new TelegramSenderBenchmark();
+    bench.setup();
+    bench.executeGetMe();
+    bench.tearDown();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <module>validator</module>
         <module>boot</module>
         <module>codec</module>
+        <module>benchmarks</module>
     </modules>
 
     <properties>
@@ -555,6 +556,26 @@
                                 </configuration>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>benchmarks</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${maven-surefire-plugin.version}</version>
+                        <configuration>
+                            <includes>
+                                <include>**/*Benchmark.java</include>
+                            </includes>
+                            <excludes>
+                                <exclude>**/*Test.java</exclude>
+                            </excludes>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
## Summary
- add new `benchmarks` module
- implement `TelegramSenderBenchmark` measuring `TelegramSender#execute`
- configure `benchmarks` profile in Maven for JMH run
- document benchmark run command

## Testing
- `mvnw com.diffplug.spotless:spotless-maven-plugin:apply` *(failed: Network is unreachable)*
- `mvnw verify` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6855850dd4608325a9adc471770f1758