### PR TITLE
Fix resource loader and annotate API

### DIFF
--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/WebHookReceiver.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/WebHookReceiver.java
@@ -94,7 +94,7 @@ class WebHookReceiver extends TelegramWebhookBot implements AutoCloseable {
   }
 
   @Override
-  public String getBotPath() {
+  public @NonNull String getBotPath() {
     return token;
   }
 

--- a/core/src/main/java/io/lonmstalker/tgkit/core/resource/Loaders.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/resource/Loaders.java
@@ -29,7 +29,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 public final class Loaders {
   private Loaders() {}
 
-  public @NonNull ResourceLoader load(@NonNull String path) {
+  public static @NonNull ResourceLoader load(@NonNull String path) {
     if (path.startsWith("classpath:")) {
       return classpath(path.replace("classpath:", ""));
     }
@@ -37,7 +37,7 @@ public final class Loaders {
       return file(Path.of(path.replace("file:", "")));
     }
     if (path.startsWith("http://") || path.startsWith("https://")) {
-      return url(URI.create(path.replace("http://", "").replace("https://", "")));
+      return url(URI.create(path));
     }
     if (path.startsWith("jar:")) {
       String[] split = path.replace("jar:", "").split("!");

--- a/core/src/main/java/io/lonmstalker/tgkit/core/wizard/StepDefinition.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/wizard/StepDefinition.java
@@ -26,6 +26,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Описатель одного шага wizard’а.
@@ -149,15 +150,15 @@ public class StepDefinition<M, I, O> {
     return id;
   }
 
-  public List<Validator<O>> getValidators() {
+  public @NonNull List<Validator<O>> getValidators() {
     return validators;
   }
 
-  public List<MessageKey> getQuestionKeys() {
+  public @NonNull List<MessageKey> getQuestionKeys() {
     return questionKeys;
   }
 
-  public Function<BotRequest<?>, I> getParser() {
+  public @Nullable Function<BotRequest<?>, I> getParser() {
     return parser;
   }
 
@@ -165,7 +166,7 @@ public class StepDefinition<M, I, O> {
     this.parser = parser;
   }
 
-  public Validator<BotRequest<?>> getTypeValidator() {
+  public @Nullable Validator<BotRequest<?>> getTypeValidator() {
     return typeValidator;
   }
 
@@ -173,7 +174,7 @@ public class StepDefinition<M, I, O> {
     this.typeValidator = typeValidator;
   }
 
-  public BiConsumer<M, O> getSetter() {
+  public @Nullable BiConsumer<M, O> getSetter() {
     return setter;
   }
 
@@ -189,7 +190,7 @@ public class StepDefinition<M, I, O> {
     this.canBack = canBack;
   }
 
-  public BiConsumer<BotRequest<?>, M> getOnBack() {
+  public @Nullable BiConsumer<BotRequest<?>, M> getOnBack() {
     return onBack;
   }
 
@@ -205,7 +206,7 @@ public class StepDefinition<M, I, O> {
     this.canSkip = canSkip;
   }
 
-  public BiConsumer<BotRequest<?>, M> getOnSkip() {
+  public @Nullable BiConsumer<BotRequest<?>, M> getOnSkip() {
     return onSkip;
   }
 
@@ -221,7 +222,7 @@ public class StepDefinition<M, I, O> {
     this.canCancel = canCancel;
   }
 
-  public BiConsumer<BotRequest<?>, M> getOnCancel() {
+  public @Nullable BiConsumer<BotRequest<?>, M> getOnCancel() {
     return onCancel;
   }
 
@@ -229,7 +230,7 @@ public class StepDefinition<M, I, O> {
     this.onCancel = onCancel;
   }
 
-  public Function<M, String> getNextSupplier() {
+  public @NonNull Function<M, String> getNextSupplier() {
     return nextSupplier;
   }
 
@@ -237,7 +238,7 @@ public class StepDefinition<M, I, O> {
     this.nextSupplier = nextSupplier;
   }
 
-  public Duration getTimeout() {
+  public @Nullable Duration getTimeout() {
     return timeout;
   }
 
@@ -245,7 +246,7 @@ public class StepDefinition<M, I, O> {
     this.timeout = timeout;
   }
 
-  public MessageKey getReminderKey() {
+  public @Nullable MessageKey getReminderKey() {
     return reminderKey;
   }
 
@@ -253,7 +254,7 @@ public class StepDefinition<M, I, O> {
     this.reminderKey = reminderKey;
   }
 
-  public Predicate<M> getPreFinishChecker() {
+  public @Nullable Predicate<M> getPreFinishChecker() {
     return preFinishChecker;
   }
 
@@ -261,7 +262,7 @@ public class StepDefinition<M, I, O> {
     this.preFinishChecker = preFinishChecker;
   }
 
-  public String getPreFinishFailStepId() {
+  public @Nullable String getPreFinishFailStepId() {
     return preFinishFailStepId;
   }
 

--- a/core/src/main/java/io/lonmstalker/tgkit/core/wizard/Wizard.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/wizard/Wizard.java
@@ -39,7 +39,7 @@ public abstract class Wizard<M> {
   private BiConsumer<BotRequest<?>, M> onComplete;
   private final List<StepDefinition<M, ?, ?>> steps = new ArrayList<>();
 
-  public String getId() {
+  public @NonNull String getId() {
     return id;
   }
 


### PR DESCRIPTION
## Summary
- make `Loaders.load` static and preserve URI scheme
- mark webhook path getter non-null
- expose wizard id as non-null
- specify nullability for wizard step getters

## Testing
- `mvn` *(failed: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6855b56aafd48325980ada720dd60aeb