### PR TITLE
Fix benchmark dependency and imports

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -14,7 +14,7 @@
     <dependencies>
         <dependency>
             <groupId>io.github.tgkit</groupId>
-            <artifactId>api</artifactId>
+            <artifactId>tgkit-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/codec/json-codec-dsljson/src/jmh/java/io/github/tgkit/json/dsljson/DslJsonCodecBenchmark.java
+++ b/codec/json-codec-dsljson/src/jmh/java/io/github/tgkit/json/dsljson/DslJsonCodecBenchmark.java
@@ -1,6 +1,6 @@
 package io.github.tgkit.json.dsljson;
 
-import io.github.tgkit.core.bot.BotConfig;
+import io.github.tgkit.internal.bot.BotConfig;
 import io.github.tgkit.json.JsonCodec;
 import java.util.Locale;
 import org.openjdk.jmh.annotations.Benchmark;

--- a/codec/json-codec-dsljson/src/test/java/io/github/tgkit/json/dsljson/DslJsonCodecTest.java
+++ b/codec/json-codec-dsljson/src/test/java/io/github/tgkit/json/dsljson/DslJsonCodecTest.java
@@ -17,7 +17,7 @@ package io.github.tgkit.json.dsljson;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.github.tgkit.core.bot.BotConfig;
+import io.github.tgkit.internal.bot.BotConfig;
 import io.github.tgkit.json.JsonCodec;
 import java.util.Locale;
 import java.util.ServiceLoader;


### PR DESCRIPTION
## Summary
- point benchmark module to the `tgkit-api` artifact
- adjust codec tests to new `io.github.tgkit.internal` package

## Testing
- `mvn -q verify` *(fails: module not found `webhook`)*

------
https://chatgpt.com/codex/tasks/task_e_6856981325588325a5eecd35335db30d