### PR TITLE
Fix testkit dependency and update imports

### DIFF
--- a/testkit/pom.xml
+++ b/testkit/pom.xml
@@ -18,7 +18,7 @@
         </dependency>
         <dependency>
             <groupId>io.github.tgkit</groupId>
-            <artifactId>api</artifactId>
+            <artifactId>tgkit-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/testkit/src/main/java/io/github/tgkit/testkit/BotTestExtension.java
+++ b/testkit/src/main/java/io/github/tgkit/testkit/BotTestExtension.java
@@ -15,10 +15,10 @@
  */
 package io.github.tgkit.testkit;
 
-import io.github.tgkit.internal.bot.BotAdapterImpl;
-import io.github.tgkit.internal.bot.BotConfig;
-import io.github.tgkit.internal.bot.TelegramSender;
-import io.github.tgkit.internal.init.BotCoreInitializer;
+import io.github.tgkit.api.bot.BotAdapterImpl;
+import io.github.tgkit.api.bot.BotConfig;
+import io.github.tgkit.api.bot.TelegramSender;
+import io.github.tgkit.api.init.BotCoreInitializer;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;

--- a/testkit/src/main/java/io/github/tgkit/testkit/TelegramMockServer.java
+++ b/testkit/src/main/java/io/github/tgkit/testkit/TelegramMockServer.java
@@ -71,7 +71,7 @@ public final class TelegramMockServer implements AutoCloseable {
     }
   }
 
-  /** Базовый URL для передачи в {@link io.github.tgkit.internal.bot.BotConfig#setBaseUrl(String)}. */
+  /** Базовый URL для передачи в {@link io.github.tgkit.api.bot.BotConfig#setBaseUrl(String)}. */
   public String baseUrl() {
     return "http://localhost:" + port + "/bot";
   }

--- a/testkit/src/main/java/io/github/tgkit/testkit/TestBotBootstrap.java
+++ b/testkit/src/main/java/io/github/tgkit/testkit/TestBotBootstrap.java
@@ -15,7 +15,7 @@
  */
 package io.github.tgkit.testkit;
 
-import io.github.tgkit.internal.init.BotCoreInitializer;
+import io.github.tgkit.api.init.BotCoreInitializer;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**

--- a/testkit/src/main/java/io/github/tgkit/testkit/UpdateInjector.java
+++ b/testkit/src/main/java/io/github/tgkit/testkit/UpdateInjector.java
@@ -15,8 +15,8 @@
  */
 package io.github.tgkit.testkit;
 
-import io.github.tgkit.internal.BotAdapter;
-import io.github.tgkit.internal.bot.TelegramSender;
+import io.github.tgkit.api.BotAdapter;
+import io.github.tgkit.api.bot.TelegramSender;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/testkit/src/test/java/io/github/tgkit/testkit/WelcomeFlowTest.java
+++ b/testkit/src/test/java/io/github/tgkit/testkit/WelcomeFlowTest.java
@@ -17,12 +17,12 @@ package io.github.tgkit.testkit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.github.tgkit.internal.BotCommand;
-import io.github.tgkit.internal.BotRequest;
-import io.github.tgkit.internal.BotRequestType;
-import io.github.tgkit.internal.BotResponse;
-import io.github.tgkit.internal.bot.BotAdapterImpl;
-import io.github.tgkit.internal.matching.CommandMatch;
+import io.github.tgkit.api.BotCommand;
+import io.github.tgkit.api.BotRequest;
+import io.github.tgkit.api.BotRequestType;
+import io.github.tgkit.api.BotResponse;
+import io.github.tgkit.api.bot.BotAdapterImpl;
+import io.github.tgkit.api.matching.CommandMatch;
 import java.util.concurrent.TimeUnit;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Summary
- point testkit to `tgkit-api` dependency
- update imports to new `io.github.tgkit.api` package names

## Testing
- `mvn -q verify` *(fails: module not found `webhook`)*

------
https://chatgpt.com/codex/tasks/task_e_6856981315e48325ab1cdee3183f1085