### PR TITLE
Introduce tgkit-api module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <module>plugin</module>
         <module>security</module>
         <module>examples</module>
+        <module>tgkit-api</module>
         <module>api</module>
         <module>testkit</module>
         <module>webhook</module>

--- a/tgkit-api/pom.xml
+++ b/tgkit-api/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.github.tgkit</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>tgkit-api</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.telegram</groupId>
+            <artifactId>telegrambots</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <!-- CHECKS -->
+        <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-qual</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/tgkit-api/src/main/java/io/github/tgkit/api/BotAdapter.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/BotAdapter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+/**
+ * Адаптер бота, выполняющий обработку входящих {@link Update} и формирующий ответ в виде метода
+ * Telegram API.
+ */
+@FunctionalInterface
+public interface BotAdapter {
+
+  /**
+   * Обработать входящее обновление Telegram.
+   *
+   * @param update полученное от Telegram обновление
+   * @return метод Telegram API для отправки пользователю или {@code null}, если ответа не требуется
+   */
+  @Nullable BotApiMethod<?> handle(@NonNull Update update) throws Exception;
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/BotCommand.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/BotCommand.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api;
+
+import io.github.tgkit.api.interceptor.BotInterceptor;
+import io.github.tgkit.api.matching.CommandMatch;
+import java.util.List;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Обработчик конкретной команды бота.
+ *
+ * <p><b>Стабильность:</b> API считается стабильным и совместимым между версиями.
+ *
+ * @param <T> тип объекта Telegram API, с которым работает обработчик
+ */
+public interface BotCommand<T> {
+
+  /**
+   * Выполняет обработку запроса пользователя.
+   *
+   * @param request запрос, содержащий данные об обновлении
+   * @return {@link BotResponse}, который необходимо отправить пользователю, либо {@code null}, если
+   *     ответ не требуется
+   */
+  @Nullable BotResponse handle(@NonNull BotRequest<T> request);
+
+  /**
+   * Тип обрабатываемого запроса.
+   *
+   * @return тип запроса
+   */
+  @NonNull BotRequestType type();
+
+  /**
+   * Правило сопоставления команды с обновлением.
+   *
+   * @return правило (matcher)
+   */
+  @NonNull CommandMatch<T> matcher();
+
+  /**
+   * Список интерсепторов команды.
+   *
+   * @return изменяемый список
+   */
+  @NonNull List<BotInterceptor> interceptors();
+
+  void setMatcher(@NonNull CommandMatch<T> matcher);
+
+  void setType(@NonNull BotRequestType type);
+
+  void setBotGroup(@NonNull String group);
+
+  /**
+   * Группа обработчика. Используется для объединения команд.
+   *
+   * @return название группы
+   */
+  default @NonNull String botGroup() {
+    return "";
+  }
+
+  /**
+   * Порядок выполнения команды (меньше — выше приоритет).
+   *
+   * @return целочисленный порядок
+   */
+  default int order() {
+    return BotCommandOrder.LAST;
+  }
+
+  /**
+   * Добавляет {@link BotInterceptor} к данной команде.
+   *
+   * @param interceptor интерсептор, выполняющийся до/после handle()
+   */
+  default void addInterceptor(@NonNull BotInterceptor interceptor) {
+    interceptors().add(interceptor);
+  }
+
+  /**
+   * Краткое описание команды для help-системы.
+   *
+   * @return текст описания
+   */
+  default @NonNull String getDescription() {
+    return "";
+  }
+
+  /**
+   * Пример использования команды.
+   *
+   * @return текст-образец
+   */
+  default @NonNull String getUsage() {
+    return "";
+  }
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/BotHandlerConverter.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/BotHandlerConverter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Конвертер для преобразования {@link BotRequest} в произвольный тип, используемый обработчиком.
+ *
+ * @param <T> целевой тип после преобразования
+ */
+@FunctionalInterface
+public interface BotHandlerConverter<T> {
+
+  /**
+   * Выполняет преобразование запроса.
+   *
+   * @param request исходный запрос
+   * @return результат преобразования
+   */
+  @NonNull T convert(@NonNull BotRequest<?> request);
+
+  /** Конвертер по умолчанию, возвращающий исходный запрос без изменений. */
+  class Identity implements BotHandlerConverter<BotRequest<?>> {
+    @Override
+    public @NonNull BotRequest<?> convert(@NonNull BotRequest<?> request) {
+      return request;
+    }
+  }
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/BotInfo.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/BotInfo.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api;
+
+/**
+ * Информация о работающем экземпляре бота.
+ *
+ * @param internalId внутренний идентификатор бота
+ */
+public record BotInfo(long internalId) {}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/BotRequest.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/BotRequest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api;
+
+import io.github.tgkit.api.dsl.BotDSL;
+import io.github.tgkit.api.dsl.DeleteBuilder;
+import io.github.tgkit.api.dsl.EditBuilder;
+import io.github.tgkit.api.dsl.InlineResultBuilder;
+import io.github.tgkit.api.dsl.MediaGroupBuilder;
+import io.github.tgkit.api.dsl.MessageBuilder;
+import io.github.tgkit.api.dsl.PhotoBuilder;
+import io.github.tgkit.api.dsl.PollBuilder;
+import io.github.tgkit.api.dsl.QuizBuilder;
+import io.github.tgkit.api.exception.BotApiException;
+import io.github.tgkit.api.user.BotUserInfo;
+import java.util.Locale;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.telegram.telegrambots.meta.api.objects.InputFile;
+
+/**
+ * Обёртка над обновлением Telegram, содержащая дополнительную информацию о боте и пользователе.
+ *
+ * @param updateId идентификатор обновления
+ * @param data данные обновления
+ * @param botInfo сведения о боте
+ * @param user информация о пользователе
+ * @param requestType Тип запроса
+ * @param <T> тип данных обновления
+ */
+public record BotRequest<T>(
+    int updateId,
+    @NonNull T data,
+    @NonNull Locale locale,
+    @Nullable Integer msgId,
+    @NonNull BotInfo botInfo,
+    @NonNull BotUserInfo user,
+    @NonNull BotService service,
+    @NonNull BotRequestType requestType) {
+
+  public void requiredChatId() {
+    if (user.chatId() == null) {
+      throw new BotApiException("Missing required chat id");
+    }
+  }
+
+  public void requiredUserId() {
+    if (user.userId() == null) {
+      throw new BotApiException("Missing required user id");
+    }
+  }
+
+  /** Сообщение. */
+  public @NonNull MessageBuilder msg(@NonNull String text) {
+    return BotDSL.msg(BotDSL.ctx(botInfo(), user(), service()), text);
+  }
+
+  /** Сообщение из i18n. */
+  public @NonNull MessageBuilder msgKey(@NonNull String key, @NonNull Object... args) {
+    return BotDSL.msgKey(BotDSL.ctx(botInfo(), user(), service()), key, args);
+  }
+
+  /** Фото. */
+  public @NonNull PhotoBuilder photo(@NonNull InputFile file) {
+    return BotDSL.photo(BotDSL.ctx(botInfo(), user(), service()), file);
+  }
+
+  /** Редактирование сообщения. */
+  public @NonNull EditBuilder edit(long msgId) {
+    return BotDSL.edit(BotDSL.ctx(botInfo(), user(), service()), msgId);
+  }
+
+  /** Удаление сообщения. */
+  public @NonNull DeleteBuilder delete(long msgId) {
+    return BotDSL.delete(BotDSL.ctx(botInfo(), user(), service()), msgId);
+  }
+
+  /** Отправка медиа-группы. */
+  public @NonNull MediaGroupBuilder mediaGroup() {
+    return BotDSL.mediaGroup(BotDSL.ctx(botInfo(), user(), service()));
+  }
+
+  /** Опрос. */
+  public @NonNull PollBuilder poll(@NonNull String question) {
+    return BotDSL.poll(BotDSL.ctx(botInfo(), user(), service()), question);
+  }
+
+  /** Викторина. */
+  public @NonNull QuizBuilder quiz(@NonNull String question, int correct) {
+    return BotDSL.quiz(BotDSL.ctx(botInfo(), user(), service()), question, correct);
+  }
+
+  /** Результаты инлайн-запроса. */
+  public @NonNull InlineResultBuilder inline() {
+    return BotDSL.inline(BotDSL.ctx(botInfo(), user(), service()));
+  }
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/BotRequestConverter.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/BotRequestConverter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+/**
+ * Преобразователь {@link Update} в необходимый тип данных запроса.
+ *
+ * <p><b>Стабильность:</b> API находится в стадии эксперимента и может изменяться.
+ *
+ * @param <T> тип результата преобразования
+ */
+@FunctionalInterface
+public interface BotRequestConverter<T> {
+
+  /**
+   * Конвертирует обновление Telegram в нужный тип.
+   *
+   * @param update объект {@link Update}, полученный от Telegram
+   * @param type тип запроса, определённый библиотекой
+   * @return сконвертированный объект
+   */
+  @NonNull T convert(@NonNull Update update, @NonNull BotRequestType type);
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/BotService.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/BotService.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api;
+
+import io.github.tgkit.api.bot.TelegramSender;
+import io.github.tgkit.api.i18n.MessageLocalizer;
+import io.github.tgkit.api.state.StateStore;
+import io.github.tgkit.api.user.store.UserKVStore;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Сервисы для работы команд
+ *
+ * @param store хранилище пользовательского состояния
+ * @param sender объект для отправки сообщений Telegram
+ * @param userKVStore объект для хранения дополнительной информации пользователя
+ * @param localizer сервис локализации сообщений
+ */
+public record BotService(
+    @NonNull StateStore store,
+    @NonNull TelegramSender sender,
+    @NonNull UserKVStore userKVStore,
+    @NonNull MessageLocalizer localizer) {}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/args/BotArgumentConverter.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/args/BotArgumentConverter.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.args;
+
+import io.github.tgkit.api.BotRequest;
+import io.github.tgkit.api.exception.BotApiException;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+public interface BotArgumentConverter<T, D> {
+
+  @NonNull D convert(@NonNull String raw, @NonNull Context<T> ctx) throws BotApiException;
+
+  default boolean isUpdate() {
+    return false;
+  }
+
+  default boolean isBotRequest() {
+    return false;
+  }
+
+  final class UpdateConverter implements BotArgumentConverter<Update, Update> {
+
+    @Override
+    public @NonNull Update convert(@NonNull String raw, @NonNull Context<Update> ctx) {
+      return ctx.data();
+    }
+
+    @Override
+    public boolean isUpdate() {
+      return true;
+    }
+  }
+
+  final class RequestConverter
+      implements BotArgumentConverter<BotRequest<Object>, BotRequest<Object>> {
+
+    @Override
+    public @NonNull BotRequest<Object> convert(
+        @NonNull String raw, @NonNull Context<BotRequest<Object>> ctx) throws BotApiException {
+      return ctx.data();
+    }
+
+    @Override
+    public boolean isBotRequest() {
+      return BotArgumentConverter.super.isBotRequest();
+    }
+  }
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/args/Context.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/args/Context.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.args;
+
+import java.util.regex.Matcher;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public record Context<T>(@NonNull T data, @Nullable Matcher matcher) {}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/args/ParamInfo.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/args/ParamInfo.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.args;
+
+import io.github.tgkit.api.BotRequest;
+import io.github.tgkit.api.annotation.Arg;
+import java.lang.reflect.Parameter;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+/**
+ * Метаданные одного параметра метода:
+ *
+ * <ul>
+ *   <li>{@code order} – порядок переменной в методе;
+ *   <li>{@code request} – если {@link BotRequest};
+ *   <li>{@code update} – если {@link Update};
+ *   <li>{@code arg} – аннотация {@link Arg} /default;
+ *   <li>{@code parameter} – параметр в методе {@link Parameter} /default;
+ *   <li>{@code converter} – конвертер строки в нужный тип параметра.
+ * </ul>
+ */
+public record ParamInfo(
+    int order,
+    boolean request,
+    boolean update,
+    @Nullable Arg arg,
+    @NonNull Parameter parameter,
+    @NonNull BotArgumentConverter<Object, Object> converter) {}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/bot/Bot.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/bot/Bot.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.bot;
+
+import io.github.tgkit.api.exception.BotApiException;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Базовый интерфейс Telegram-бота.
+ *
+ * <p>Предоставляет методы управления жизненным циклом и доступ к метаданным бота.
+ *
+ * <p>Пример создания и запуска простого бота:
+ *
+ * <pre>{@code
+ * BotConfig config = BotConfig.builder().build();
+ * BotAdapter adapter = update -> null;
+ * Bot bot = BotFactory.INSTANCE.from("TOKEN", config, adapter, "io.example.bot");
+ * bot.start();
+ * }</pre>
+ */
+public interface Bot {
+
+  /**
+   * Возвращает внутренний идентификатор бота, используемый библиотекой.
+   *
+   * @return идентификатор бота
+   * @throws BotApiException при попытке обратиться к значению до запуска бота
+   */
+  long internalId() throws BotApiException;
+
+  /**
+   * Возвращает идентификатор бота в Telegram.
+   *
+   * @return внешний идентификатор
+   * @throws BotApiException если бот ещё не запущен или произошла ошибка API
+   */
+  long externalId() throws BotApiException;
+
+  /**
+   * Запускает бота и инициализирует соединение с Telegram.
+   *
+   * @throws BotApiException при ошибке инициализации или подключения
+   */
+  void start() throws BotApiException;
+
+  /**
+   * Останавливает работу бота и освобождает ресурсы.
+   *
+   * @throws BotApiException если возникли ошибки при завершении работы
+   */
+  void stop() throws BotApiException;
+
+  /**
+   * Имя пользователя бота в Telegram.
+   *
+   * @return username бота
+   * @throws BotApiException если бот ещё не запущен
+   */
+  @NonNull String username() throws BotApiException;
+
+  /**
+   * Реестр команд, доступных для данного бота.
+   *
+   * @return объект реестра команд
+   */
+  @NonNull BotCommandRegistry registry();
+
+  /**
+   * Текущее состояние бота
+   *
+   * @return состояние бота
+   */
+  @NonNull BotState state();
+
+  /**
+   * Добавляет действие, выполняемое после остановки бота.
+   *
+   * @param action действие завершения
+   */
+  void onComplete(@NonNull BotCompleteAction action);
+
+  /**
+   * Текущая конфигурация бота.
+   *
+   * @return объект конфигурации
+   */
+  @NonNull BotConfig config();
+
+  /**
+   * Токен Telegram, использующийся при работе с API.
+   *
+   * @return строка токена
+   */
+  @NonNull String token();
+
+  /**
+   * Получить хранилище ботов
+   *
+   * @return хранилище ботов
+   */
+  @NonNull BotRegistry botRegistry();
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/bot/BotCommandRegistry.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/bot/BotCommandRegistry.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.bot;
+
+import io.github.tgkit.api.BotCommand;
+import io.github.tgkit.api.BotRequestType;
+import java.util.List;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
+
+public interface BotCommandRegistry {
+
+  /**
+   * Возвращает список всех зарегистрированных команд (неизменяемый).
+   *
+   * @return список команд
+   */
+  @NonNull List<BotCommand<?>> all();
+
+  /**
+   * Регистрирует новую команду и сортирует список по приоритету.
+   *
+   * @param command экземпляр команды
+   */
+  void add(@NonNull BotCommand<?> command);
+
+  /**
+   * Ищет первую команду, подходящую под тип, группу и matcher.
+   *
+   * @param type тип запроса
+   * @param botGroup группа команд (любая == пустая строка)
+   * @param data объект Telegram API
+   * @param <T> тип объекта
+   * @return команда или {@code null}, если не найдена
+   */
+  <T extends BotApiObject> @Nullable BotCommand<T> find(
+      @NonNull BotRequestType type, @NonNull String botGroup, @NonNull T data);
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/bot/BotCompleteAction.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/bot/BotCompleteAction.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.bot;
+
+@FunctionalInterface
+public interface BotCompleteAction {
+  void complete() throws Exception;
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/bot/BotRegistry.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/bot/BotRegistry.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.bot;
+
+import java.util.Collection;
+import java.util.Optional;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public interface BotRegistry {
+
+  @NonNull Collection<Bot> all();
+
+  @NonNull Optional<Bot> getByInternalId(long internalId);
+
+  @NonNull Optional<Bot> getByExternalId(long externalId);
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/crypto/TokenCipher.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/crypto/TokenCipher.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.crypto;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public interface TokenCipher {
+  @NonNull String encrypt(@NonNull String token);
+
+  @NonNull String decrypt(@NonNull String cipherText);
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/dsl/Button.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/dsl/Button.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.dsl;
+
+import io.github.tgkit.api.i18n.MessageLocalizer;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
+import org.telegram.telegrambots.meta.api.objects.webapp.WebAppInfo;
+
+/** Фабрика кнопок. */
+public interface Button {
+
+  /** Кнопка с callback data. */
+  static @NonNull Button cb(@NonNull String label, @NonNull String data) {
+    return req -> InlineKeyboardButton.builder().text(label).callbackData(data).build();
+  }
+
+  /** Обычная кнопка. */
+  static @NonNull Button btn(@NonNull String label) {
+    return cb(label, label);
+  }
+
+  /** Обычная кнопка из i18n. */
+  static @NonNull Button btnKey(@NonNull String key, @NonNull Object... args) {
+    return loc -> {
+      String text = loc != null ? loc.get(key, args) : key;
+      return InlineKeyboardButton.builder().text(text).callbackData(text).build();
+    };
+  }
+
+  /** Ссылка. */
+  static @NonNull Button url(@NonNull String label, @NonNull String url) {
+    return loc -> InlineKeyboardButton.builder().text(label).url(url).build();
+  }
+
+  /** Ссылка с текстом из i18n. */
+  static @NonNull Button urlKey(@NonNull String key, @NonNull String url, @NonNull Object... args) {
+    return loc ->
+        InlineKeyboardButton.builder()
+            .text(loc != null ? loc.get(key, args) : key)
+            .url(url)
+            .build();
+  }
+
+  /** Веб‑приложение. */
+  static @NonNull Button webApp(@NonNull String label, @NonNull String url) {
+    return loc -> InlineKeyboardButton.builder().text(label).webApp(new WebAppInfo(url)).build();
+  }
+
+  /** Веб‑приложение с текстом из i18n. */
+  static @NonNull Button webAppKey(
+      @NonNull String key, @NonNull String url, @NonNull Object... args) {
+    return loc ->
+        InlineKeyboardButton.builder()
+            .text(loc != null ? loc.get(key, args) : key)
+            .webApp(new WebAppInfo(url))
+            .build();
+  }
+
+  /** Кнопка с callback и текстом из i18n. */
+  static @NonNull Button cbKey(@NonNull String key, @NonNull String data, @NonNull Object... args) {
+    return loc ->
+        InlineKeyboardButton.builder()
+            .text(loc != null ? loc.get(key, args) : key)
+            .callbackData(data)
+            .build();
+  }
+
+  /** Создаёт экземпляр кнопки. */
+  @NonNull InlineKeyboardButton build(MessageLocalizer loc);
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/dsl/Common.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/dsl/Common.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.dsl;
+
+import io.github.tgkit.api.BotResponse;
+import io.github.tgkit.api.dsl.context.DSLContext;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.telegram.telegrambots.meta.api.methods.PartialBotApiMethod;
+
+/**
+ * Базовый fluent-контракт для всех билдeров DSL.
+ *
+ * @param <D> тип Telegram-метода, который возвращает {@link #build()}
+ * @param <T> конкретный тип билдера (для fluent-цепочек без кастов)
+ */
+public interface Common<T extends Common<T, D>, D extends PartialBotApiMethod<?>> {
+
+  @NonNull T requireChatId();
+
+  @NonNull T missingIdStrategy(@NonNull MissingIdStrategy strategy);
+
+  @NonNull T replyTo(long msgId);
+
+  @NonNull T disableNotif();
+
+  @NonNull T keyboard(@NonNull Consumer<KbBuilder> cfg);
+
+  @NonNull T when(@NonNull Predicate<DSLContext> cond, @NonNull Consumer<Common<T, D>> branch);
+
+  @NonNull T onlyAdmin(@NonNull Consumer<Common<T, D>> branch);
+
+  @NonNull T ifFlag(@NonNull String flag, @NonNull Consumer<Common<T, D>> branch);
+
+  @NonNull T flag(@NonNull String flag, @NonNull Consumer<Common<T, D>> branch);
+
+  // проверка для userId
+  @NonNull T flagUser(@NonNull String flag, @NonNull Consumer<Common<T, D>> branch);
+
+  // A/B-сплит: control / variant
+  @NonNull T abTest(
+      @NonNull String key,
+      @NonNull Consumer<Common<T, D>> control,
+      @NonNull Consumer<Common<T, D>> variant);
+
+  @NonNull T hooks(@NonNull Consumer<Long> ok, @NonNull Consumer<Throwable> fail);
+
+  @NonNull BotResponse send();
+
+  @NonNull CompletableFuture<BotResponse> sendAsync(@NonNull Executor executor);
+
+  @NonNull WithTtl ttl(@NonNull Duration d);
+
+  @NonNull D build();
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/dsl/MissingIdStrategy.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/dsl/MissingIdStrategy.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.dsl;
+
+import io.github.tgkit.api.dsl.context.DSLContext;
+import io.github.tgkit.api.exception.BotApiException;
+import io.github.tgkit.api.storage.BotRequestContextHolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@FunctionalInterface
+@SuppressWarnings("argument")
+public interface MissingIdStrategy {
+  Logger LOG = LoggerFactory.getLogger(MissingIdStrategy.class);
+
+  /** --- Готовые стратегии --- */
+  MissingIdStrategy ERROR =
+      (name, u) -> {
+        throw new BotApiException(
+            name + " is required but null in update: " + BotRequestContextHolder.getRequestId());
+      };
+
+  MissingIdStrategy WARN =
+      (name, u) ->
+          LOG.warn("{} is null in update {}", name, BotRequestContextHolder.getRequestId());
+  MissingIdStrategy IGNORE =
+      (name, u) -> {
+        /* ничего */
+      };
+
+  /** Вызывается, когда chatId или userId отсутствуют. */
+  void onMissing(String idName, DSLContext ctx) throws BotApiException;
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/dsl/context/DSLContext.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/dsl/context/DSLContext.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.dsl.context;
+
+import io.github.tgkit.api.BotInfo;
+import io.github.tgkit.api.BotService;
+import io.github.tgkit.api.exception.BotApiException;
+import io.github.tgkit.api.user.BotUserInfo;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/** Контекст выполнения ответа. */
+public interface DSLContext {
+
+  @NonNull BotInfo botInfo();
+
+  @NonNull BotUserInfo userInfo();
+
+  @NonNull BotService service();
+
+  /** Проверяет роль администратора. */
+  boolean isAdmin();
+
+  record SimpleDSLContext(
+      @NonNull BotService service, @NonNull BotInfo botInfo, @NonNull BotUserInfo userInfo)
+      implements DSLContext {
+
+    public SimpleDSLContext {
+      Long cId = userInfo.chatId();
+      Long uId = userInfo.userId();
+      if (cId == null && uId == null) {
+        throw new BotApiException("Both chatId and userId are null in update");
+      }
+    }
+
+    /** Проверяет роль администратора. */
+    public boolean isAdmin() {
+      return userInfo.roles().contains("ADMIN");
+    }
+  }
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/dsl/feature_flags/FeatureFlags.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/dsl/feature_flags/FeatureFlags.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.dsl.feature_flags;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/** Контракт проверки фич-флагов и A/B-тестов. */
+public interface FeatureFlags {
+
+  /** Включён ли флаг для чата? */
+  boolean isEnabled(@NonNull String key, long chatId);
+
+  /** Включён ли флаг для пользователя? */
+  boolean isEnabledForUser(@NonNull String key, long userId);
+
+  /** Вариант (“control”/“variant”) для A/B-теста; null = не участвует. */
+  @Nullable Variant variant(@NonNull String abKey, long entityId);
+
+  /** Включить флаг для чата */
+  void enableChat(@NonNull String key, long chatId);
+
+  /** Включить флаг для пользователя */
+  void enableUser(@NonNull String key, long userId);
+
+  /** Выключить флаг для чата */
+  void disableChat(@NonNull String key, long chatId);
+
+  /** Выключить флаг для пользователя */
+  void disableUser(@NonNull String key, long userId);
+
+  /** Добавить ключ для A/B */
+  void rollout(@NonNull String key, int percent);
+
+  /** Выключить флаг */
+  void disable(@NonNull String key);
+
+  /** Включить флаг */
+  void enable(@NonNull String key);
+
+  enum Variant {
+    CONTROL,
+    VARIANT
+  }
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/dsl/validator/PollSpec.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/dsl/validator/PollSpec.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.dsl.validator;
+
+import java.util.List;
+
+/* Вспомогательный record для опросов */
+public record PollSpec(String question, List<String> options, Integer correct) {}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/event/BotEvent.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/event/BotEvent.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.event;
+
+/** Маркер любого события шины */
+public interface BotEvent {}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/event/BotEventBus.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/event/BotEventBus.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.event;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Шина событий бота.
+ *
+ * <p><b>Стабильность:</b> API планируется стабильным, но пока может измениться.
+ */
+public interface BotEventBus {
+
+  /** Публикует событие *синхронно* (throw-on-error). */
+  <E extends BotEvent> void publish(@NonNull E event);
+
+  /** Публикует *асинхронно* (не блокирует продюсера). */
+  <E extends BotEvent> @NonNull CompletableFuture<Void> publishAsync(@NonNull E event);
+
+  /** Подписка на тип E. Возвращает handle для detach(). */
+  <E extends BotEvent> @NonNull BotEventSubscription subscribe(
+      @NonNull Class<E> type, @NonNull Consumer<E> handler);
+
+  /** Отписка вручную (optional). */
+  void unsubscribe(@NonNull BotEventSubscription s);
+
+  /** Кол-во событий, которые ещё в queue. */
+  int backlog();
+
+  /** Graceful-shutdown: дренируем очередь и ждём, когда consumers исчезнут. */
+  void shutdown() throws InterruptedException;
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/event/BotEventSubscription.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/event/BotEventSubscription.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.event;
+
+public interface BotEventSubscription {}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/exception/BotExceptionHandler.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/exception/BotExceptionHandler.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.exception;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+@FunctionalInterface
+public interface BotExceptionHandler {
+  @Nullable BotApiMethod<?> handle(@NonNull Update update, @NonNull Exception ex);
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/i18n/MessageKey.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/i18n/MessageKey.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.i18n;
+
+import java.util.Locale;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/** Обёртка над ключом для локализованных сообщений и аргументами форматирования. */
+public record MessageKey(String key, Object... args) {
+
+  /**
+   * @param key уникальный ключ в ресурсах (например, "wizard.reg.name.ask")
+   * @param args параметры для {@link String#format(Locale, String, Object...)}
+   */
+  public MessageKey(@NonNull String key, @NonNull Object... args) {
+    this.key = key;
+    this.args = args != null ? args.clone() : new Object[0];
+  }
+
+  public static @NonNull MessageKey of(@NonNull String key, Object... args) {
+    return new MessageKey(key, args);
+  }
+
+  /**
+   * @return аргументы для форматирования
+   */
+  @Override
+  public Object[] args() {
+    return args.clone();
+  }
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/i18n/MessageLocalizer.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/i18n/MessageLocalizer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.i18n;
+
+import java.util.Locale;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public interface MessageLocalizer {
+
+  /**
+   * Устанавливает локаль для текущего потока.
+   *
+   * @param locale новая локаль
+   */
+  void setLocale(@NonNull Locale locale);
+
+  /** Сбрасывает локаль текущего потока на дефолтную. */
+  void resetLocale();
+
+  /** Получить локализованную строку по ключу. Если ключ не найден, возвращается сам ключ. */
+  @NonNull String get(@NonNull MessageKey key);
+
+  /** Получить локализованную строку по ключу. Если ключ не найден, возвращается сам ключ. */
+  @NonNull String get(@NonNull String key);
+
+  /** Получить локализованную строку по ключу. Если ключ не найден, возвращается сам ключ. */
+  @NonNull String get(@NonNull String key, @NonNull String defaultValue);
+
+  /** Получить локализованную и форматированную строку по ключу с параметрами. */
+  @NonNull String get(@NonNull String key, @NonNull Object... args);
+
+  /** Получить локализованную и форматированную строку по ключу с параметрами. */
+  @NonNull String get(@NonNull String key, @NonNull String defaultValue, Object... args);
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/interceptor/BotInterceptor.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/interceptor/BotInterceptor.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.interceptor;
+
+import io.github.tgkit.api.BotRequest;
+import io.github.tgkit.api.BotResponse;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+/** Интерцептор обработки обновлений. Позволяет выполнить логику до и после основного хендлера. */
+public interface BotInterceptor {
+
+  /**
+   * Вызывается перед обработкой обновления.
+   *
+   * @param update полученное обновление
+   * @param request сформированный запрос
+   */
+  void preHandle(@NonNull Update update, @NonNull BotRequest<?> request);
+
+  /**
+   * Вызывается после основного обработчика, но до отправки ответа.
+   *
+   * @param update обработанное обновление
+   * @param request сформированный запрос
+   */
+  void postHandle(@NonNull Update update, @NonNull BotRequest<?> request);
+
+  /**
+   * Вызывается после завершения обработки обновления.
+   *
+   * @param update обновление
+   * @param request сформированный запрос
+   * @param response сформированный ответ, может быть {@code null}
+   * @param ex исключение, возникшее при обработке, может быть {@code null}
+   * @throws Exception любая ошибка, которую необходимо пробросить
+   */
+  void afterCompletion(
+      @NonNull Update update,
+      @Nullable BotRequest<?> request,
+      @Nullable BotResponse response,
+      @Nullable Exception ex)
+      throws Exception;
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/loader/BotCommandFactory.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/loader/BotCommandFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.loader;
+
+import io.github.tgkit.api.BotCommand;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Фабрика, позволяющая расширять {@link BotCommand}.
+ *
+ * @param <A> тип аннотации, по которой срабатывает фабрика
+ */
+public interface BotCommandFactory<A extends Annotation> {
+
+  /**
+   * @return класс аннотации, по которой нужно применить этот фабричный алгоритм(null == любая)
+   */
+  @SuppressWarnings("unchecked")
+  default @NonNull Class<A> annotationType() {
+    return (Class<A>) None.class;
+  }
+
+  /**
+   * Вызывается при обнаружении аннотации {@linkplain #annotationType()} на методе-хендлере.
+   * Доступна команда и сам метод.
+   *
+   * @param command команда {@link BotCommand}
+   * @param method метод-хендлер
+   * @param ann экземпляр аннотации
+   */
+  void apply(@NonNull BotCommand<?> command, @NonNull Method method, @Nullable A ann);
+
+  /** BotCommandFactory применяется на все команды */
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @interface None {}
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/matching/CommandMatch.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/matching/CommandMatch.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.matching;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+@FunctionalInterface
+@SuppressWarnings({"unchecked", "rawtypes"})
+public interface CommandMatch<T> {
+
+  boolean match(@NonNull T data);
+
+  default CommandMatch<T> and(@NonNull CommandMatch... other) {
+    return new CommandMatchAnd<>(other);
+  }
+
+  default CommandMatch<T> or(@NonNull CommandMatch... other) {
+    return new CommandMatchOr<>(other);
+  }
+
+  class CommandMatchOr<T> implements CommandMatch<T> {
+    private final CommandMatch<T>[] commandMatchers;
+
+    @SafeVarargs
+    public CommandMatchOr(@NonNull CommandMatch<T>... commandMatchers) {
+      this.commandMatchers = commandMatchers;
+    }
+
+    @Override
+    public boolean match(@NonNull T data) {
+      for (CommandMatch<T> matcher : commandMatchers) {
+        if (matcher.match(data)) {
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+
+  class CommandMatchAnd<T> implements CommandMatch<T> {
+    private final CommandMatch<T>[] commandMatchers;
+
+    @SafeVarargs
+    public CommandMatchAnd(@NonNull CommandMatch<T>... commandMatchers) {
+      this.commandMatchers = commandMatchers;
+    }
+
+    @Override
+    public boolean match(@NonNull T data) {
+      for (CommandMatch<T> matcher : commandMatchers) {
+        if (!matcher.match(data)) {
+          return false;
+        }
+      }
+      return true;
+    }
+  }
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/observability/ClosableMetricsServer.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/observability/ClosableMetricsServer.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.observability;
+
+import java.io.IOException;
+
+/** Интерфейс для управляемого HTTP-сервера метрик. */
+public interface ClosableMetricsServer extends AutoCloseable {
+
+  /** Запустить сервер метрик, принимающий запросы Prometheus. */
+  void start() throws IOException;
+
+  /** Остановить сервер метрик. */
+  void stop() throws IOException;
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/observability/ImmutableTag.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/observability/ImmutableTag.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.observability;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/** Неизменяемый тег. */
+public record ImmutableTag(String key, String value) implements Tag {
+
+  /**
+   * Создаёт тег с ключом и значением.
+   *
+   * @param key ключ
+   * @param value значение
+   */
+  public ImmutableTag(@NonNull String key, @NonNull String value) {
+    this.key = key;
+    this.value = value;
+  }
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/observability/Span.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/observability/Span.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.observability;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/** Интерфейс абстракции над span системы трассировки. */
+public interface Span extends AutoCloseable {
+
+  /**
+   * Отмечает span как завершившийся с ошибкой.
+   *
+   * @param t причина ошибки
+   */
+  void setError(@NonNull Throwable t);
+
+  /**
+   * Проставляет тег в span
+   *
+   * @param tag - ключ
+   * @param value - значение
+   */
+  void setTag(@NonNull String tag, @NonNull String value);
+
+  /**
+   * Завершает span без ошибки.
+   *
+   * @see AutoCloseable#close()
+   */
+  @Override
+  void close();
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/observability/Tag.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/observability/Tag.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.observability;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/** Интерфейс тега метрики. */
+public interface Tag extends Comparable<Tag> {
+
+  /**
+   * Создаёт неизменяемый тег.
+   *
+   * @param key ключ
+   * @param value значение
+   * @return новый тег
+   */
+  static Tag of(@NonNull String key, @NonNull String value) {
+    return new ImmutableTag(key, value);
+  }
+
+  /** Возвращает ключ тега. */
+  @NonNull String key();
+
+  /** Возвращает значение тега. */
+  @NonNull String value();
+
+  /**
+   * Сравнивает теги по ключу.
+   *
+   * @param o другой тег
+   * @return результат сравнения
+   */
+  @Override
+  default int compareTo(@NonNull Tag o) {
+    return this.key().compareTo(o.key());
+  }
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/observability/Tags.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/observability/Tags.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.observability;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Набор тегов метрик.
+ *
+ * @param items массив тегов Micrometer
+ */
+public record Tags(@NonNull Tag... items) {
+
+  /**
+   * Создаёт объект {@link Tags} из набора тегов.
+   *
+   * @param items массив тегов
+   * @return новый объект
+   */
+  public static Tags of(@NonNull Tag... items) {
+    return new Tags(items);
+  }
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/observability/Tracer.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/observability/Tracer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.observability;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/** Абстракция над системой трассировки. */
+public interface Tracer {
+
+  /**
+   * Запускает новый span.
+   *
+   * @param spanName имя span
+   * @param tags теги
+   * @return созданный {@link Span}
+   */
+  Span start(@NonNull String spanName, @NonNull Tags tags);
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/plugin/BotPlugin.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/plugin/BotPlugin.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.plugin;
+
+public interface BotPlugin extends PluginLifecycle {
+
+  default void start() throws Exception {}
+
+  default void stop() throws Exception {}
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/plugin/BotPluginContext.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/plugin/BotPluginContext.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.plugin;
+
+import io.github.tgkit.api.bot.BotRegistry;
+import io.github.tgkit.api.config.BotGlobalConfig;
+import io.github.tgkit.api.dsl.feature_flags.FeatureFlags;
+import io.github.tgkit.api.event.BotEventBus;
+import io.github.tgkit.api.ttl.TtlScheduler;
+import io.github.tgkit.api.security.audit.AuditBus;
+import io.github.tgkit.api.security.secret.SecretStore;
+import java.net.http.HttpClient;
+import java.util.concurrent.ExecutorService;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public interface BotPluginContext {
+
+  /** Получить spi сервис */
+  @Nullable <T> T getService(@NonNull Class<T> type);
+
+  /** Основной конфиг (на чтение). */
+  @NonNull BotGlobalConfig config();
+
+  /** Планировщик TTL-/cron-задач. */
+  @NonNull TtlScheduler scheduler();
+
+  /** Feature-flags (LaunchDarkly / Redis). */
+  @NonNull FeatureFlags featureFlags();
+
+  /** Централизованный Audit-шлюз. */
+  @NonNull AuditBus audit();
+
+  /** Храним и забираем секреты. */
+  @NonNull SecretStore secrets();
+
+  /** Рассылка/подписка на события ядра. */
+  @NonNull BotEventBus eventBus();
+
+  @NonNull BotRegistry registry();
+
+  /** Выделенный CPU-/I/O-executor плагина. */
+  @NonNull ExecutorService ioExecutor();
+
+  /** Готовый настроенный HTTP-клиент (TLS, proxy, retry). */
+  @NonNull HttpClient http();
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/plugin/PluginLifecycle.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/plugin/PluginLifecycle.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.plugin;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ *
+ *
+ * <h3>PluginLifecycle</h3>
+ *
+ * <p>Минимальный контракт, который должен реализовать каждый JAR-плагин.
+ *
+ * <ul>
+ *   <li>{@link #onLoad(BotPluginContext)} — вызывается сразу после того, как PluginManager
+ *       подгрузил JAR и сформировал контекст.
+ *   <li>{@link #onUnload()} — всегда вызывается перед выгрузкой ClassLoader’а (hot-reload,
+ *       shutdown). Освободите ресурсы, отмените задачи.
+ * </ul>
+ *
+ * <p>❗ Не блокируйте поток внутри этих методов. Для I/O используйте
+ */
+public interface PluginLifecycle {
+
+  /** Инициализация плагина. */
+  default void onLoad(@NonNull BotPluginContext ctx) throws Exception {}
+
+  /** Корректное завершение работы, освобождение ресурсов. */
+  default void onUnload() throws Exception {}
+
+  /** Hook перед остановкой плагина, для подготовки. */
+  default void beforeStop() throws Exception {}
+
+  /** Hook после stop, для финальной очистки. */
+  default void afterStop() throws Exception {}
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/resource/ResourceLoader.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/resource/ResourceLoader.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.resource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public interface ResourceLoader {
+
+  /** Открывает поток к содержимому. */
+  @NonNull InputStream open() throws IOException;
+
+  /** Идентификатор/имя (используется для логов и чтобы понять расширение). */
+  @NonNull String id();
+
+  /* sugar-helpers */
+  default byte[] bytes() throws IOException {
+    try (InputStream is = open()) {
+      return is.readAllBytes();
+    }
+  }
+
+  default String text() throws IOException {
+    return new String(bytes());
+  }
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/security/antispam/DuplicateProvider.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/security/antispam/DuplicateProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.security.antispam;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public interface DuplicateProvider {
+
+  /**
+   * @return {@code true}, если такой текст уже встречался в окне TTL
+   */
+  boolean isDuplicate(long chat, @NonNull String text);
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/security/audit/AuditBus.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/security/audit/AuditBus.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.security.audit;
+
+import java.util.List;
+import java.util.function.Consumer;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/** Единый контракт для публикации и подписки. */
+public interface AuditBus extends AutoCloseable {
+
+  /** Опубликовать событие (быстро, без блокировок). */
+  void publish(@NonNull AuditEvent event);
+
+  /** Зарегистрировать подписчика. */
+  void subscribe(@NonNull Consumer<AuditEvent> handler);
+
+  /** Убрать подписчика. */
+  void unsubscribe(@NonNull Consumer<AuditEvent> handler);
+
+  @NonNull List<Consumer<AuditEvent>> getSubscribers();
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/security/audit/AuditConverter.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/security/audit/AuditConverter.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.security.audit;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+public interface AuditConverter {
+  @NonNull AuditEvent convert(@NonNull Update src);
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/security/audit/AuditSink.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/security/audit/AuditSink.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.security.audit;
+
+import java.io.Closeable;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public interface AuditSink extends Closeable {
+
+  /** асинхронно - вызывается в worker-треде AuditBus */
+  void emit(@NonNull AuditEvent ev) throws Exception;
+
+  /** low-bps fallback */
+  default void close() {}
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/security/captcha/CaptchaProvider.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/security/captcha/CaptchaProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.security.captcha;
+
+import io.github.tgkit.api.BotRequest;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.telegram.telegrambots.meta.api.methods.PartialBotApiMethod;
+
+/**
+ * Провайдер CAPTCHA. Возвращает готовое сообщение с вопросом и клавиатурой и проверяет ответ
+ * пользователя.
+ */
+public interface CaptchaProvider {
+
+  /**
+   * Формирует сообщение-вопрос для указанного чата.
+   *
+   * @return {@link PartialBotApiMethod}
+   */
+  @NonNull PartialBotApiMethod<?> question(@NonNull BotRequest<?> request);
+
+  /**
+   * Проверяет ответ пользователя.
+   *
+   * @param answer ответ пользователя
+   * @return {@code true}, если ответ верен
+   */
+  boolean verify(@NonNull BotRequest<?> request, @NonNull String answer);
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/security/captcha/MathCaptchaProviderStore.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/security/captcha/MathCaptchaProviderStore.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.security.captcha;
+
+import java.time.Duration;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public interface MathCaptchaProviderStore {
+
+  void put(long chatId, int answer, @NonNull Duration ttl);
+
+  @Nullable Integer pop(long chatId); // get + delete
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/security/ratelimit/RateLimiter.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/security/ratelimit/RateLimiter.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.security.ratelimit;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public interface RateLimiter {
+
+  boolean tryAcquire(@NonNull String key, int permits, int seconds);
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/security/secret/SecretStore.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/security/secret/SecretStore.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.security.secret;
+
+import java.util.Optional;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public interface SecretStore extends AutoCloseable {
+
+  /**
+   * @return secret or {@code Optional.empty()} if provider does not have it.
+   */
+  Optional<String> get(@NonNull String key);
+
+  /** override if store keeps connections/resources */
+  default void close() {
+    /* noop */
+  }
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/state/StateStore.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/state/StateStore.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.state;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public interface StateStore {
+
+  @Nullable String get(@NonNull String chatId);
+
+  void set(@NonNull String chatId, @NonNull String value);
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/ttl/DeleteTask.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/ttl/DeleteTask.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.ttl;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/** Задача удаления. */
+public record DeleteTask(long chatId, long messageId, @NonNull Runnable action) {}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/ttl/TtlPolicy.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/ttl/TtlPolicy.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.ttl;
+
+import java.time.Duration;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public interface TtlPolicy {
+
+  static TtlPolicy defaults() {
+    return new TtlPolicy() {
+
+      @Override
+      public int maxRetries() {
+        return 7;
+      }
+
+      @Override
+      public @NonNull Duration initialBackOff() {
+        return Duration.ofSeconds(2);
+      }
+
+      @Override
+      public @NonNull Duration maxBackOff() {
+        return Duration.ofSeconds(5);
+      }
+    };
+  }
+
+  int maxRetries();
+
+  @NonNull Duration initialBackOff();
+
+  @NonNull Duration maxBackOff();
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/ttl/TtlScheduler.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/ttl/TtlScheduler.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.ttl;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/** Планировщик задач TTL-delete. */
+public interface TtlScheduler extends AutoCloseable {
+
+  @NonNull CompletableFuture<Void> schedule(
+      @NonNull DeleteTask task, @NonNull Duration delay, @NonNull TtlPolicy policy);
+
+  default @NonNull CompletableFuture<Void> schedule(
+      @NonNull DeleteTask task, @NonNull Duration delay) {
+    return schedule(task, delay, TtlPolicy.defaults());
+  }
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/user/BotUserInfo.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/user/BotUserInfo.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.user;
+
+import java.util.Locale;
+import java.util.Set;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public interface BotUserInfo {
+
+  @Nullable Long chatId();
+
+  @Nullable Long userId();
+
+  @Nullable Long internalUserId();
+
+  @NonNull Set<String> roles();
+
+  default @Nullable Locale locale() {
+    return null;
+  }
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/user/BotUserProvider.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/user/BotUserProvider.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.user;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+public interface BotUserProvider {
+  @NonNull BotUserInfo resolve(@NonNull Update update);
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/user/store/UserKVStore.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/user/store/UserKVStore.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.user.store;
+
+import java.util.Map;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/** Контракт key-value-хранилища «данные пользователя» */
+public interface UserKVStore {
+
+  @Nullable String get(long userId, @NonNull String key);
+
+  @NonNull Map<String, String> getAll(long userId);
+
+  void put(long userId, @NonNull String key, @NonNull String value);
+
+  void remove(long userId, @NonNull String key);
+
+  default boolean contains(long userId, @NonNull String key) {
+    return get(userId, key) != null;
+  }
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/validator/Validator.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/validator/Validator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.validator;
+
+import io.github.tgkit.api.exception.ValidationException;
+import io.github.tgkit.api.i18n.MessageKey;
+import java.util.Objects;
+import java.util.function.Predicate;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Универсальный валидатор для любых типов {@code T}.
+ *
+ * @param <T> тип проверяемого значения
+ */
+@FunctionalInterface
+public interface Validator<T> {
+
+  /**
+   * Создаёт {@code Validator<T>} из произвольного {@link Predicate} и ключа ошибки.
+   *
+   * @param predicate условие прохождения
+   * @param errorKey ключ для локализованного сообщения об ошибке
+   */
+  static <T> @NonNull Validator<T> of(
+      @NonNull Predicate<T> predicate, @NonNull MessageKey errorKey) {
+    return v -> {
+      if (!predicate.test(v)) {
+        throw ValidationException.of(errorKey);
+      }
+    };
+  }
+
+  /**
+   * Проверяет значение на корректность.
+   *
+   * @param value входное значение
+   * @throws ValidationException если проверка не прошла
+   */
+  void validate(@Nullable T value) throws ValidationException;
+
+  /** Комбинирует два валидатора: сначала этот, потом другой. */
+  default @NonNull Validator<T> and(@NonNull Validator<? super T> other) {
+    Objects.requireNonNull(other, "other");
+    return v -> {
+      validate(v);
+      other.validate(v);
+    };
+  }
+
+  /** «Или»: если первый не прошёл, пытаем второй. */
+  default @NonNull Validator<T> or(@NonNull Validator<? super T> other) {
+    Objects.requireNonNull(other, "other");
+    return v -> {
+      try {
+        validate(v);
+      } catch (ValidationException ex) {
+        other.validate(v);
+      }
+    };
+  }
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/wizard/StepBuilder.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/wizard/StepBuilder.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.wizard;
+
+import io.github.tgkit.api.BotRequest;
+import io.github.tgkit.api.i18n.MessageKey;
+import io.github.tgkit.api.validator.Validator;
+import java.time.Duration;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.telegram.telegrambots.meta.api.objects.Location;
+import org.telegram.telegrambots.meta.api.objects.PhotoSize;
+import org.telegram.telegrambots.meta.api.objects.Video;
+import org.telegram.telegrambots.meta.api.objects.VideoNote;
+
+/**
+ * Построитель одного шага сценария: задаёт вопрос, парсит ввод, валидирует, сохраняет в модель и
+ * настраивает branching/timeout/resume/A-B/preFinish.
+ *
+ * @param <M> модель‐DTO
+ * @param <I> исходный тип ввода
+ * @param <O> тип после преобразования
+ */
+public interface StepBuilder<M, I, O> {
+
+  /** Варианты вопроса (A/B-тест). */
+  @NonNull StepBuilder<M, I, O> ask(@NonNull MessageKey... questionKeys);
+
+  /** Парсим простую строку. */
+  @NonNull StepBuilder<M, String, String> expectText();
+
+  /** Парсим целое. */
+  @NonNull StepBuilder<M, String, Integer> expectInt();
+
+  /** Парсим фото. */
+  @NonNull StepBuilder<M, ?, List<PhotoSize>> expectPhoto();
+
+  /** Парсим видео. */
+  @NonNull StepBuilder<M, ?, Video> expectVideo();
+
+  /** Парсим videoNote. */
+  @NonNull StepBuilder<M, ?, VideoNote> expectVideoNote();
+
+  /** Парсим локацию. */
+  @NonNull StepBuilder<M, ?, Location> expectLocation();
+
+  /** Парсим callback-кнопку по payload → строка. */
+  @NonNull StepBuilder<M, ?, String> expectButtons(@NonNull List<String> payloads);
+
+  /** Добавляет валидатор. */
+  @NonNull <V extends Validator<O>> StepBuilder<M, I, O> validate(@NonNull V validator);
+
+  /** Сохраняет результат O в модель M. */
+  void save(@NonNull BiConsumer<M, O> setter);
+
+  /** Разрешает «назад» и задаёт hook. */
+  @NonNull StepBuilder<M, I, O> allowBack(@NonNull BiConsumer<BotRequest<?>, M> onBack);
+
+  /** Разрешает «пропустить» и задаёт hook. */
+  @NonNull StepBuilder<M, I, O> allowSkip(@NonNull BiConsumer<BotRequest<?>, M> onSkip);
+
+  /** Разрешает «отменить» и задаёт hook. */
+  @NonNull StepBuilder<M, I, O> allowCancel(@NonNull BiConsumer<BotRequest<?>, M> onCancel);
+
+  /** Ветвление: условие + следующий шаг. */
+  @NonNull StepBuilder<M, I, O> nextIf(@NonNull Predicate<M> condition, @NonNull String nextStepId);
+
+  /** Таймаут и клавиша-навигация после него. */
+  @NonNull StepBuilder<M, I, O> onTimeout(@NonNull Duration after, @NonNull MessageKey reminderKey);
+
+  /** Pre–finish hook; при false идём на failStepId. */
+  @NonNull StepBuilder<M, I, O> preFinish(
+      @NonNull Predicate<M> checker, @NonNull String failStepId);
+}

--- a/tgkit-api/src/main/java/module-info.java
+++ b/tgkit-api/src/main/java/module-info.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.github.tgkit.api {
+  requires transitive telegrambots;
+  requires transitive telegrambots.meta;
+  requires transitive org.slf4j;
+  requires transitive java.net.http;
+  requires transitive org.apache.httpcomponents.httpclient;
+  requires transitive org.apache.httpcomponents.httpcore;
+  requires static webhook;
+  requires static com.fasterxml.jackson.annotation;
+  requires static org.checkerframework.checker.qual;
+
+  exports io.github.tgkit.api;
+  exports io.github.tgkit.api.annotation;
+  exports io.github.tgkit.api.args;
+  exports io.github.tgkit.api.bot;
+  exports io.github.tgkit.api.config;
+  exports io.github.tgkit.api.crypto;
+  exports io.github.tgkit.api.dsl;
+  exports io.github.tgkit.api.dsl.context;
+  exports io.github.tgkit.api.dsl.feature_flags;
+  exports io.github.tgkit.api.dsl.ttl;
+  exports io.github.tgkit.api.dsl.validator;
+  exports io.github.tgkit.api.event;
+  exports io.github.tgkit.api.exception;
+  exports io.github.tgkit.api.i18n;
+  exports io.github.tgkit.api.interceptor;
+  exports io.github.tgkit.api.matching;
+  exports io.github.tgkit.api.parse_mode;
+  exports io.github.tgkit.api.resource;
+  exports io.github.tgkit.api.state;
+  exports io.github.tgkit.api.storage;
+  exports io.github.tgkit.api.ttl;
+  exports io.github.tgkit.api.user;
+  exports io.github.tgkit.api.user.store;
+  exports io.github.tgkit.api.wizard;
+  exports io.github.tgkit.api.validator;
+  exports io.github.tgkit.api.annotation.wizard;
+  exports io.github.tgkit.api.observability;
+  exports io.github.tgkit.api.plugin;
+  exports io.github.tgkit.api.security.antispam;
+  exports io.github.tgkit.api.security.audit;
+  exports io.github.tgkit.api.security.captcha;
+  exports io.github.tgkit.api.security.ratelimit;
+  exports io.github.tgkit.api.security.rbac;
+  exports io.github.tgkit.api.security.secret;
+}


### PR DESCRIPTION
## Summary
- register `tgkit-api` module in parent POM
- copy module-info to new module
- move public interfaces and records into `io.github.tgkit.api.*`

## Testing
- `mvn -q verify` *(fails: module not found webhook)*

------
https://chatgpt.com/codex/tasks/task_e_685697f663908325aaef6f0e9dd806ae