### PR TITLE
Fix package names in docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,8 +95,8 @@ telegram-bot-lib/
 | telegram-bot-core    | 21          | telegram.bot.core              | public             | ≥ 90 %   | Revapi, NullAway |
 | testkit              | 21          | —                              | incubating         | ≥ 95 %   | JUnit 5          |
 | telegram-bot-plugins | 21          | разные                         | incubating         | ≥ 80 %   | SPI loader       |
-| validator            | 21          | io.lonmstalker.tgkit.validator | public             | ≥ 90 %   | —                |
-| boot                 | 21          | io.lonmstalker.tgkit.boot      | incubating         | ≥ 90 %   | Spring Boot      |
+| validator            | 21          | io.github.tgkit.validator | public             | ≥ 90 %   | —                |
+| boot                 | 21          | io.github.tgkit.boot      | incubating         | ≥ 90 %   | Spring Boot      |
 
 ## 8. Проверка качества ✅
 

--- a/doc2oas/README.md
+++ b/doc2oas/README.md
@@ -28,7 +28,7 @@ mvn -pl doc2oas package
 ## Запуск
 
 ```bash
-java -cp doc2oas/target/doc2oas-<version>.jar io.lonmstalker.tgkit.doc.cli.DocCli --help
+java -cp doc2oas/target/doc2oas-<version>.jar io.github.tgkit.doc.cli.DocCli --help
 # либо
 java -jar doc2oas/target/doc2oas-<version>-shaded.jar --help
 ```
@@ -36,8 +36,8 @@ java -jar doc2oas/target/doc2oas-<version>-shaded.jar --help
 ## Пошаговый пример
 
 ```bash
-java -cp doc2oas/target/doc2oas-<version>.jar io.lonmstalker.tgkit.doc.cli.DocCli --api --output build/openapi/telegram.yaml
-java -cp doc2oas/target/doc2oas-<version>.jar io.lonmstalker.tgkit.doc.generator.GeneratorCli \
+java -cp doc2oas/target/doc2oas-<version>.jar io.github.tgkit.doc.cli.DocCli --api --output build/openapi/telegram.yaml
+java -cp doc2oas/target/doc2oas-<version>.jar io.github.tgkit.doc.generator.GeneratorCli \
   --spec build/openapi/telegram.yaml \
   --target build/sdk \
   --language java

--- a/docs/DSL_README.md
+++ b/docs/DSL_README.md
@@ -11,7 +11,7 @@ BotDSL.msg(ctx, "Привет, мир!").disableNotif().send();
 ## 📦 Установка
 ```xml
 <dependency>
-  <groupId>io.lonmstalker</groupId>
+<groupId>io.github.tgkit</groupId>
   <artifactId>tgkit-dsl</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 </dependency>

--- a/examples/simple-bot/bot.json
+++ b/examples/simple-bot/bot.json
@@ -3,5 +3,5 @@
   "base-url": "https://api.telegram.org/bot",
   "bot-group": "sample",
   "requests-per-second": 30,
-  "packages": ["io.lonmstalker.examples.simplebot"]
+  "packages": ["io.github.examples.simplebot"]
 }

--- a/examples/simple-bot/bot.yaml
+++ b/examples/simple-bot/bot.yaml
@@ -3,4 +3,4 @@ base-url: "https://api.telegram.org/bot"
 bot-group: "sample"
 requests-per-second: 30
 packages:
-  - io.lonmstalker.examples.simplebot
+  - io.github.examples.simplebot

--- a/security/README.md
+++ b/security/README.md
@@ -23,7 +23,7 @@ BotAdapter adapter = BotAdapterImpl.builder()
         .build();
 
 Bot bot = BotFactory.INSTANCE.from("TOKEN", cfg, adapter,
-        "io.lonmstalker.examples.simplebot");
+        "io.github.examples.simplebot");
         bot.start();
 );
 ```


### PR DESCRIPTION
## Summary
- update groupId in docs/DSL_README.md
- update CLI class packages in doc2oas/README.md
- update example package in security README
- adjust example config for simple bot
- update module table in AGENTS.md

## Testing
- `mvn -q spotless:apply verify` *(fails: cannot find symbol WebhookServer)*

------
https://chatgpt.com/codex/tasks/task_e_6856819b31f4832591aeb915c2641550