### PR TITLE
Fix JSON codec packages

### DIFF
--- a/codec/json-codec-dsljson/src/jmh/java/io/github/tgkit/json/dsljson/DslJsonCodecBenchmark.java
+++ b/codec/json-codec-dsljson/src/jmh/java/io/github/tgkit/json/dsljson/DslJsonCodecBenchmark.java
@@ -1,7 +1,7 @@
-package io.lonmstalker.tgkit.json.dsljson;
+package io.github.tgkit.json.dsljson;
 
 import io.lonmstalker.tgkit.core.bot.BotConfig;
-import io.lonmstalker.tgkit.json.JsonCodec;
+import io.github.tgkit.json.JsonCodec;
 import java.util.Locale;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;

--- a/codec/json-codec-dsljson/src/main/java/io/github/tgkit/json/dsljson/DslJsonCodec.java
+++ b/codec/json-codec-dsljson/src/main/java/io/github/tgkit/json/dsljson/DslJsonCodec.java
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.lonmstalker.tgkit.json.dsljson;
+package io.github.tgkit.json.dsljson;
 
 import com.dslplatform.json.DslJson;
 import com.dslplatform.json.JsonReader;
-import io.lonmstalker.tgkit.json.JsonCodec;
+import io.github.tgkit.json.JsonCodec;
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;

--- a/codec/json-codec-dsljson/src/main/resources/META-INF/services/io.github.tgkit.json.JsonCodec
+++ b/codec/json-codec-dsljson/src/main/resources/META-INF/services/io.github.tgkit.json.JsonCodec
@@ -1,0 +1,1 @@
+io.github.tgkit.json.dsljson.DslJsonCodec

--- a/codec/json-codec-dsljson/src/main/resources/META-INF/services/io.lonmstalker.tgkit.json.JsonCodec
+++ b/codec/json-codec-dsljson/src/main/resources/META-INF/services/io.lonmstalker.tgkit.json.JsonCodec
@@ -1,1 +1,0 @@
-io.lonmstalker.tgkit.json.dsljson.DslJsonCodec

--- a/codec/json-codec-dsljson/src/test/java/io/github/tgkit/json/dsljson/DslJsonCodecTest.java
+++ b/codec/json-codec-dsljson/src/test/java/io/github/tgkit/json/dsljson/DslJsonCodecTest.java
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.lonmstalker.tgkit.json.dsljson;
+package io.github.tgkit.json.dsljson;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.lonmstalker.tgkit.core.bot.BotConfig;
-import io.lonmstalker.tgkit.json.JsonCodec;
+import io.github.tgkit.json.JsonCodec;
 import java.util.Locale;
 import java.util.ServiceLoader;
 import org.junit.jupiter.api.Test;

--- a/codec/json-codec-spi/src/main/java/io/github/tgkit/json/JsonCodec.java
+++ b/codec/json-codec-spi/src/main/java/io/github/tgkit/json/JsonCodec.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.lonmstalker.tgkit.json;
+package io.github.tgkit.json;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;


### PR DESCRIPTION
## Summary
- rename `io.lonmstalker.tgkit.json.*` to `io.github.tgkit.json.*`
- update service descriptor path
- adjust tests and benchmarks

## Testing
- `mvn -q -pl codec/json-codec-spi,codec/json-codec-dsljson,api,webhook,observability spotless:apply verify` *(fails: package WebhookServer does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6856819509b88325b2961735114d48d3