### PR TITLE
Fix interrupted exception handler

### DIFF
--- a/api/src/main/java/io/lonmstalker/tgkit/core/bot/TelegramSender.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/bot/TelegramSender.java
@@ -294,9 +294,6 @@ public class TelegramSender extends DefaultAbsSender implements AutoCloseable {
         } else {
           throw ex;
         }
-      } catch (InterruptedException ie) {
-        Thread.currentThread().interrupt();
-        throw new BotApiException(ie);
       }
     }
   }


### PR DESCRIPTION
## Summary
- remove outer `InterruptedException` catch in `TelegramSender`

## Testing
- `mvn spotless:apply verify` *(fails: could not resolve dependencies)*
- `mvn -pl :core -am test-compile` *(fails: compilation errors)*
- `java -jar core/target/*-full.jar --dry-run` *(fails: jar not found)*
- `mvn revapi:check`

------
https://chatgpt.com/codex/tasks/task_e_6856097d7d2c8325abdbea755c441d23