### PR TITLE
Fix imports to new module

### DIFF
--- a/codec/json-codec-dsljson/src/jmh/java/io/github/tgkit/json/dsljson/DslJsonCodecBenchmark.java
+++ b/codec/json-codec-dsljson/src/jmh/java/io/github/tgkit/json/dsljson/DslJsonCodecBenchmark.java
@@ -1,6 +1,6 @@
 package io.github.tgkit.json.dsljson;
 
-import io.github.tgkit.core.bot.BotConfig;
+import io.github.tgkit.internal.bot.BotConfig;
 import io.github.tgkit.json.JsonCodec;
 import java.util.Locale;
 import org.openjdk.jmh.annotations.Benchmark;

--- a/codec/json-codec-dsljson/src/test/java/io/github/tgkit/json/dsljson/DslJsonCodecTest.java
+++ b/codec/json-codec-dsljson/src/test/java/io/github/tgkit/json/dsljson/DslJsonCodecTest.java
@@ -17,7 +17,7 @@ package io.github.tgkit.json.dsljson;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.github.tgkit.core.bot.BotConfig;
+import io.github.tgkit.internal.bot.BotConfig;
 import io.github.tgkit.json.JsonCodec;
 import java.util.Locale;
 import java.util.ServiceLoader;


### PR DESCRIPTION
## Summary
- fix import references to BotConfig after moving to the api module
- keep module-info dependencies on tgkit-core

## Testing
- `mvn -q verify` *(fails: module not found: webhook)*

------
https://chatgpt.com/codex/tasks/task_e_68569815c5048325a360d8656ffa2fef