### PR TITLE
Integrate SpotBugs checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           java-version: 21
 
       - name: Maven verify
-        run: ./mvnw -B -pl testkit,core,observability,plugin,security,examples,api spotless:check checkstyle:check verify
+        run: ./mvnw -B -Pstrict -pl testkit,core,observability,plugin,security,examples,api spotless:check checkstyle:check verify
 
       - name: JaCoCo report
         run: ./mvnw -B jacoco:report
@@ -44,3 +44,8 @@ jobs:
         with:
           name: jacoco-report
           path: '**/target/site/jacoco'
+      - name: Upload SpotBugs
+        uses: actions/upload-artifact@v4
+        with:
+          name: spotbugs-report
+          path: '**/target/spotbugs*'

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
         <nullaway.version>0.12.7</nullaway.version>
         <errorprone-maven-plugin.version>2.38.0</errorprone-maven-plugin.version>
         <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
+        <spotbugs-maven-plugin.version>4.9.5</spotbugs-maven-plugin.version>
 
         <!-- TEST -->
         <h2.version>2.3.232</h2.version>
@@ -353,6 +354,11 @@
                     <artifactId>pitest-maven</artifactId>
                     <version>${pitest-maven-plugin.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-maven-plugin</artifactId>
+                    <version>${spotbugs-maven-plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -626,6 +632,33 @@
                                 <exclude>**/*Test.java</exclude>
                             </excludes>
                         </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>strict</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
+                        <configuration>
+                            <effort>Max</effort>
+                            <threshold>High</threshold>
+                            <failOnError>true</failOnError>
+                            <xmlOutput>true</xmlOutput>
+                            <htmlOutput>true</htmlOutput>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>spotbugs</goal>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
## Summary
- manage version for spotbugs plugin
- enable spotbugs in pluginManagement
- add strict profile with SpotBugs configuration
- update CI to run strict checks and upload SpotBugs artifacts

## Testing
- `./mvnw -Pstrict verify` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.13 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6855a03f4ed083259de8cd5f1b4ea218