### PR TITLE
Update core dependency to tgkit-api

### DIFF
--- a/codec/json-codec-dsljson/src/jmh/java/io/github/tgkit/json/dsljson/DslJsonCodecBenchmark.java
+++ b/codec/json-codec-dsljson/src/jmh/java/io/github/tgkit/json/dsljson/DslJsonCodecBenchmark.java
@@ -1,6 +1,6 @@
 package io.github.tgkit.json.dsljson;
 
-import io.github.tgkit.core.bot.BotConfig;
+import io.github.tgkit.internal.bot.BotConfig;
 import io.github.tgkit.json.JsonCodec;
 import java.util.Locale;
 import org.openjdk.jmh.annotations.Benchmark;

--- a/codec/json-codec-dsljson/src/test/java/io/github/tgkit/json/dsljson/DslJsonCodecTest.java
+++ b/codec/json-codec-dsljson/src/test/java/io/github/tgkit/json/dsljson/DslJsonCodecTest.java
@@ -17,7 +17,7 @@ package io.github.tgkit.json.dsljson;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.github.tgkit.core.bot.BotConfig;
+import io.github.tgkit.internal.bot.BotConfig;
 import io.github.tgkit.json.JsonCodec;
 import java.util.Locale;
 import java.util.ServiceLoader;

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,7 +16,7 @@
     <dependencies>
         <dependency>
             <groupId>io.github.tgkit</groupId>
-            <artifactId>api</artifactId>
+            <artifactId>tgkit-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -28,10 +28,16 @@ module io.github.tgkit.core {
   requires jedis;
   requires io.netty.transport;
 
-  exports io.github.tgkit.internal.loader to io.github.tgkit.plugin;
-  exports io.github.tgkit.internal.bot to io.github.tgkit.plugin;
-  exports io.github.tgkit.internal.config to io.github.tgkit.plugin;
-  exports io.github.tgkit.internal.dsl.feature_flags to io.github.tgkit.plugin;
-  exports io.github.tgkit.internal.event to io.github.tgkit.plugin;
-  exports io.github.tgkit.internal.ttl to io.github.tgkit.plugin;
+  exports io.github.tgkit.internal.loader to
+      io.github.tgkit.plugin;
+  exports io.github.tgkit.internal.bot to
+      io.github.tgkit.plugin;
+  exports io.github.tgkit.internal.config to
+      io.github.tgkit.plugin;
+  exports io.github.tgkit.internal.dsl.feature_flags to
+      io.github.tgkit.plugin;
+  exports io.github.tgkit.internal.event to
+      io.github.tgkit.plugin;
+  exports io.github.tgkit.internal.ttl to
+      io.github.tgkit.plugin;
 }

--- a/testkit/src/main/java/io/github/tgkit/testkit/TelegramMockServer.java
+++ b/testkit/src/main/java/io/github/tgkit/testkit/TelegramMockServer.java
@@ -71,7 +71,9 @@ public final class TelegramMockServer implements AutoCloseable {
     }
   }
 
-  /** Базовый URL для передачи в {@link io.github.tgkit.internal.bot.BotConfig#setBaseUrl(String)}. */
+  /**
+   * Базовый URL для передачи в {@link io.github.tgkit.internal.bot.BotConfig#setBaseUrl(String)}.
+   */
   public String baseUrl() {
     return "http://localhost:" + port + "/bot";
   }


### PR DESCRIPTION
## Summary
- use `tgkit-api` artifact in `core`
- adjust imports after package move
- reformat module-info and docs

## Testing
- `mvn -q verify` *(fails: module not found: webhook)*
- `mvn -q spotless:check`


------
https://chatgpt.com/codex/tasks/task_e_685698031d988325b9f538af5245d178