### PR TITLE
Update doc2oas README and build

### DIFF
--- a/doc2oas/README.md
+++ b/doc2oas/README.md
@@ -1,6 +1,6 @@
 # Модуль doc2oas
 
-Утилита преобразует документацию Telegram Bot API в спецификацию OpenAPI и генерирует SDK.
+Утилита конвертирует документацию Telegram Bot API в спецификацию OpenAPI и генерирует SDK.
 
 ## Зачем
 Док позволяет синхронизировать типы и методы Telegram с вашим кодом всего одной командой.
@@ -10,9 +10,23 @@
 2. `OpenApiEmitter` строит `openapi.yaml`, проверяя его парсером.
 3. `GeneratorCli` запускает [OpenAPI Generator](https://github.com/OpenAPITools/openapi-generator).
 
+## Сборка
+```bash
+mvn -pl doc2oas package
+```
+
+## Запуск
+```bash
+java -cp doc2oas/target/doc2oas-<version>.jar io.lonmstalker.tgkit.doc.cli.DocCli --help
+# либо
+java -jar doc2oas/target/doc2oas-<version>-shaded.jar --help
+```
+
 ## Пошаговый пример
 ```bash
-java -jar doc2oas.jar --api --output build/openapi/telegram.yaml
-java -cp doc2oas.jar io.lonmstalker.tgkit.doc.generator.GeneratorCli \
-  --spec build/openapi/telegram.yaml --target build/sdk
+java -cp doc2oas/target/doc2oas-<version>.jar io.lonmstalker.tgkit.doc.cli.DocCli --api --output build/openapi/telegram.yaml
+java -cp doc2oas/target/doc2oas-<version>.jar io.lonmstalker.tgkit.doc.generator.GeneratorCli \
+  --spec build/openapi/telegram.yaml \
+  --target build/sdk \
+  --language java
 ```

--- a/doc2oas/pom.xml
+++ b/doc2oas/pom.xml
@@ -116,6 +116,14 @@
                         <goals>
                             <goal>shade</goal>
                         </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>io.lonmstalker.tgkit.doc.cli.DocCli</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
## Summary
- describe doc2oas module purpose and add build instructions
- show correct CLI usage in README
- make jar self-executable via maven-shade-plugin

## Testing
- `mvn -Drevapi.skip=true -pl doc2oas spotless:apply verify`

------
https://chatgpt.com/codex/tasks/task_e_68567d36f138832582fba74faae36d8a