### PR TITLE
Fix testkit to use tgkit-api

### DIFF
--- a/testkit/pom.xml
+++ b/testkit/pom.xml
@@ -18,7 +18,7 @@
         </dependency>
         <dependency>
             <groupId>io.github.tgkit</groupId>
-            <artifactId>api</artifactId>
+            <artifactId>tgkit-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/testkit/src/main/java/io/github/tgkit/testkit/UpdateInjector.java
+++ b/testkit/src/main/java/io/github/tgkit/testkit/UpdateInjector.java
@@ -15,7 +15,7 @@
  */
 package io.github.tgkit.testkit;
 
-import io.github.tgkit.internal.BotAdapter;
+import io.github.tgkit.api.BotAdapter;
 import io.github.tgkit.internal.bot.TelegramSender;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/testkit/src/test/java/io/github/tgkit/testkit/WelcomeFlowTest.java
+++ b/testkit/src/test/java/io/github/tgkit/testkit/WelcomeFlowTest.java
@@ -17,12 +17,12 @@ package io.github.tgkit.testkit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.github.tgkit.internal.BotCommand;
-import io.github.tgkit.internal.BotRequest;
-import io.github.tgkit.internal.BotRequestType;
-import io.github.tgkit.internal.BotResponse;
+import io.github.tgkit.api.BotCommand;
+import io.github.tgkit.api.BotRequest;
+import io.github.tgkit.api.BotRequestType;
+import io.github.tgkit.api.BotResponse;
 import io.github.tgkit.internal.bot.BotAdapterImpl;
-import io.github.tgkit.internal.matching.CommandMatch;
+import io.github.tgkit.api.matching.CommandMatch;
 import java.util.concurrent.TimeUnit;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Summary
- depend on `tgkit-api` in testkit
- update imports in UpdateInjector and WelcomeFlowTest

## Testing
- `mvn -pl testkit -am test -Dspotless.check.skip=true` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856a93176e883259164627c57f5fff3