### PR TITLE
Add modular doc converter

### DIFF
--- a/doc-openapi/pom.xml
+++ b/doc-openapi/pom.xml
@@ -1,0 +1,105 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.lonmstalker.tgkit</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>doc-openapi</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>${jsoup.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${mapstruct.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-core</artifactId>
+            <version>${swagger.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${snakeyaml.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+            <version>${picocli.version}</version>
+        </dependency>
+        <!-- CHECKS -->
+        <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-qual</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker</artifactId>
+        </dependency>
+        <!-- TEST -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${mapstruct.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${exec-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-openapi</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>io.lonmstalker.tgkit.doc.cli.DocCli</mainClass>
+                            <arguments>
+                                <argument>--output</argument>
+                                <argument>${project.build.directory}/openapi/telegram.yaml</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/doc-openapi/src/main/java/io/lonmstalker/tgkit/doc/DocumentationService.java
+++ b/doc-openapi/src/main/java/io/lonmstalker/tgkit/doc/DocumentationService.java
@@ -1,0 +1,46 @@
+package io.lonmstalker.tgkit.doc;
+
+import io.lonmstalker.tgkit.doc.emitter.OpenApiEmitter;
+import io.lonmstalker.tgkit.doc.mapper.MethodDocMapper;
+import io.lonmstalker.tgkit.doc.scraper.DocScraper;
+import io.lonmstalker.tgkit.doc.scraper.JsoupDocScraper;
+import io.lonmstalker.tgkit.doc.scraper.MethodDoc;
+import io.swagger.v3.oas.models.OpenAPI;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Сервис преобразования документации Telegram API в спецификацию OpenAPI.
+ *
+ * <p>Пример использования:
+ * <pre>{@code
+ * DocumentationService service = new DocumentationService();
+ * service.generate(Path.of("index.html"), Path.of("build/telegram.yaml"));
+ * }</pre>
+ */
+public final class DocumentationService {
+
+  private final DocScraper scraper = new JsoupDocScraper();
+  private final MethodDocMapper mapper = MethodDocMapper.INSTANCE;
+  private final OpenApiEmitter emitter = new OpenApiEmitter();
+
+  /**
+   * Генерирует файл OpenAPI из HTML-документа.
+   *
+   * @param input  путь к исходному HTML
+   * @param output путь для сохранения YAML
+   */
+  public void generate(Path input, Path output) {
+    try (InputStream in = Files.newInputStream(input)) {
+      List<MethodDoc> docs = scraper.scrape(in);
+      OpenAPI api = emitter.toOpenApi(docs.stream().map(mapper::toOperation).toList());
+      emitter.write(api, output);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Не удалось обработать документ", e);
+    }
+  }
+}

--- a/doc-openapi/src/main/java/io/lonmstalker/tgkit/doc/cli/DocCli.java
+++ b/doc-openapi/src/main/java/io/lonmstalker/tgkit/doc/cli/DocCli.java
@@ -1,0 +1,31 @@
+package io.lonmstalker.tgkit.doc.cli;
+
+import io.lonmstalker.tgkit.doc.DocumentationService;
+import java.nio.file.Path;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Консольная утилита для генерации OpenAPI из HTML-документации.
+ */
+@Command(name = "doc-to-openapi", mixinStandardHelpOptions = true, version = "1.0")
+public class DocCli implements Runnable {
+
+  @Option(names = "--input", description = "Входной HTML файл", required = true)
+  private Path input;
+
+  @Option(names = "--output", description = "Файл назначения YAML",
+      defaultValue = "${sys:user.dir}/build/openapi/telegram.yaml")
+  private Path output;
+
+  @Override
+  public void run() {
+    new DocumentationService().generate(input, output);
+  }
+
+  /** Точка входа. */
+  public static void main(String[] args) {
+    new CommandLine(new DocCli()).execute(args);
+  }
+}

--- a/doc-openapi/src/main/java/io/lonmstalker/tgkit/doc/emitter/OpenApiEmitter.java
+++ b/doc-openapi/src/main/java/io/lonmstalker/tgkit/doc/emitter/OpenApiEmitter.java
@@ -1,0 +1,45 @@
+package io.lonmstalker.tgkit.doc.emitter;
+
+import io.lonmstalker.tgkit.doc.mapper.OperationInfo;
+import io.swagger.v3.core.util.Yaml;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Построитель и писатель спецификации OpenAPI.
+ */
+public class OpenApiEmitter {
+  /**
+   * Формирует объект {@link OpenAPI} по списку операций.
+   */
+  public OpenAPI toOpenApi(List<OperationInfo> operations) {
+    OpenAPI openApi = new OpenAPI();
+    Paths paths = new Paths();
+    for (OperationInfo op : operations) {
+      Operation operation = new Operation();
+      operation.setSummary(op.description());
+      PathItem path = new PathItem().post(operation);
+      paths.addPathItem("/" + op.name(), path);
+    }
+    openApi.setPaths(paths);
+    return openApi;
+  }
+
+  /**
+   * Сохраняет YAML-файл со схемой OpenAPI.
+   */
+  public void write(OpenAPI openApi, Path file) {
+    try {
+      Files.createDirectories(file.getParent());
+      Files.writeString(file, Yaml.mapper().writeValueAsString(openApi));
+    } catch (IOException e) {
+      throw new IllegalStateException("Не удалось записать OpenAPI", e);
+    }
+  }
+}

--- a/doc-openapi/src/main/java/io/lonmstalker/tgkit/doc/mapper/MethodDocMapper.java
+++ b/doc-openapi/src/main/java/io/lonmstalker/tgkit/doc/mapper/MethodDocMapper.java
@@ -1,0 +1,15 @@
+package io.lonmstalker.tgkit.doc.mapper;
+
+import io.lonmstalker.tgkit.doc.scraper.MethodDoc;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Маппер между {@link MethodDoc} и внутренней моделью {@link OperationInfo}.
+ */
+@Mapper
+public interface MethodDocMapper {
+  MethodDocMapper INSTANCE = Mappers.getMapper(MethodDocMapper.class);
+
+  OperationInfo toOperation(MethodDoc methodDoc);
+}

--- a/doc-openapi/src/main/java/io/lonmstalker/tgkit/doc/mapper/OperationInfo.java
+++ b/doc-openapi/src/main/java/io/lonmstalker/tgkit/doc/mapper/OperationInfo.java
@@ -1,0 +1,9 @@
+package io.lonmstalker.tgkit.doc.mapper;
+
+/**
+ * Внутреннее представление метода Telegram API.
+ *
+ * @param name        имя метода
+ * @param description краткое описание
+ */
+public record OperationInfo(String name, String description) {}

--- a/doc-openapi/src/main/java/io/lonmstalker/tgkit/doc/scraper/DocScraper.java
+++ b/doc-openapi/src/main/java/io/lonmstalker/tgkit/doc/scraper/DocScraper.java
@@ -1,0 +1,18 @@
+package io.lonmstalker.tgkit.doc.scraper;
+
+import java.io.InputStream;
+import java.util.List;
+
+/**
+ * Интерфейс парсера HTML-документации Telegram API.
+ *
+ * <p>Пример:
+ * <pre>{@code
+ * DocScraper scraper = new JsoupDocScraper();
+ * List<MethodDoc> docs = scraper.scrape(stream);
+ * }</pre>
+ */
+public interface DocScraper {
+  /** Читает HTML и возвращает список методов. */
+  List<MethodDoc> scrape(InputStream stream);
+}

--- a/doc-openapi/src/main/java/io/lonmstalker/tgkit/doc/scraper/JsoupDocScraper.java
+++ b/doc-openapi/src/main/java/io/lonmstalker/tgkit/doc/scraper/JsoupDocScraper.java
@@ -1,0 +1,32 @@
+package io.lonmstalker.tgkit.doc.scraper;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+/**
+ * Реализация {@link DocScraper} на базе Jsoup.
+ */
+public class JsoupDocScraper implements DocScraper {
+  @Override
+  public List<MethodDoc> scrape(InputStream stream) {
+    Document doc;
+    try {
+      doc = Jsoup.parse(stream, null, "");
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Не удалось распарсить документ", e);
+    }
+    Elements methods = doc.select("div.method");
+    return methods.stream().map(this::parseMethod).collect(Collectors.toList());
+  }
+
+  private MethodDoc parseMethod(Element el) {
+    String name = el.selectFirst("h3").text();
+    String desc = el.selectFirst("p").text();
+    return new MethodDoc(name, desc);
+  }
+}

--- a/doc-openapi/src/main/java/io/lonmstalker/tgkit/doc/scraper/MethodDoc.java
+++ b/doc-openapi/src/main/java/io/lonmstalker/tgkit/doc/scraper/MethodDoc.java
@@ -1,0 +1,9 @@
+package io.lonmstalker.tgkit.doc.scraper;
+
+/**
+ * Описание метода Telegram API.
+ *
+ * @param name        имя метода
+ * @param description краткое описание
+ */
+public record MethodDoc(String name, String description) {}

--- a/doc-openapi/src/test/java/io/lonmstalker/tgkit/doc/cli/DocCliTest.java
+++ b/doc-openapi/src/test/java/io/lonmstalker/tgkit/doc/cli/DocCliTest.java
@@ -1,0 +1,22 @@
+package io.lonmstalker.tgkit.doc.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+class DocCliTest {
+  @Test
+  void generatesFile() throws Exception {
+    Path html = Files.createTempFile("doc", ".html");
+    Files.writeString(html, "<div class='method'><h3>getMe</h3><p>desc</p></div>");
+    Path out = Files.createTempDirectory("out").resolve("telegram.yaml");
+    int code = new CommandLine(new DocCli()).execute("--input", html.toString(), "--output", out.toString());
+    assertThat(code).isZero();
+    assertThat(out.toFile()).exists();
+    assertThat(Files.readString(out)).contains("getMe");
+  }
+}

--- a/doc-openapi/src/test/java/io/lonmstalker/tgkit/doc/emitter/OpenApiEmitterTest.java
+++ b/doc-openapi/src/test/java/io/lonmstalker/tgkit/doc/emitter/OpenApiEmitterTest.java
@@ -1,0 +1,23 @@
+package io.lonmstalker.tgkit.doc.emitter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.lonmstalker.tgkit.doc.mapper.OperationInfo;
+import io.swagger.v3.oas.models.OpenAPI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OpenApiEmitterTest {
+  @Test
+  void buildsAndWritesYaml() throws Exception {
+    OpenApiEmitter emitter = new OpenApiEmitter();
+    List<OperationInfo> ops = List.of(new OperationInfo("getMe", "desc"));
+    OpenAPI api = emitter.toOpenApi(ops);
+    Path tmp = Files.createTempFile("openapi", ".yaml");
+    emitter.write(api, tmp);
+    String yaml = Files.readString(tmp);
+    assertThat(yaml).contains("/getMe");
+  }
+}

--- a/doc-openapi/src/test/java/io/lonmstalker/tgkit/doc/mapper/MethodDocMapperTest.java
+++ b/doc-openapi/src/test/java/io/lonmstalker/tgkit/doc/mapper/MethodDocMapperTest.java
@@ -1,0 +1,16 @@
+package io.lonmstalker.tgkit.doc.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.lonmstalker.tgkit.doc.scraper.MethodDoc;
+import org.junit.jupiter.api.Test;
+
+class MethodDocMapperTest {
+  @Test
+  void mapsMethodDoc() {
+    MethodDoc src = new MethodDoc("getMe", "desc");
+    OperationInfo info = MethodDocMapper.INSTANCE.toOperation(src);
+    assertThat(info.name()).isEqualTo("getMe");
+    assertThat(info.description()).isEqualTo("desc");
+  }
+}

--- a/doc-openapi/src/test/java/io/lonmstalker/tgkit/doc/scraper/JsoupDocScraperTest.java
+++ b/doc-openapi/src/test/java/io/lonmstalker/tgkit/doc/scraper/JsoupDocScraperTest.java
@@ -1,0 +1,19 @@
+package io.lonmstalker.tgkit.doc.scraper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class JsoupDocScraperTest {
+  @Test
+  void parsesMethodsFromHtml() {
+    DocScraper scraper = new JsoupDocScraper();
+    InputStream in = getClass().getResourceAsStream("/sample.html");
+    List<MethodDoc> methods = scraper.scrape(in);
+    assertThat(methods).hasSize(2);
+    assertThat(methods.get(0).name()).isEqualTo("getMe");
+    assertThat(methods.get(1).name()).isEqualTo("sendMessage");
+  }
+}

--- a/doc-openapi/src/test/resources/sample.html
+++ b/doc-openapi/src/test/resources/sample.html
@@ -1,0 +1,12 @@
+<html>
+<body>
+<div class="method">
+<h3>getMe</h3>
+<p>Returns basic information about the bot.</p>
+</div>
+<div class="method">
+<h3>sendMessage</h3>
+<p>Use this method to send text messages.</p>
+</div>
+</body>
+</html>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,8 @@
         <module>validator</module>
         <module>boot</module>
         <module>codec</module>
+        <module>doc-openapi</module>
+        <module>telegram-doc-to-openapi</module>
     </modules>
 
     <properties>
@@ -55,6 +57,11 @@
         <spring.boot.version>3.2.5</spring.boot.version>
         <dsljson.version>1.10.2</dsljson.version>
         <jmh.version>1.37</jmh.version>
+        <jsoup.version>1.18.3</jsoup.version>
+        <mapstruct.version>1.6.3</mapstruct.version>
+        <swagger.core.version>2.2.5</swagger.core.version>
+        <snakeyaml.version>2.0</snakeyaml.version>
+        <picocli.version>4.7.5</picocli.version>
 
         <!-- PLUGINS -->
         <checkerframework.version>3.49.4</checkerframework.version>

--- a/telegram-doc-to-openapi/README.md
+++ b/telegram-doc-to-openapi/README.md
@@ -1,0 +1,11 @@
+# Модуль telegram-doc-to-openapi
+
+Набор утилит для конвертации документации Telegram Bot API в спецификацию OpenAPI.
+
+## Использование
+
+```bash
+mvn -pl telegram-doc-to-openapi/cli -q exec:java
+```
+
+По умолчанию результат сохраняется в `build/openapi/telegram.yaml`.

--- a/telegram-doc-to-openapi/cli/pom.xml
+++ b/telegram-doc-to-openapi/cli/pom.xml
@@ -1,0 +1,75 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.lonmstalker.tgkit</groupId>
+        <artifactId>telegram-doc-to-openapi</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>telegram-doc-to-openapi-cli</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.lonmstalker.tgkit</groupId>
+            <artifactId>telegram-doc-to-openapi-scraper</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.lonmstalker.tgkit</groupId>
+            <artifactId>telegram-doc-to-openapi-mapper</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.lonmstalker.tgkit</groupId>
+            <artifactId>telegram-doc-to-openapi-emitter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+            <version>${picocli.version}</version>
+        </dependency>
+        <!-- TEST -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${exec-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-openapi</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>io.lonmstalker.tgkit.doc.cli.DocCli</mainClass>
+                            <arguments>
+                                <argument>--input</argument>
+                                <argument>${project.basedir}/src/test/resources/sample.html</argument>
+                                <argument>--output</argument>
+                                <argument>${project.build.directory}/openapi/telegram.yaml</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/telegram-doc-to-openapi/cli/src/main/java/io/lonmstalker/tgkit/doc/DocumentationService.java
+++ b/telegram-doc-to-openapi/cli/src/main/java/io/lonmstalker/tgkit/doc/DocumentationService.java
@@ -1,0 +1,46 @@
+package io.lonmstalker.tgkit.doc;
+
+import io.lonmstalker.tgkit.doc.emitter.OpenApiEmitter;
+import io.lonmstalker.tgkit.doc.mapper.MethodDocMapper;
+import io.lonmstalker.tgkit.doc.scraper.BotApiScraper;
+import io.lonmstalker.tgkit.doc.scraper.DocScraper;
+import io.lonmstalker.tgkit.doc.scraper.HtmlDocScraper;
+import io.lonmstalker.tgkit.doc.scraper.MethodDoc;
+import io.swagger.v3.oas.models.OpenAPI;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Конвейер преобразования документации в OpenAPI.
+ */
+public final class DocumentationService {
+  private final DocScraper htmlScraper = new HtmlDocScraper();
+  private final BotApiScraper apiScraper = new BotApiScraper();
+  private final MethodDocMapper mapper = MethodDocMapper.INSTANCE;
+  private final OpenApiEmitter emitter = new OpenApiEmitter();
+
+  /** Из HTML-файла. */
+  public void generate(Path input, Path output) {
+    try (InputStream in = Files.newInputStream(input)) {
+      List<MethodDoc> docs = htmlScraper.scrape(in);
+      write(docs, output);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Не удалось обработать файл", e);
+    }
+  }
+
+  /** Скачивает официальную документацию и сохраняет YAML. */
+  public void generateFromApi(Path output) {
+    List<MethodDoc> docs = apiScraper.fetch();
+    write(docs, output);
+  }
+
+  private void write(List<MethodDoc> docs, Path output) {
+    OpenAPI api = emitter.toOpenApi(docs.stream().map(mapper::toOperation).toList());
+    emitter.write(api, output);
+  }
+}

--- a/telegram-doc-to-openapi/cli/src/main/java/io/lonmstalker/tgkit/doc/cli/DocCli.java
+++ b/telegram-doc-to-openapi/cli/src/main/java/io/lonmstalker/tgkit/doc/cli/DocCli.java
@@ -1,0 +1,37 @@
+package io.lonmstalker.tgkit.doc.cli;
+
+import io.lonmstalker.tgkit.doc.DocumentationService;
+import java.nio.file.Path;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Консольная утилита для генерации OpenAPI.
+ */
+@Command(name = "doc-to-openapi", mixinStandardHelpOptions = true)
+public class DocCli implements Runnable {
+  @Option(names = "--input", description = "HTML файл с документацией")
+  private Path input;
+
+  @Option(names = "--api", description = "Загрузить официальную документацию")
+  private boolean fromApi;
+
+  @Option(names = "--output", description = "Файл YAML", defaultValue = "${sys:user.dir}/build/openapi/telegram.yaml")
+  private Path output;
+
+  @Override
+  public void run() {
+    DocumentationService service = new DocumentationService();
+    if (fromApi) {
+      service.generateFromApi(output);
+    } else {
+      service.generate(input, output);
+    }
+  }
+
+  /** Точка входа. */
+  public static void main(String[] args) {
+    new CommandLine(new DocCli()).execute(args);
+  }
+}

--- a/telegram-doc-to-openapi/cli/src/test/java/io/lonmstalker/tgkit/doc/cli/DocCliTest.java
+++ b/telegram-doc-to-openapi/cli/src/test/java/io/lonmstalker/tgkit/doc/cli/DocCliTest.java
@@ -1,0 +1,20 @@
+package io.lonmstalker.tgkit.doc.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+class DocCliTest {
+  @Test
+  void generatesFileFromHtml() throws Exception {
+    Path html = Files.createTempFile("doc", ".html");
+    Files.writeString(html, "<div class='method'><h3>getMe</h3><p>desc</p></div>");
+    Path out = Files.createTempDirectory("out").resolve("telegram.yaml");
+    int code = new CommandLine(new DocCli()).execute("--input", html.toString(), "--output", out.toString());
+    assertThat(code).isZero();
+    assertThat(Files.readString(out)).contains("getMe");
+  }
+}

--- a/telegram-doc-to-openapi/cli/src/test/resources/sample.html
+++ b/telegram-doc-to-openapi/cli/src/test/resources/sample.html
@@ -1,0 +1,12 @@
+<html>
+<body>
+<div class="method">
+<h3>getMe</h3>
+<p>Returns basic information about the bot.</p>
+</div>
+<div class="method">
+<h3>sendMessage</h3>
+<p>Use this method to send text messages.</p>
+</div>
+</body>
+</html>

--- a/telegram-doc-to-openapi/emitter/pom.xml
+++ b/telegram-doc-to-openapi/emitter/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.lonmstalker.tgkit</groupId>
+        <artifactId>telegram-doc-to-openapi</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>telegram-doc-to-openapi-emitter</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-core</artifactId>
+            <version>${swagger.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${snakeyaml.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <!-- TEST -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/telegram-doc-to-openapi/emitter/src/main/java/io/lonmstalker/tgkit/doc/emitter/OpenApiEmitter.java
+++ b/telegram-doc-to-openapi/emitter/src/main/java/io/lonmstalker/tgkit/doc/emitter/OpenApiEmitter.java
@@ -1,0 +1,41 @@
+package io.lonmstalker.tgkit.doc.emitter;
+
+import io.lonmstalker.tgkit.doc.mapper.OperationInfo;
+import io.swagger.v3.core.util.Yaml;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Конструктор спецификации OpenAPI и запись на диск.
+ */
+public class OpenApiEmitter {
+  /** Формирует объект OpenAPI по операциям. */
+  public OpenAPI toOpenApi(List<OperationInfo> operations) {
+    OpenAPI api = new OpenAPI();
+    Paths paths = new Paths();
+    for (OperationInfo op : operations) {
+      Operation operation = new Operation();
+      operation.setSummary(op.description());
+      PathItem item = new PathItem().post(operation);
+      paths.addPathItem("/" + op.name(), item);
+    }
+    api.setPaths(paths);
+    return api;
+  }
+
+  /** Пишет YAML-файл. */
+  public void write(OpenAPI api, Path file) {
+    try {
+      Files.createDirectories(file.getParent());
+      Files.writeString(file, Yaml.mapper().writeValueAsString(api));
+    } catch (IOException e) {
+      throw new IllegalStateException("Не удалось записать YAML", e);
+    }
+  }
+}

--- a/telegram-doc-to-openapi/emitter/src/test/java/io/lonmstalker/tgkit/doc/emitter/OpenApiEmitterTest.java
+++ b/telegram-doc-to-openapi/emitter/src/test/java/io/lonmstalker/tgkit/doc/emitter/OpenApiEmitterTest.java
@@ -1,0 +1,23 @@
+package io.lonmstalker.tgkit.doc.emitter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.lonmstalker.tgkit.doc.mapper.OperationInfo;
+import io.swagger.v3.oas.models.OpenAPI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OpenApiEmitterTest {
+  @Test
+  void buildsAndWritesYaml() throws Exception {
+    OpenApiEmitter emitter = new OpenApiEmitter();
+    List<OperationInfo> ops = List.of(new OperationInfo("getMe", "desc"));
+    OpenAPI api = emitter.toOpenApi(ops);
+    Path tmp = Files.createTempFile("openapi", ".yaml");
+    emitter.write(api, tmp);
+    String yaml = Files.readString(tmp);
+    assertThat(yaml).contains("/getMe");
+  }
+}

--- a/telegram-doc-to-openapi/mapper/pom.xml
+++ b/telegram-doc-to-openapi/mapper/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.lonmstalker.tgkit</groupId>
+        <artifactId>telegram-doc-to-openapi</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>telegram-doc-to-openapi-mapper</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${mapstruct.version}</version>
+        </dependency>
+        <!-- TEST -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${mapstruct.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/telegram-doc-to-openapi/mapper/src/main/java/io/lonmstalker/tgkit/doc/mapper/MethodDocMapper.java
+++ b/telegram-doc-to-openapi/mapper/src/main/java/io/lonmstalker/tgkit/doc/mapper/MethodDocMapper.java
@@ -1,0 +1,15 @@
+package io.lonmstalker.tgkit.doc.mapper;
+
+import io.lonmstalker.tgkit.doc.scraper.MethodDoc;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Маппер между {@link MethodDoc} и {@link OperationInfo}.
+ */
+@Mapper
+public interface MethodDocMapper {
+  MethodDocMapper INSTANCE = Mappers.getMapper(MethodDocMapper.class);
+
+  OperationInfo toOperation(MethodDoc doc);
+}

--- a/telegram-doc-to-openapi/mapper/src/main/java/io/lonmstalker/tgkit/doc/mapper/OperationInfo.java
+++ b/telegram-doc-to-openapi/mapper/src/main/java/io/lonmstalker/tgkit/doc/mapper/OperationInfo.java
@@ -1,0 +1,6 @@
+package io.lonmstalker.tgkit.doc.mapper;
+
+/**
+ * Внутреннее представление метода Telegram API.
+ */
+public record OperationInfo(String name, String description) {}

--- a/telegram-doc-to-openapi/mapper/src/test/java/io/lonmstalker/tgkit/doc/mapper/MethodDocMapperTest.java
+++ b/telegram-doc-to-openapi/mapper/src/test/java/io/lonmstalker/tgkit/doc/mapper/MethodDocMapperTest.java
@@ -1,0 +1,15 @@
+package io.lonmstalker.tgkit.doc.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.lonmstalker.tgkit.doc.scraper.MethodDoc;
+import org.junit.jupiter.api.Test;
+
+class MethodDocMapperTest {
+  @Test
+  void mapsMethodDoc() {
+    MethodDoc doc = new MethodDoc("getMe", "desc");
+    OperationInfo info = MethodDocMapper.INSTANCE.toOperation(doc);
+    assertThat(info.name()).isEqualTo("getMe");
+  }
+}

--- a/telegram-doc-to-openapi/pom.xml
+++ b/telegram-doc-to-openapi/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.lonmstalker.tgkit</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>telegram-doc-to-openapi</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>scraper</module>
+        <module>mapper</module>
+        <module>emitter</module>
+        <module>cli</module>
+    </modules>
+</project>

--- a/telegram-doc-to-openapi/scraper/pom.xml
+++ b/telegram-doc-to-openapi/scraper/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.lonmstalker.tgkit</groupId>
+        <artifactId>telegram-doc-to-openapi</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>telegram-doc-to-openapi-scraper</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>${jsoup.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <!-- TEST -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/telegram-doc-to-openapi/scraper/src/main/java/io/lonmstalker/tgkit/doc/scraper/BotApiScraper.java
+++ b/telegram-doc-to-openapi/scraper/src/main/java/io/lonmstalker/tgkit/doc/scraper/BotApiScraper.java
@@ -1,0 +1,41 @@
+package io.lonmstalker.tgkit.doc.scraper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+
+/**
+ * Скачивает официальную документацию Telegram Bot API и парсит её как HTML.
+ */
+public class BotApiScraper extends HtmlDocScraper {
+  private static final URI DEFAULT_URI = URI.create("https://core.telegram.org/bots/api");
+
+  private final HttpClient client;
+  private final URI uri;
+
+  public BotApiScraper() {
+    this(HttpClient.newHttpClient(), DEFAULT_URI);
+  }
+
+  BotApiScraper(HttpClient client, URI uri) {
+    this.client = client;
+    this.uri = uri;
+  }
+
+  /** Загружает страницу API и возвращает список методов. */
+  public List<MethodDoc> fetch() {
+    HttpRequest request = HttpRequest.newBuilder(uri).GET().build();
+    try {
+      HttpResponse<InputStream> resp = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+      try (InputStream stream = resp.body()) {
+        return scrape(stream);
+      }
+    } catch (IOException | InterruptedException e) {
+      throw new IllegalStateException("Не удалось загрузить API", e);
+    }
+  }
+}

--- a/telegram-doc-to-openapi/scraper/src/main/java/io/lonmstalker/tgkit/doc/scraper/DocScraper.java
+++ b/telegram-doc-to-openapi/scraper/src/main/java/io/lonmstalker/tgkit/doc/scraper/DocScraper.java
@@ -1,0 +1,14 @@
+package io.lonmstalker.tgkit.doc.scraper;
+
+import java.io.InputStream;
+import java.util.List;
+
+/**
+ * Интерфейс парсера документации Telegram API.
+ */
+public interface DocScraper {
+  /**
+   * Читает содержимое и возвращает список методов.
+   */
+  List<MethodDoc> scrape(InputStream stream);
+}

--- a/telegram-doc-to-openapi/scraper/src/main/java/io/lonmstalker/tgkit/doc/scraper/HtmlDocScraper.java
+++ b/telegram-doc-to-openapi/scraper/src/main/java/io/lonmstalker/tgkit/doc/scraper/HtmlDocScraper.java
@@ -1,0 +1,32 @@
+package io.lonmstalker.tgkit.doc.scraper;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+/**
+ * Scraper, использующий Jsoup для разбора локального HTML.
+ */
+public class HtmlDocScraper implements DocScraper {
+  @Override
+  public List<MethodDoc> scrape(InputStream stream) {
+    Document doc;
+    try {
+      doc = Jsoup.parse(stream, null, "");
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Невозможно распарсить HTML", e);
+    }
+    Elements methods = doc.select("div.method");
+    return methods.stream().map(this::parseMethod).collect(Collectors.toList());
+  }
+
+  private MethodDoc parseMethod(Element el) {
+    String name = el.selectFirst("h3").text();
+    String desc = el.selectFirst("p").text();
+    return new MethodDoc(name, desc);
+  }
+}

--- a/telegram-doc-to-openapi/scraper/src/main/java/io/lonmstalker/tgkit/doc/scraper/MethodDoc.java
+++ b/telegram-doc-to-openapi/scraper/src/main/java/io/lonmstalker/tgkit/doc/scraper/MethodDoc.java
@@ -1,0 +1,9 @@
+package io.lonmstalker.tgkit.doc.scraper;
+
+/**
+ * Описание метода Telegram API.
+ *
+ * @param name        имя метода
+ * @param description описание
+ */
+public record MethodDoc(String name, String description) {}

--- a/telegram-doc-to-openapi/scraper/src/test/java/io/lonmstalker/tgkit/doc/scraper/BotApiScraperTest.java
+++ b/telegram-doc-to-openapi/scraper/src/test/java/io/lonmstalker/tgkit/doc/scraper/BotApiScraperTest.java
@@ -1,0 +1,40 @@
+package io.lonmstalker.tgkit.doc.scraper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class BotApiScraperTest {
+  @Test
+  void downloadsAndParses() throws IOException {
+    HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+    server.createContext("/bots/api", new TestHandler());
+    server.start();
+    URI uri = URI.create("http://localhost:" + server.getAddress().getPort() + "/bots/api");
+    BotApiScraper scraper = new BotApiScraper(HttpClient.newHttpClient(), uri);
+    List<MethodDoc> methods = scraper.fetch();
+    server.stop(0);
+    assertThat(methods).hasSize(1);
+    assertThat(methods.get(0).name()).isEqualTo("getMe");
+  }
+
+  private static class TestHandler implements HttpHandler {
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+      String html = "<div class='method'><h3>getMe</h3><p>desc</p></div>";
+      exchange.sendResponseHeaders(200, html.getBytes().length);
+      try (OutputStream os = exchange.getResponseBody()) {
+        os.write(html.getBytes());
+      }
+    }
+  }
+}

--- a/telegram-doc-to-openapi/scraper/src/test/java/io/lonmstalker/tgkit/doc/scraper/HtmlDocScraperTest.java
+++ b/telegram-doc-to-openapi/scraper/src/test/java/io/lonmstalker/tgkit/doc/scraper/HtmlDocScraperTest.java
@@ -1,0 +1,18 @@
+package io.lonmstalker.tgkit.doc.scraper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class HtmlDocScraperTest {
+  @Test
+  void parsesMethodsFromHtml() {
+    DocScraper scraper = new HtmlDocScraper();
+    InputStream in = getClass().getResourceAsStream("/sample.html");
+    List<MethodDoc> methods = scraper.scrape(in);
+    assertThat(methods).hasSize(2);
+    assertThat(methods.get(0).name()).isEqualTo("getMe");
+  }
+}

--- a/telegram-doc-to-openapi/scraper/src/test/resources/sample.html
+++ b/telegram-doc-to-openapi/scraper/src/test/resources/sample.html
@@ -1,0 +1,12 @@
+<html>
+<body>
+<div class="method">
+<h3>getMe</h3>
+<p>Returns basic information about the bot.</p>
+</div>
+<div class="method">
+<h3>sendMessage</h3>
+<p>Use this method to send text messages.</p>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- introduce new multi-module `telegram-doc-to-openapi`
- implement HTML and remote API scrapers
- provide mapper and emitter modules
- expose CLI with `--api` option
- document usage in README

## Testing
- `./mvnw -q -pl telegram-doc-to-openapi/cli test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.13 could not be resolved)*
- `./mvnw -q spotless:apply verify` *(fails: No plugin found for prefix 'spotless')*

------
https://chatgpt.com/codex/tasks/task_e_6855881fc5988325bcac1073ad681645