### PR TITLE
Update imports after package move

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 ...
 <annotationProcessors>
     <annotationProcessor>
-        io.github.tgkit.core.processor.BotHandlerProcessor
+        io.github.tgkit.internal.processor.BotHandlerProcessor
     </annotationProcessor>
 ...
 </plugin>
@@ -72,7 +72,7 @@
 <summary>Gradle Kotlin DSL</summary>
 
 ```kotlin 
-implementation("io.github.tgkit:core:0.0.1-SNAPSHOT")
+implementation("io.github.tgkit:api:0.0.1-SNAPSHOT")
 ```
 
 </details>

--- a/codec/json-codec-dsljson/src/jmh/java/io/github/tgkit/json/dsljson/DslJsonCodecBenchmark.java
+++ b/codec/json-codec-dsljson/src/jmh/java/io/github/tgkit/json/dsljson/DslJsonCodecBenchmark.java
@@ -1,6 +1,6 @@
 package io.github.tgkit.json.dsljson;
 
-import io.github.tgkit.core.bot.BotConfig;
+import io.github.tgkit.internal.bot.BotConfig;
 import io.github.tgkit.json.JsonCodec;
 import java.util.Locale;
 import org.openjdk.jmh.annotations.Benchmark;

--- a/codec/json-codec-dsljson/src/test/java/io/github/tgkit/json/dsljson/DslJsonCodecTest.java
+++ b/codec/json-codec-dsljson/src/test/java/io/github/tgkit/json/dsljson/DslJsonCodecTest.java
@@ -17,7 +17,7 @@ package io.github.tgkit.json.dsljson;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.github.tgkit.core.bot.BotConfig;
+import io.github.tgkit.internal.bot.BotConfig;
 import io.github.tgkit.json.JsonCodec;
 import java.util.Locale;
 import java.util.ServiceLoader;

--- a/docs/LOADER_README.md
+++ b/docs/LOADER_README.md
@@ -142,7 +142,7 @@ public final class RateLimitBotCommandFactory implements BotCommandFactory<RateL
 ```
 
 Подключение:
-```META-INF/services/io.github.tgkit.core.loader.BotCommandFactory```
+```META-INF/services/io.github.tgkit.internal.loader.BotCommandFactory```
 
 ---
 


### PR DESCRIPTION
## Summary
- update outdated BotConfig imports to the new package
- adjust README examples to use the new module and processor path
- fix Loader README service path

## Testing
- `mvn -q verify` *(fails: module not found `webhook`)*

------
https://chatgpt.com/codex/tasks/task_e_68569816d83c83258b8343bd14cae5d9