### PR TITLE
Add missing Javadocs

### DIFF
--- a/api/src/main/java/io/lonmstalker/tgkit/observability/ImmutableTag.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/observability/ImmutableTag.java
@@ -17,8 +17,15 @@ package io.lonmstalker.tgkit.observability;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 
+/** Неизменяемый тег. */
 public record ImmutableTag(String key, String value) implements Tag {
 
+  /**
+   * Создаёт тег с ключом и значением.
+   *
+   * @param key ключ
+   * @param value значение
+   */
   public ImmutableTag(@NonNull String key, @NonNull String value) {
     this.key = key;
     this.value = value;

--- a/api/src/main/java/io/lonmstalker/tgkit/observability/Span.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/observability/Span.java
@@ -35,5 +35,11 @@ public interface Span extends AutoCloseable {
    */
   void setTag(@NonNull String tag, @NonNull String value);
 
+  /**
+   * Завершает span без ошибки.
+   *
+   * @see AutoCloseable#close()
+   */
+  @Override
   void close();
 }

--- a/api/src/main/java/io/lonmstalker/tgkit/observability/Tag.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/observability/Tag.java
@@ -15,16 +15,38 @@
  */
 package io.lonmstalker.tgkit.observability;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/** Интерфейс тега метрики. */
 public interface Tag extends Comparable<Tag> {
+
+  /** Возвращает ключ тега. */
+  @NonNull
   String key();
 
+  /** Возвращает значение тега. */
+  @NonNull
   String value();
 
-  static Tag of(String key, String value) {
+  /**
+   * Создаёт неизменяемый тег.
+   *
+   * @param key ключ
+   * @param value значение
+   * @return новый тег
+   */
+  static Tag of(@NonNull String key, @NonNull String value) {
     return new ImmutableTag(key, value);
   }
 
-  default int compareTo(Tag o) {
+  /**
+   * Сравнивает теги по ключу.
+   *
+   * @param o другой тег
+   * @return результат сравнения
+   */
+  @Override
+  default int compareTo(@NonNull Tag o) {
     return this.key().compareTo(o.key());
   }
 }


### PR DESCRIPTION
## Summary
- add russian Javadocs to observability interfaces
- keep blank lines per Google Java Style

## Testing
- `mvn -q -pl api checkstyle:check`

------
https://chatgpt.com/codex/tasks/task_e_6856094be96c8325b2cb362d15b432ae