### PR TITLE
Fix typos in parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,7 +266,7 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <afrtifactId>maven-checkstyle-plugin</afrtifactId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>${checkstyle-maven-plugin.version}</version>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
## Summary
- fix typo in `pom.xml` plugin definition

## Testing
- `mvn -DskipTests=true validate`
- `mvn spotless:apply verify` *(fails: cannot find symbol WebhookServer)*

------
https://chatgpt.com/codex/tasks/task_e_6855e9c583b48325b43b7e06c7f29290