### PR TITLE
Update example modules to new API imports

### DIFF
--- a/examples/observability-demo/src/main/java/io/github/examples/observability/ObservabilityDemoApplication.java
+++ b/examples/observability-demo/src/main/java/io/github/examples/observability/ObservabilityDemoApplication.java
@@ -17,12 +17,12 @@ package io.github.examples.observability;
 
 import io.github.observability.BotObservability;
 import io.github.observability.ObservabilityInterceptor;
-import io.github.tgkit.internal.BotAdapter;
-import io.github.tgkit.internal.bot.Bot;
-import io.github.tgkit.internal.bot.BotAdapterImpl;
-import io.github.tgkit.internal.bot.BotConfig;
-import io.github.tgkit.internal.bot.BotFactory;
-import io.github.tgkit.internal.init.BotCoreInitializer;
+import io.github.tgkit.api.BotAdapter;
+import io.github.tgkit.api.bot.Bot;
+import io.github.tgkit.api.bot.BotAdapterImpl;
+import io.github.tgkit.api.bot.BotConfig;
+import io.github.tgkit.api.bot.BotFactory;
+import io.github.tgkit.api.init.BotCoreInitializer;
 
 public class ObservabilityDemoApplication {
 

--- a/examples/plugin-demo/app/src/main/java/io/github/tgkit/app/Main.java
+++ b/examples/plugin-demo/app/src/main/java/io/github/tgkit/app/Main.java
@@ -15,7 +15,7 @@
  */
 package io.github.tgkit.app;
 
-import io.github.tgkit.internal.init.BotCoreInitializer;
+import io.github.tgkit.api.init.BotCoreInitializer;
 import io.github.tgkit.plugin.BotPluginManager;
 import io.github.tgkit.security.init.BotSecurityInitializer;
 import java.nio.file.Path;

--- a/examples/simple-bot/src/main/java/io/github/examples/simplebot/SimpleBotApplication.java
+++ b/examples/simple-bot/src/main/java/io/github/examples/simplebot/SimpleBotApplication.java
@@ -15,8 +15,8 @@
  */
 package io.github.examples.simplebot;
 
-import io.github.tgkit.internal.TelegramBot;
-import io.github.tgkit.internal.init.BotCoreInitializer;
+import io.github.tgkit.api.TelegramBot;
+import io.github.tgkit.api.init.BotCoreInitializer;
 import java.nio.file.Path;
 
 public class SimpleBotApplication {

--- a/examples/simple-bot/src/main/java/io/github/examples/simplebot/SimpleBotCommands.java
+++ b/examples/simple-bot/src/main/java/io/github/examples/simplebot/SimpleBotCommands.java
@@ -15,15 +15,15 @@
  */
 package io.github.examples.simplebot;
 
-import io.github.tgkit.internal.BotRequest;
-import io.github.tgkit.internal.BotRequestType;
-import io.github.tgkit.internal.BotResponse;
-import io.github.tgkit.internal.annotation.BotHandler;
-import io.github.tgkit.internal.annotation.matching.AlwaysMatch;
-import io.github.tgkit.internal.annotation.matching.MessageContainsMatch;
-import io.github.tgkit.internal.annotation.matching.MessageRegexMatch;
-import io.github.tgkit.internal.annotation.matching.MessageTextMatch;
-import io.github.tgkit.internal.annotation.matching.UserRoleMatch;
+import io.github.tgkit.api.BotRequest;
+import io.github.tgkit.api.BotRequestType;
+import io.github.tgkit.api.BotResponse;
+import io.github.tgkit.api.annotation.BotHandler;
+import io.github.tgkit.api.annotation.matching.AlwaysMatch;
+import io.github.tgkit.api.annotation.matching.MessageContainsMatch;
+import io.github.tgkit.api.annotation.matching.MessageRegexMatch;
+import io.github.tgkit.api.annotation.matching.MessageTextMatch;
+import io.github.tgkit.api.annotation.matching.UserRoleMatch;
 import java.util.Collections;
 import org.telegram.telegrambots.meta.api.methods.AnswerCallbackQuery;
 import org.telegram.telegrambots.meta.api.methods.AnswerInlineQuery;

--- a/examples/simple-bot/src/main/java/io/github/examples/simplebot/SimpleRoleProvider.java
+++ b/examples/simple-bot/src/main/java/io/github/examples/simplebot/SimpleRoleProvider.java
@@ -15,11 +15,11 @@
  */
 package io.github.examples.simplebot;
 
-import static io.github.tgkit.internal.update.UpdateUtils.resolveChatId;
-import static io.github.tgkit.internal.update.UpdateUtils.resolveUserId;
+import static io.github.tgkit.api.update.UpdateUtils.resolveChatId;
+import static io.github.tgkit.api.update.UpdateUtils.resolveUserId;
 
-import io.github.tgkit.internal.user.BotUserInfo;
-import io.github.tgkit.internal.user.BotUserProvider;
+import io.github.tgkit.api.user.BotUserInfo;
+import io.github.tgkit.api.user.BotUserProvider;
 import java.util.Set;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;


### PR DESCRIPTION
## Summary
- migrate example imports to `io.github.tgkit.api.*`
- keep core dependency in POMs

## Testing
- `mvn -q -pl examples/simple-bot -am verify` *(fails: module not found: webhook)*

------
https://chatgpt.com/codex/tasks/task_e_685698181b0c8325bff7aadd81403d85