### PR TITLE
Rename observability packages

### DIFF
--- a/api/src/main/java/io/lonmstalker/observability/MetricsCollector.java
+++ b/api/src/main/java/io/lonmstalker/observability/MetricsCollector.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.github.observability;
+package io.github.tgkit.observability;
 
 import io.github.tgkit.observability.Tags;
 import io.micrometer.core.instrument.Counter;

--- a/api/src/main/java/io/lonmstalker/tgkit/core/config/BotGlobalConfig.java
+++ b/api/src/main/java/io/lonmstalker/tgkit/core/config/BotGlobalConfig.java
@@ -17,8 +17,8 @@
 package io.github.tgkit.core.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.github.observability.MetricsCollector;
-import io.github.observability.impl.NoOpMetricsCollector;
+import io.github.tgkit.observability.MetricsCollector;
+import io.github.tgkit.observability.impl.NoOpMetricsCollector;
 import io.github.tgkit.core.dsl.MissingIdStrategy;
 import io.github.tgkit.core.dsl.feature_flags.FeatureFlags;
 import io.github.tgkit.core.event.BotEventBus;

--- a/boot/src/main/java/io/lonmstalker/tgkit/boot/BotAutoConfiguration.java
+++ b/boot/src/main/java/io/lonmstalker/tgkit/boot/BotAutoConfiguration.java
@@ -16,9 +16,9 @@
 
 package io.github.tgkit.boot;
 
-import io.github.observability.BotObservability;
-import io.github.observability.MetricsCollector;
-import io.github.observability.impl.NoOpMetricsCollector;
+import io.github.tgkit.observability.BotObservability;
+import io.github.tgkit.observability.MetricsCollector;
+import io.github.tgkit.observability.impl.NoOpMetricsCollector;
 import io.github.tgkit.security.init.BotSecurityInitializer;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotSessionImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotSessionImpl.java
@@ -18,7 +18,7 @@ package io.github.tgkit.core.bot;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.github.observability.MetricsCollector;
+import io.github.tgkit.observability.MetricsCollector;
 import io.github.tgkit.core.config.BotGlobalConfig;
 import io.github.tgkit.core.exception.BotApiException;
 import io.github.tgkit.observability.Tags;

--- a/core/src/main/java/io/lonmstalker/tgkit/core/init/BotCoreInitializer.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/init/BotCoreInitializer.java
@@ -17,7 +17,7 @@
 package io.github.tgkit.core.init;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.github.observability.impl.NoOpMetricsCollector;
+import io.github.tgkit.observability.impl.NoOpMetricsCollector;
 import io.github.tgkit.core.config.BotGlobalConfig;
 import io.github.tgkit.core.dsl.MissingIdStrategy;
 import io.github.tgkit.core.dsl.feature_flags.InMemoryFeatureFlags;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotSessionImplTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotSessionImplTest.java
@@ -18,8 +18,8 @@ package io.github.tgkit.core.bot;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import io.github.observability.BotObservability;
-import io.github.observability.MetricsCollector;
+import io.github.tgkit.observability.BotObservability;
+import io.github.tgkit.observability.MetricsCollector;
 import io.github.tgkit.core.config.BotGlobalConfig;
 import io.github.tgkit.testkit.TestBotBootstrap;
 import java.io.IOException;

--- a/examples/observability-demo/src/main/java/io/github/examples/observability/ObservabilityDemoApplication.java
+++ b/examples/observability-demo/src/main/java/io/github/examples/observability/ObservabilityDemoApplication.java
@@ -16,8 +16,8 @@
 
 package io.github.examples.observability;
 
-import io.github.observability.BotObservability;
-import io.github.observability.ObservabilityInterceptor;
+import io.github.tgkit.observability.BotObservability;
+import io.github.tgkit.observability.ObservabilityInterceptor;
 import io.github.tgkit.core.BotAdapter;
 import io.github.tgkit.core.bot.Bot;
 import io.github.tgkit.core.bot.BotAdapterImpl;

--- a/observability/src/main/java/io/lonmstalker/observability/BotObservability.java
+++ b/observability/src/main/java/io/lonmstalker/observability/BotObservability.java
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package io.github.observability;
+package io.github.tgkit.observability;
 
-import io.github.observability.impl.CompositeTracer;
-import io.github.observability.impl.MicrometerCollector;
-import io.github.observability.impl.NoOpTracer;
-import io.github.observability.impl.OTelTracer;
+import io.github.tgkit.observability.impl.CompositeTracer;
+import io.github.tgkit.observability.impl.MicrometerCollector;
+import io.github.tgkit.observability.impl.NoOpTracer;
+import io.github.tgkit.observability.impl.OTelTracer;
 import io.github.tgkit.observability.Tracer;
 import io.micrometer.prometheusmetrics.PrometheusConfig;
 import java.util.Arrays;

--- a/observability/src/main/java/io/lonmstalker/observability/LogContext.java
+++ b/observability/src/main/java/io/lonmstalker/observability/LogContext.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.github.observability;
+package io.github.tgkit.observability;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.MDC;

--- a/observability/src/main/java/io/lonmstalker/observability/ObservabilityInterceptor.java
+++ b/observability/src/main/java/io/lonmstalker/observability/ObservabilityInterceptor.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.github.observability;
+package io.github.tgkit.observability;
 
 import io.github.tgkit.core.BotRequest;
 import io.github.tgkit.core.BotResponse;

--- a/observability/src/main/java/io/lonmstalker/observability/impl/CompositeTracer.java
+++ b/observability/src/main/java/io/lonmstalker/observability/impl/CompositeTracer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.github.observability.impl;
+package io.github.tgkit.observability.impl;
 
 import io.github.tgkit.observability.Span;
 import io.github.tgkit.observability.Tags;

--- a/observability/src/main/java/io/lonmstalker/observability/impl/MicrometerCollector.java
+++ b/observability/src/main/java/io/lonmstalker/observability/impl/MicrometerCollector.java
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package io.github.observability.impl;
+package io.github.tgkit.observability.impl;
 
-import io.github.observability.MetricsCollector;
+import io.github.tgkit.observability.MetricsCollector;
 import io.github.tgkit.core.exception.BotApiException;
 import io.github.tgkit.observability.Tags;
 import io.micrometer.core.instrument.Counter;

--- a/observability/src/main/java/io/lonmstalker/observability/impl/NoOpMetricsCollector.java
+++ b/observability/src/main/java/io/lonmstalker/observability/impl/NoOpMetricsCollector.java
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package io.github.observability.impl;
+package io.github.tgkit.observability.impl;
 
-import io.github.observability.MetricsCollector;
+import io.github.tgkit.observability.MetricsCollector;
 import io.github.tgkit.observability.Tags;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;

--- a/observability/src/main/java/io/lonmstalker/observability/impl/NoOpTracer.java
+++ b/observability/src/main/java/io/lonmstalker/observability/impl/NoOpTracer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.github.observability.impl;
+package io.github.tgkit.observability.impl;
 
 import io.github.tgkit.observability.Span;
 import io.github.tgkit.observability.Tags;

--- a/observability/src/main/java/io/lonmstalker/observability/impl/OTelTracer.java
+++ b/observability/src/main/java/io/lonmstalker/observability/impl/OTelTracer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.github.observability.impl;
+package io.github.tgkit.observability.impl;
 
 import io.github.tgkit.observability.Span;
 import io.github.tgkit.observability.Tag;

--- a/observability/src/main/java/io/lonmstalker/observability/impl/PrometheusMetricsServer.java
+++ b/observability/src/main/java/io/lonmstalker/observability/impl/PrometheusMetricsServer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.github.observability.impl;
+package io.github.tgkit.observability.impl;
 
 import io.github.tgkit.observability.ClosableMetricsServer;
 import io.prometheus.client.CollectorRegistry;

--- a/observability/src/main/java/io/lonmstalker/observability/package-info.java
+++ b/observability/src/main/java/io/lonmstalker/observability/package-info.java
@@ -1,8 +1,8 @@
 /**
  * Инструменты наблюдаемости: метрики и трассировки.
  *
- * <p>Содержит {@link io.github.observability.ObservabilityInterceptor} и утилиты из {@link
- * io.github.observability.BotObservability}.
+ * <p>Содержит {@link io.github.tgkit.observability.ObservabilityInterceptor} и утилиты из {@link
+ * io.github.tgkit.observability.BotObservability}.
  *
  * <p>Пример подключения:
  *
@@ -15,4 +15,4 @@
  * }</pre>
  */
 
-package io.github.observability;
+package io.github.tgkit.observability;

--- a/observability/src/main/java/module-info.java
+++ b/observability/src/main/java/module-info.java
@@ -23,7 +23,7 @@ module io.github.tgkit.observability {
   requires io.micrometer.registry.prometheus;
   requires io.prometheus.simpleclient_httpserver;
 
-  exports io.github.observability;
-  exports io.github.observability.impl to
+  exports io.github.tgkit.observability;
+  exports io.github.tgkit.observability.impl to
       io.github.tgkit.plugin;
 }

--- a/observability/src/test/java/io/lonmstalker/observability/BotAdapterCleanupTest.java
+++ b/observability/src/test/java/io/lonmstalker/observability/BotAdapterCleanupTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.github.observability;
+package io.github.tgkit.observability;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;

--- a/observability/src/test/java/io/lonmstalker/observability/CompositeTracerTest.java
+++ b/observability/src/test/java/io/lonmstalker/observability/CompositeTracerTest.java
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package io.github.observability;
+package io.github.tgkit.observability;
 
 import static io.github.tgkit.observability.Tags.*;
 import static org.mockito.Mockito.*;
 
-import io.github.observability.impl.CompositeTracer;
+import io.github.tgkit.observability.impl.CompositeTracer;
 import io.github.tgkit.observability.Span;
 import io.github.tgkit.observability.Tag;
 import io.github.tgkit.observability.Tags;

--- a/observability/src/test/java/io/lonmstalker/observability/MetricsServerLifecycleTest.java
+++ b/observability/src/test/java/io/lonmstalker/observability/MetricsServerLifecycleTest.java
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package io.github.observability;
+package io.github.tgkit.observability;
 
-import io.github.observability.impl.PrometheusMetricsServer;
+import io.github.tgkit.observability.impl.PrometheusMetricsServer;
 import java.net.ServerSocket;
 import org.junit.jupiter.api.*;
 

--- a/observability/src/test/java/io/lonmstalker/observability/ObservabilityInterceptorTest.java
+++ b/observability/src/test/java/io/lonmstalker/observability/ObservabilityInterceptorTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.github.observability;
+package io.github.tgkit.observability;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;

--- a/webhook/src/main/java/io/lonmstalker/tgkit/webhook/WebhookServer.java
+++ b/webhook/src/main/java/io/lonmstalker/tgkit/webhook/WebhookServer.java
@@ -17,7 +17,7 @@
 package io.github.tgkit.webhook;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.github.observability.MetricsCollector;
+import io.github.tgkit.observability.MetricsCollector;
 import io.github.tgkit.core.bot.WebHookReceiver;
 import io.github.tgkit.core.config.BotGlobalConfig;
 import io.github.tgkit.observability.Tags;

--- a/webhook/src/test/java/io/lonmstalker/tgkit/webhook/WebhookServerTest.java
+++ b/webhook/src/test/java/io/lonmstalker/tgkit/webhook/WebhookServerTest.java
@@ -19,8 +19,8 @@ package io.github.tgkit.webhook;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.github.observability.BotObservability;
-import io.github.observability.MetricsCollector;
+import io.github.tgkit.observability.BotObservability;
+import io.github.tgkit.observability.MetricsCollector;
 import io.github.tgkit.core.BotCommand;
 import io.github.tgkit.core.BotRequest;
 import io.github.tgkit.core.BotRequestType;


### PR DESCRIPTION
## Summary
- rename old `io.github.observability` packages to `io.github.tgkit.observability`
- update imports and module descriptors accordingly

## Testing
- `mvn -q verify` *(fails: format violations)*

------
https://chatgpt.com/codex/tasks/task_e_68568aa878f88325bb3afcea8a895edc