### PR TITLE
Fix RNG reuse in TokenCipherImpl

### DIFF
--- a/core/src/main/java/io/lonmstalker/tgkit/core/crypto/TokenCipherImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/crypto/TokenCipherImpl.java
@@ -42,6 +42,7 @@ public class TokenCipherImpl implements TokenCipher {
   private static final String TRANSFORMATION = "AES/GCM/NoPadding";
   private static final int IV_LENGTH = 12;
   private static final int TAG_LENGTH = 128;
+  private static final SecureRandom RNG = new SecureRandom();
 
   private final SecretKeySpec key;
 
@@ -58,7 +59,7 @@ public class TokenCipherImpl implements TokenCipher {
   public @NonNull String encrypt(@NonNull String token) {
     try {
       byte[] iv = new byte[IV_LENGTH];
-      new SecureRandom().nextBytes(iv);
+      RNG.nextBytes(iv);
 
       Cipher cipher = Cipher.getInstance(TRANSFORMATION);
       cipher.init(Cipher.ENCRYPT_MODE, this.key, new GCMParameterSpec(TAG_LENGTH, iv));

--- a/core/src/test/java/io/lonmstalker/tgkit/core/crypto/TokenCipherImplTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/crypto/TokenCipherImplTest.java
@@ -52,4 +52,17 @@ public class TokenCipherImplTest {
     var cipher = new TokenCipherImpl("secretkey123456");
     assertThrows(BotApiException.class, () -> cipher.decrypt("boom"));
   }
+
+  @Test
+  void encrypt_returns_different_values_each_time() {
+    var cipher = new TokenCipherImpl("secretkey123456");
+    var token = "repeat";
+
+    var first = cipher.encrypt(token);
+    var second = cipher.encrypt(token);
+
+    assertNotEquals(first, second, "IV must ensure unique ciphertext");
+    assertEquals(token, cipher.decrypt(first));
+    assertEquals(token, cipher.decrypt(second));
+  }
 }


### PR DESCRIPTION
## Summary
- reuse a single SecureRandom instance for AES/GCM encryption
- ensure successive encrypt calls yield different ciphertexts

## Testing
- `./mvnw com.diffplug.spotless:spotless-maven-plugin:apply verify` *(fails: Could not transfer artifact com.diffplug.spotless:spotless-maven-plugin:pom:2.44.5)*
- `./mvnw -pl :core -q test-compile` *(fails: Could not transfer artifact org.jacoco:jacoco-maven-plugin:pom:0.8.13)*

------
https://chatgpt.com/codex/tasks/task_e_6855a05d71c88325a369028eadea0110