### PR TITLE
Update example package paths

### DIFF
--- a/examples/observability-demo/src/main/java/io/github/examples/observability/ObservabilityDemoApplication.java
+++ b/examples/observability-demo/src/main/java/io/github/examples/observability/ObservabilityDemoApplication.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.lonmstalker.tgkit.examples.observability;
+package io.github.examples.observability;
 
 import io.lonmstalker.observability.BotObservability;
 import io.lonmstalker.observability.ObservabilityInterceptor;
@@ -38,8 +38,7 @@ public class ObservabilityDemoApplication {
             .build();
 
     BotAdapter adapter = BotAdapterImpl.builder().config(config).build();
-    Bot bot =
-        BotFactory.INSTANCE.from("TOKEN", config, adapter, "io.lonmstalker.examples.simplebot");
+    Bot bot = BotFactory.INSTANCE.from("TOKEN", config, adapter, "io.github.examples.simplebot");
 
     bot.start();
   }

--- a/examples/simple-bot/bot.json
+++ b/examples/simple-bot/bot.json
@@ -3,5 +3,5 @@
   "base-url": "https://api.telegram.org/bot",
   "bot-group": "sample",
   "requests-per-second": 30,
-  "packages": ["io.lonmstalker.examples.simplebot"]
+  "packages": ["io.github.examples.simplebot"]
 }

--- a/examples/simple-bot/bot.yaml
+++ b/examples/simple-bot/bot.yaml
@@ -3,4 +3,4 @@ base-url: "https://api.telegram.org/bot"
 bot-group: "sample"
 requests-per-second: 30
 packages:
-  - io.lonmstalker.examples.simplebot
+  - io.github.examples.simplebot

--- a/examples/simple-bot/src/main/java/io/github/examples/simplebot/SimpleBotApplication.java
+++ b/examples/simple-bot/src/main/java/io/github/examples/simplebot/SimpleBotApplication.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.lonmstalker.examples.simplebot;
+package io.github.examples.simplebot;
 
 import io.lonmstalker.tgkit.core.TelegramBot;
 import io.lonmstalker.tgkit.core.init.BotCoreInitializer;

--- a/examples/simple-bot/src/main/java/io/github/examples/simplebot/SimpleBotCommands.java
+++ b/examples/simple-bot/src/main/java/io/github/examples/simplebot/SimpleBotCommands.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.lonmstalker.examples.simplebot;
+package io.github.examples.simplebot;
 
 import io.lonmstalker.tgkit.core.BotRequest;
 import io.lonmstalker.tgkit.core.BotRequestType;

--- a/examples/simple-bot/src/main/java/io/github/examples/simplebot/SimpleRoleProvider.java
+++ b/examples/simple-bot/src/main/java/io/github/examples/simplebot/SimpleRoleProvider.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.lonmstalker.examples.simplebot;
+package io.github.examples.simplebot;
 
 import static io.lonmstalker.tgkit.core.update.UpdateUtils.resolveChatId;
 import static io.lonmstalker.tgkit.core.update.UpdateUtils.resolveUserId;

--- a/examples/testkit-demo/src/test/java/io/github/examples/testkitdemo/PingCommandTest.java
+++ b/examples/testkit-demo/src/test/java/io/github/examples/testkitdemo/PingCommandTest.java
@@ -1,4 +1,4 @@
-package io.lonmstalker.examples.testkitdemo;
+package io.github.examples.testkitdemo;
 
 import io.lonmstalker.tgkit.testkit.TelegramBotTest;
 import io.lonmstalker.tgkit.testkit.UpdateInjector;

--- a/security/README.md
+++ b/security/README.md
@@ -23,7 +23,7 @@ BotAdapter adapter = BotAdapterImpl.builder()
         .build();
 
 Bot bot = BotFactory.INSTANCE.from("TOKEN", cfg, adapter,
-        "io.lonmstalker.examples.simplebot");
+        "io.github.examples.simplebot");
         bot.start();
 );
 ```


### PR DESCRIPTION
## Summary
- refactor example modules to use `io.github.examples` package
- update bot configuration files and security doc references

## Testing
- `mvn -q spotless:apply`
- `mvn -q verify -DskipTests` *(failed: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68568197e9c883259390a82658ee47e1