### PR TITLE
Update tgkit-api dependency

### DIFF
--- a/codec/json-codec-dsljson/pom.xml
+++ b/codec/json-codec-dsljson/pom.xml
@@ -43,7 +43,7 @@
         </dependency>
         <dependency>
             <groupId>io.github.tgkit</groupId>
-            <artifactId>api</artifactId>
+            <artifactId>tgkit-api</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>

--- a/codec/json-codec-dsljson/src/jmh/java/io/github/tgkit/json/dsljson/DslJsonCodecBenchmark.java
+++ b/codec/json-codec-dsljson/src/jmh/java/io/github/tgkit/json/dsljson/DslJsonCodecBenchmark.java
@@ -1,6 +1,6 @@
 package io.github.tgkit.json.dsljson;
 
-import io.github.tgkit.core.bot.BotConfig;
+import io.github.tgkit.internal.bot.BotConfig;
 import io.github.tgkit.json.JsonCodec;
 import java.util.Locale;
 import org.openjdk.jmh.annotations.Benchmark;

--- a/codec/json-codec-dsljson/src/test/java/io/github/tgkit/json/dsljson/DslJsonCodecTest.java
+++ b/codec/json-codec-dsljson/src/test/java/io/github/tgkit/json/dsljson/DslJsonCodecTest.java
@@ -17,7 +17,7 @@ package io.github.tgkit.json.dsljson;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.github.tgkit.core.bot.BotConfig;
+import io.github.tgkit.internal.bot.BotConfig;
 import io.github.tgkit.json.JsonCodec;
 import java.util.Locale;
 import java.util.ServiceLoader;


### PR DESCRIPTION
## Summary
- use `tgkit-api` for testing instead of obsolete `api`
- update imports in benchmarks and tests for renamed packages

## Testing
- `mvn -q -pl codec/json-codec-dsljson -am verify` *(fails: could not resolve artifact tgkit-api)*

------
https://chatgpt.com/codex/tasks/task_e_68569813d354832597c527f597be7413