### PR TITLE
Add Error Prone version property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <checkstyle-maven-plugin.version>3.6.0</checkstyle-maven-plugin.version>
         <checkstyle.version>10.25.0</checkstyle.version>
         <spotless-maven-plugin.version>2.44.5</spotless-maven-plugin.version>
+        <errorprone.version>2.27.1</errorprone.version>
         <revapi.version>0.28.2</revapi.version>
         <revapi-maven-plugin.version>0.15.1</revapi-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>


### PR DESCRIPTION
## Summary
- define `<errorprone.version>` in parent `pom.xml`

## Testing
- `mvn -Pstrict -pl api test-compile` *(fails: invalid flag -XepAllErrorsAsErrors)*
- `mvn spotless:apply verify` *(fails: compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856093faa108325b1060e5e9edfaf73