### PR TITLE
Fix groupId docs to io.github.tgkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 ```xml
 <dependency>
-    <groupId>io.lonmstalker.tgkit</groupId>
+    <groupId>io.github.tgkit</groupId>
     <artifactId>core</artifactId>
     <version>0.0.1-SNAPSHOT</version>
 </dependency>
@@ -53,14 +53,14 @@
 <annotationProcessorPaths>
 ...
     <path>
-        <groupId>io.lonmstalker.tgkit</groupId>
+        <groupId>io.github.tgkit</groupId>
         <artifactId>core</artifactId>
         <version>${project.version}</version>
     </path>
 ...
 <annotationProcessors>
     <annotationProcessor>
-        io.lonmstalker.tgkit.core.processor.BotHandlerProcessor
+        io.github.tgkit.core.processor.BotHandlerProcessor
     </annotationProcessor>
 ...
 </plugin>
@@ -71,7 +71,7 @@
 <summary>Gradle Kotlin DSL</summary>
 
 ```kotlin 
-implementation("io.lonmstalker.tgkit:core:0.0.1-SNAPSHOT")
+implementation("io.github.tgkit:core:0.0.1-SNAPSHOT")
 ```
 
 </details>
@@ -81,7 +81,7 @@ implementation("io.lonmstalker.tgkit:core:0.0.1-SNAPSHOT")
 
 ```xml
 <dependency>
-    <groupId>io.lonmstalker.tgkit</groupId>
+    <groupId>io.github.tgkit</groupId>
     <artifactId>testkit</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <scope>test</scope>
@@ -89,7 +89,7 @@ implementation("io.lonmstalker.tgkit:core:0.0.1-SNAPSHOT")
 ```
 
 ```kotlin
-testImplementation("io.lonmstalker.tgkit:testkit:0.0.1-SNAPSHOT")
+testImplementation("io.github.tgkit:testkit:0.0.1-SNAPSHOT")
 ```
 
 </details>
@@ -99,7 +99,7 @@ testImplementation("io.lonmstalker.tgkit:testkit:0.0.1-SNAPSHOT")
 
 ```xml
 <dependency>
-    <groupId>io.lonmstalker.tgkit</groupId>
+    <groupId>io.github.tgkit</groupId>
     <artifactId>boot</artifactId>
     <version>0.0.1-SNAPSHOT</version>
 </dependency>

--- a/api/README.md
+++ b/api/README.md
@@ -8,7 +8,7 @@
 
 ```xml
 <dependency>
-  <groupId>io.lonmstalker.tgkit</groupId>
+  <groupId>io.github.tgkit</groupId>
   <artifactId>api</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 </dependency>

--- a/boot/README.md
+++ b/boot/README.md
@@ -7,7 +7,7 @@
 
 ```xml
 <dependency>
-    <groupId>io.lonmstalker.tgkit</groupId>
+    <groupId>io.github.tgkit</groupId>
     <artifactId>boot</artifactId>
     <version>0.0.1-SNAPSHOT</version>
 </dependency>

--- a/docs/LOADER_README.md
+++ b/docs/LOADER_README.md
@@ -142,7 +142,7 @@ public final class RateLimitBotCommandFactory implements BotCommandFactory<RateL
 ```
 
 Подключение:
-```META-INF/services/io.lonmstalker.tgkit.core.loader.BotCommandFactory```
+```META-INF/services/io.github.tgkit.core.loader.BotCommandFactory```
 
 ---
 

--- a/docs/TESTKIT_README.md
+++ b/docs/TESTKIT_README.md
@@ -11,7 +11,7 @@
 
 ```xml
 <dependency>
-    <groupId>io.lonmstalker.tgkit</groupId>
+    <groupId>io.github.tgkit</groupId>
     <artifactId>testkit</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <scope>test</scope>
@@ -22,7 +22,7 @@
 <summary>Gradle Kotlin DSL</summary>
 
 ```kotlin
-testImplementation("io.lonmstalker.tgkit:testkit:0.0.1-SNAPSHOT")
+testImplementation("io.github.tgkit:testkit:0.0.1-SNAPSHOT")
 ```
 </details>
 


### PR DESCRIPTION
## Summary
- update README instructions to use `io.github.tgkit`
- fix TestKit, Boot and API docs accordingly
- clean up loader documentation

## Testing
- `mvn -q spotless:apply verify` *(fails: cannot find symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68567a7ffdd08325b033c6e901126620