### PR TITLE
Update validator to use tgkit-api

### DIFF
--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -15,7 +15,7 @@
     <dependencies>
         <dependency>
             <groupId>io.github.tgkit</groupId>
-            <artifactId>api</artifactId>
+            <artifactId>tgkit-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/validator/src/main/java/io/github/tgkit/validator/impl/AdvancedValidators.java
+++ b/validator/src/main/java/io/github/tgkit/validator/impl/AdvancedValidators.java
@@ -15,9 +15,9 @@
  */
 package io.github.tgkit.validator.impl;
 
-import io.github.tgkit.internal.BotRequest;
-import io.github.tgkit.internal.i18n.MessageKey;
-import io.github.tgkit.internal.validator.Validator;
+import io.github.tgkit.api.BotRequest;
+import io.github.tgkit.api.i18n.MessageKey;
+import io.github.tgkit.api.validator.Validator;
 import io.github.tgkit.validator.language.LanguageDetectionService;
 import java.net.URI;
 import java.time.Instant;

--- a/validator/src/main/java/io/github/tgkit/validator/impl/ContactValidators.java
+++ b/validator/src/main/java/io/github/tgkit/validator/impl/ContactValidators.java
@@ -15,8 +15,8 @@
  */
 package io.github.tgkit.validator.impl;
 
-import io.github.tgkit.internal.i18n.MessageKey;
-import io.github.tgkit.internal.validator.Validator;
+import io.github.tgkit.api.i18n.MessageKey;
+import io.github.tgkit.api.validator.Validator;
 import java.util.regex.Pattern;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.telegram.telegrambots.meta.api.objects.Contact;

--- a/validator/src/main/java/io/github/tgkit/validator/impl/DocumentValidators.java
+++ b/validator/src/main/java/io/github/tgkit/validator/impl/DocumentValidators.java
@@ -15,8 +15,8 @@
  */
 package io.github.tgkit.validator.impl;
 
-import io.github.tgkit.internal.i18n.MessageKey;
-import io.github.tgkit.internal.validator.Validator;
+import io.github.tgkit.api.i18n.MessageKey;
+import io.github.tgkit.api.validator.Validator;
 import io.github.tgkit.validator.moderation.ContentModerationService;
 import java.util.ServiceLoader;
 import java.util.Set;

--- a/validator/src/main/java/io/github/tgkit/validator/impl/LocationValidators.java
+++ b/validator/src/main/java/io/github/tgkit/validator/impl/LocationValidators.java
@@ -15,8 +15,8 @@
  */
 package io.github.tgkit.validator.impl;
 
-import io.github.tgkit.internal.i18n.MessageKey;
-import io.github.tgkit.internal.validator.Validator;
+import io.github.tgkit.api.i18n.MessageKey;
+import io.github.tgkit.api.validator.Validator;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.telegram.telegrambots.meta.api.objects.Location;
 

--- a/validator/src/main/java/io/github/tgkit/validator/impl/MiscValidators.java
+++ b/validator/src/main/java/io/github/tgkit/validator/impl/MiscValidators.java
@@ -15,8 +15,8 @@
  */
 package io.github.tgkit.validator.impl;
 
-import io.github.tgkit.internal.i18n.MessageKey;
-import io.github.tgkit.internal.validator.Validator;
+import io.github.tgkit.api.i18n.MessageKey;
+import io.github.tgkit.api.validator.Validator;
 import java.util.Objects;
 import java.util.Set;
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/validator/src/main/java/io/github/tgkit/validator/impl/PaymentValidators.java
+++ b/validator/src/main/java/io/github/tgkit/validator/impl/PaymentValidators.java
@@ -15,8 +15,8 @@
  */
 package io.github.tgkit.validator.impl;
 
-import io.github.tgkit.internal.i18n.MessageKey;
-import io.github.tgkit.internal.validator.Validator;
+import io.github.tgkit.api.i18n.MessageKey;
+import io.github.tgkit.api.validator.Validator;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.telegram.telegrambots.meta.api.objects.payments.Invoice;
 

--- a/validator/src/main/java/io/github/tgkit/validator/impl/PhotoValidators.java
+++ b/validator/src/main/java/io/github/tgkit/validator/impl/PhotoValidators.java
@@ -15,8 +15,8 @@
  */
 package io.github.tgkit.validator.impl;
 
-import io.github.tgkit.internal.i18n.MessageKey;
-import io.github.tgkit.internal.validator.Validator;
+import io.github.tgkit.api.i18n.MessageKey;
+import io.github.tgkit.api.validator.Validator;
 import io.github.tgkit.validator.moderation.ContentModerationService;
 import java.util.List;
 import java.util.ServiceLoader;

--- a/validator/src/main/java/io/github/tgkit/validator/impl/PollValidators.java
+++ b/validator/src/main/java/io/github/tgkit/validator/impl/PollValidators.java
@@ -15,8 +15,8 @@
  */
 package io.github.tgkit.validator.impl;
 
-import io.github.tgkit.internal.i18n.MessageKey;
-import io.github.tgkit.internal.validator.Validator;
+import io.github.tgkit.api.i18n.MessageKey;
+import io.github.tgkit.api.validator.Validator;
 import java.util.List;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.telegram.telegrambots.meta.api.objects.polls.Poll;

--- a/validator/src/main/java/io/github/tgkit/validator/impl/TextValidators.java
+++ b/validator/src/main/java/io/github/tgkit/validator/impl/TextValidators.java
@@ -15,8 +15,8 @@
  */
 package io.github.tgkit.validator.impl;
 
-import io.github.tgkit.internal.i18n.MessageKey;
-import io.github.tgkit.internal.validator.Validator;
+import io.github.tgkit.api.i18n.MessageKey;
+import io.github.tgkit.api.validator.Validator;
 import io.github.tgkit.validator.moderation.ContentModerationService;
 import java.util.ServiceLoader;
 import java.util.regex.Pattern;

--- a/validator/src/main/java/io/github/tgkit/validator/impl/UrlValidators.java
+++ b/validator/src/main/java/io/github/tgkit/validator/impl/UrlValidators.java
@@ -15,8 +15,8 @@
  */
 package io.github.tgkit.validator.impl;
 
-import io.github.tgkit.internal.i18n.MessageKey;
-import io.github.tgkit.internal.validator.Validator;
+import io.github.tgkit.api.i18n.MessageKey;
+import io.github.tgkit.api.validator.Validator;
 import io.github.tgkit.validator.moderation.ContentModerationService;
 import java.net.URI;
 import java.util.ServiceLoader;

--- a/validator/src/main/java/io/github/tgkit/validator/impl/VideoValidators.java
+++ b/validator/src/main/java/io/github/tgkit/validator/impl/VideoValidators.java
@@ -15,8 +15,8 @@
  */
 package io.github.tgkit.validator.impl;
 
-import io.github.tgkit.internal.i18n.MessageKey;
-import io.github.tgkit.internal.validator.Validator;
+import io.github.tgkit.api.i18n.MessageKey;
+import io.github.tgkit.api.validator.Validator;
 import io.github.tgkit.validator.moderation.ContentModerationService;
 import java.util.ServiceLoader;
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/validator/src/test/java/io/github/tgkit/validator/impl/AdvancedValidatorsTest.java
+++ b/validator/src/test/java/io/github/tgkit/validator/impl/AdvancedValidatorsTest.java
@@ -18,7 +18,7 @@ package io.github.tgkit.validator.impl;
 import static io.github.tgkit.validator.impl.AdvancedValidators.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import io.github.tgkit.internal.exception.ValidationException;
+import io.github.tgkit.api.exception.ValidationException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;

--- a/validator/src/test/java/io/github/tgkit/validator/impl/ContactValidatorsTest.java
+++ b/validator/src/test/java/io/github/tgkit/validator/impl/ContactValidatorsTest.java
@@ -18,7 +18,7 @@ package io.github.tgkit.validator.impl;
 import static io.github.tgkit.validator.impl.ContactValidators.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import io.github.tgkit.internal.exception.ValidationException;
+import io.github.tgkit.api.exception.ValidationException;
 import org.junit.jupiter.api.Test;
 import org.telegram.telegrambots.meta.api.objects.Contact;
 

--- a/validator/src/test/java/io/github/tgkit/validator/impl/DocumentValidatorsTest.java
+++ b/validator/src/test/java/io/github/tgkit/validator/impl/DocumentValidatorsTest.java
@@ -18,7 +18,7 @@ package io.github.tgkit.validator.impl;
 import static io.github.tgkit.validator.impl.DocumentValidators.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import io.github.tgkit.internal.exception.ValidationException;
+import io.github.tgkit.api.exception.ValidationException;
 import org.junit.jupiter.api.Test;
 import org.telegram.telegrambots.meta.api.objects.Document;
 

--- a/validator/src/test/java/io/github/tgkit/validator/impl/LocationValidatorsTest.java
+++ b/validator/src/test/java/io/github/tgkit/validator/impl/LocationValidatorsTest.java
@@ -18,7 +18,7 @@ package io.github.tgkit.validator.impl;
 import static io.github.tgkit.validator.impl.LocationValidators.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import io.github.tgkit.internal.exception.ValidationException;
+import io.github.tgkit.api.exception.ValidationException;
 import org.junit.jupiter.api.Test;
 import org.telegram.telegrambots.meta.api.objects.Location;
 

--- a/validator/src/test/java/io/github/tgkit/validator/impl/PaymentValidatorsTest.java
+++ b/validator/src/test/java/io/github/tgkit/validator/impl/PaymentValidatorsTest.java
@@ -18,7 +18,7 @@ package io.github.tgkit.validator.impl;
 import static io.github.tgkit.validator.impl.PaymentValidators.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import io.github.tgkit.internal.exception.ValidationException;
+import io.github.tgkit.api.exception.ValidationException;
 import org.junit.jupiter.api.Test;
 import org.telegram.telegrambots.meta.api.objects.payments.Invoice;
 

--- a/validator/src/test/java/io/github/tgkit/validator/impl/PhotoValidatorsTest.java
+++ b/validator/src/test/java/io/github/tgkit/validator/impl/PhotoValidatorsTest.java
@@ -18,7 +18,7 @@ package io.github.tgkit.validator.impl;
 import static io.github.tgkit.validator.impl.PhotoValidators.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import io.github.tgkit.internal.exception.ValidationException;
+import io.github.tgkit.api.exception.ValidationException;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.telegram.telegrambots.meta.api.objects.PhotoSize;

--- a/validator/src/test/java/io/github/tgkit/validator/impl/PollValidatorsTest.java
+++ b/validator/src/test/java/io/github/tgkit/validator/impl/PollValidatorsTest.java
@@ -18,7 +18,7 @@ package io.github.tgkit.validator.impl;
 import static io.github.tgkit.validator.impl.PollValidators.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import io.github.tgkit.internal.exception.ValidationException;
+import io.github.tgkit.api.exception.ValidationException;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.telegram.telegrambots.meta.api.objects.polls.Poll;

--- a/validator/src/test/java/io/github/tgkit/validator/impl/TextValidatorsTest.java
+++ b/validator/src/test/java/io/github/tgkit/validator/impl/TextValidatorsTest.java
@@ -18,7 +18,7 @@ package io.github.tgkit.validator.impl;
 import static io.github.tgkit.validator.impl.TextValidators.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import io.github.tgkit.internal.exception.ValidationException;
+import io.github.tgkit.api.exception.ValidationException;
 import org.junit.jupiter.api.Test;
 
 class TextValidatorsTest {

--- a/validator/src/test/java/io/github/tgkit/validator/impl/UrlValidatorsTest.java
+++ b/validator/src/test/java/io/github/tgkit/validator/impl/UrlValidatorsTest.java
@@ -18,7 +18,7 @@ package io.github.tgkit.validator.impl;
 import static io.github.tgkit.validator.impl.UrlValidators.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import io.github.tgkit.internal.exception.ValidationException;
+import io.github.tgkit.api.exception.ValidationException;
 import org.junit.jupiter.api.Test;
 
 class UrlValidatorsTest {

--- a/validator/src/test/java/io/github/tgkit/validator/impl/VideoValidatorsTest.java
+++ b/validator/src/test/java/io/github/tgkit/validator/impl/VideoValidatorsTest.java
@@ -18,7 +18,7 @@ package io.github.tgkit.validator.impl;
 import static io.github.tgkit.validator.impl.VideoValidators.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import io.github.tgkit.internal.exception.ValidationException;
+import io.github.tgkit.api.exception.ValidationException;
 import org.junit.jupiter.api.Test;
 import org.telegram.telegrambots.meta.api.objects.Video;
 


### PR DESCRIPTION
## Summary
- use new `tgkit-api` artifact
- adjust imports to `io.github.tgkit.api.*`

## Testing
- `mvn verify` *(fails: module not found `webhook`)*

------
https://chatgpt.com/codex/tasks/task_e_6856980db6488325aabaf7907bb1aba4