### PR TITLE
Refactor parent groupId to property

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.lonmstalker.tgkit</groupId>
+        <groupId>${tgkit.groupId}</groupId>
         <artifactId>parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.lonmstalker.tgkit</groupId>
+        <groupId>${tgkit.groupId}</groupId>
         <artifactId>parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -13,12 +13,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.lonmstalker.tgkit</groupId>
+            <groupId>${tgkit.groupId}</groupId>
             <artifactId>api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.lonmstalker.tgkit</groupId>
+            <groupId>${tgkit.groupId}</groupId>
             <artifactId>testkit</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.lonmstalker.tgkit</groupId>
+        <groupId>${tgkit.groupId}</groupId>
         <artifactId>parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -13,18 +13,18 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.lonmstalker.tgkit</groupId>
+            <groupId>${tgkit.groupId}</groupId>
             <artifactId>core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.lonmstalker.tgkit</groupId>
+            <groupId>${tgkit.groupId}</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.lonmstalker.tgkit</groupId>
+            <groupId>${tgkit.groupId}</groupId>
             <artifactId>observability</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>

--- a/codec/json-codec-dsljson/pom.xml
+++ b/codec/json-codec-dsljson/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.lonmstalker.tgkit</groupId>
+        <groupId>${tgkit.groupId}</groupId>
         <artifactId>codec</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -13,7 +13,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.lonmstalker.tgkit</groupId>
+            <groupId>${tgkit.groupId}</groupId>
             <artifactId>json-codec-spi</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -42,7 +42,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.lonmstalker.tgkit</groupId>
+            <groupId>${tgkit.groupId}</groupId>
             <artifactId>api</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/codec/json-codec-spi/pom.xml
+++ b/codec/json-codec-spi/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.lonmstalker.tgkit</groupId>
+        <groupId>${tgkit.groupId}</groupId>
         <artifactId>codec</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>

--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.lonmstalker.tgkit</groupId>
+        <groupId>${tgkit.groupId}</groupId>
         <artifactId>parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.lonmstalker.tgkit</groupId>
+        <groupId>${tgkit.groupId}</groupId>
         <artifactId>parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -15,12 +15,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.lonmstalker.tgkit</groupId>
+            <groupId>${tgkit.groupId}</groupId>
             <artifactId>api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.lonmstalker.tgkit</groupId>
+            <groupId>${tgkit.groupId}</groupId>
             <artifactId>validator</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/doc2oas/pom.xml
+++ b/doc2oas/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.lonmstalker.tgkit</groupId>
+        <groupId>${tgkit.groupId}</groupId>
         <artifactId>parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>

--- a/examples/observability-demo/pom.xml
+++ b/examples/observability-demo/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.lonmstalker.tgkit</groupId>
+        <groupId>${tgkit.groupId}</groupId>
         <artifactId>examples</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -13,12 +13,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.lonmstalker.tgkit</groupId>
+            <groupId>${tgkit.groupId}</groupId>
             <artifactId>core</artifactId>
             <version>0.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>io.lonmstalker.tgkit</groupId>
+            <groupId>${tgkit.groupId}</groupId>
             <artifactId>observability</artifactId>
             <version>0.0.1-SNAPSHOT</version>
         </dependency>

--- a/examples/plugin-demo/app/pom.xml
+++ b/examples/plugin-demo/app/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.lonmstalker.tgkit</groupId>
+        <groupId>${tgkit.groupId}</groupId>
         <artifactId>plugin-demo</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -16,7 +16,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.lonmstalker.tgkit</groupId>
+            <groupId>${tgkit.groupId}</groupId>
             <artifactId>plugin</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/examples/plugin-demo/plugin-example/pom.xml
+++ b/examples/plugin-demo/plugin-example/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.lonmstalker.tgkit</groupId>
+        <groupId>${tgkit.groupId}</groupId>
         <artifactId>plugin-demo</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -16,7 +16,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.lonmstalker.tgkit</groupId>
+            <groupId>${tgkit.groupId}</groupId>
             <artifactId>plugin</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/examples/plugin-demo/pom.xml
+++ b/examples/plugin-demo/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.lonmstalker.tgkit</groupId>
+        <groupId>${tgkit.groupId}</groupId>
         <artifactId>examples</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.lonmstalker.tgkit</groupId>
+        <groupId>${tgkit.groupId}</groupId>
         <artifactId>parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -28,7 +28,7 @@
                     <fork>true</fork>
                     <annotationProcessorPaths>
                         <path>
-                            <groupId>io.lonmstalker.tgkit</groupId>
+                            <groupId>${tgkit.groupId}</groupId>
                             <artifactId>core</artifactId>
                             <version>${project.version}</version>
                         </path>

--- a/examples/simple-bot/pom.xml
+++ b/examples/simple-bot/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.lonmstalker.tgkit</groupId>
+        <groupId>${tgkit.groupId}</groupId>
         <artifactId>examples</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -13,7 +13,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.lonmstalker.tgkit</groupId>
+            <groupId>${tgkit.groupId}</groupId>
             <artifactId>core</artifactId>
             <version>0.0.1-SNAPSHOT</version>
         </dependency>

--- a/examples/testkit-demo/pom.xml
+++ b/examples/testkit-demo/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.lonmstalker.tgkit</groupId>
+        <groupId>${tgkit.groupId}</groupId>
         <artifactId>examples</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -13,12 +13,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.lonmstalker.tgkit</groupId>
+            <groupId>${tgkit.groupId}</groupId>
             <artifactId>core</artifactId>
             <version>0.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>io.lonmstalker.tgkit</groupId>
+            <groupId>${tgkit.groupId}</groupId>
             <artifactId>testkit</artifactId>
             <version>0.0.1-SNAPSHOT</version>
             <scope>test</scope>

--- a/observability/pom.xml
+++ b/observability/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.lonmstalker.tgkit</groupId>
+        <groupId>${tgkit.groupId}</groupId>
         <artifactId>parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -13,7 +13,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.lonmstalker.tgkit</groupId>
+            <groupId>${tgkit.groupId}</groupId>
             <artifactId>core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.lonmstalker.tgkit</groupId>
+        <groupId>${tgkit.groupId}</groupId>
         <artifactId>parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -13,17 +13,17 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.lonmstalker.tgkit</groupId>
+            <groupId>${tgkit.groupId}</groupId>
             <artifactId>core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.lonmstalker.tgkit</groupId>
+            <groupId>${tgkit.groupId}</groupId>
             <artifactId>observability</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.lonmstalker.tgkit</groupId>
+            <groupId>${tgkit.groupId}</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.lonmstalker.tgkit</groupId>
+    <groupId>${tgkit.groupId}</groupId>
     <artifactId>parent</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
@@ -26,6 +26,7 @@
     </modules>
 
     <properties>
+        <tgkit.groupId>io.lonmstalker.tgkit</tgkit.groupId>
         <revision>0.0.1-SNAPSHOT</revision>
         <previousRevision>0.0.0</previousRevision>
         <maven.compiler.release>21</maven.compiler.release>

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.lonmstalker.tgkit</groupId>
+        <groupId>${tgkit.groupId}</groupId>
         <artifactId>parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -13,7 +13,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.lonmstalker.tgkit</groupId>
+            <groupId>${tgkit.groupId}</groupId>
             <artifactId>core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/testkit/pom.xml
+++ b/testkit/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.lonmstalker.tgkit</groupId>
+        <groupId>${tgkit.groupId}</groupId>
         <artifactId>parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -17,7 +17,7 @@
             <artifactId>undertow-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.lonmstalker.tgkit</groupId>
+            <groupId>${tgkit.groupId}</groupId>
             <artifactId>api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.lonmstalker.tgkit</groupId>
+        <groupId>${tgkit.groupId}</groupId>
         <artifactId>parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
@@ -14,7 +14,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.lonmstalker.tgkit</groupId>
+            <groupId>${tgkit.groupId}</groupId>
             <artifactId>api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/webhook/pom.xml
+++ b/webhook/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.lonmstalker.tgkit</groupId>
+        <groupId>${tgkit.groupId}</groupId>
         <artifactId>parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -13,7 +13,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.lonmstalker.tgkit</groupId>
+            <groupId>${tgkit.groupId}</groupId>
             <artifactId>core</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -45,7 +45,7 @@
 
         <!-- TEST -->
         <dependency>
-            <groupId>io.lonmstalker.tgkit</groupId>
+            <groupId>${tgkit.groupId}</groupId>
             <artifactId>testkit</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>


### PR DESCRIPTION
## Summary
- define new `tgkit.groupId` property for the whole build
- use `${tgkit.groupId}` for project groupId, parents and inter‑module dependencies

## Testing
- `mvn -q spotless:apply verify` *(fails: cannot find symbol in api module)*

------
https://chatgpt.com/codex/tasks/task_e_68567a68d57c8325b559fb3371e8f104