### PR TITLE
Refactor security imports for new API module

### DIFF
--- a/security/src/main/java/io/github/tgkit/security/antispam/AntiSpamInterceptor.java
+++ b/security/src/main/java/io/github/tgkit/security/antispam/AntiSpamInterceptor.java
@@ -15,10 +15,10 @@
  */
 package io.github.tgkit.security.antispam;
 
-import io.github.tgkit.internal.BotRequest;
+import io.github.tgkit.api.BotRequest;
 import io.github.tgkit.internal.BotResponse;
 import io.github.tgkit.internal.config.BotGlobalConfig;
-import io.github.tgkit.internal.interceptor.BotInterceptor;
+import io.github.tgkit.api.interceptor.BotInterceptor;
 import io.github.tgkit.security.captcha.CaptchaProvider;
 import io.github.tgkit.security.event.SecurityBotEvent;
 import io.github.tgkit.security.ratelimit.RateLimiter;

--- a/security/src/main/java/io/github/tgkit/security/audit/AsyncAuditBus.java
+++ b/security/src/main/java/io/github/tgkit/security/audit/AsyncAuditBus.java
@@ -16,7 +16,7 @@
 package io.github.tgkit.security.audit;
 
 import io.github.tgkit.internal.config.BotGlobalConfig;
-import io.github.tgkit.internal.exception.BotApiException;
+import io.github.tgkit.api.exception.BotApiException;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CopyOnWriteArrayList;

--- a/security/src/main/java/io/github/tgkit/security/audit/AuditBotCommandFactory.java
+++ b/security/src/main/java/io/github/tgkit/security/audit/AuditBotCommandFactory.java
@@ -15,9 +15,9 @@
  */
 package io.github.tgkit.security.audit;
 
-import io.github.tgkit.internal.BotCommand;
-import io.github.tgkit.internal.interceptor.BotInterceptor;
-import io.github.tgkit.internal.loader.BotCommandFactory;
+import io.github.tgkit.api.BotCommand;
+import io.github.tgkit.api.interceptor.BotInterceptor;
+import io.github.tgkit.api.loader.BotCommandFactory;
 import io.github.tgkit.internal.reflection.ReflectionUtils;
 import io.github.tgkit.security.config.BotSecurityGlobalConfig;
 import java.lang.reflect.Method;

--- a/security/src/main/java/io/github/tgkit/security/audit/DelegatingAuditInterceptor.java
+++ b/security/src/main/java/io/github/tgkit/security/audit/DelegatingAuditInterceptor.java
@@ -15,9 +15,9 @@
  */
 package io.github.tgkit.security.audit;
 
-import io.github.tgkit.internal.BotRequest;
+import io.github.tgkit.api.BotRequest;
 import io.github.tgkit.internal.BotResponse;
-import io.github.tgkit.internal.interceptor.BotInterceptor;
+import io.github.tgkit.api.interceptor.BotInterceptor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.telegram.telegrambots.meta.api.objects.Update;

--- a/security/src/main/java/io/github/tgkit/security/captcha/provider/MathCaptchaProvider.java
+++ b/security/src/main/java/io/github/tgkit/security/captcha/provider/MathCaptchaProvider.java
@@ -15,7 +15,7 @@
  */
 package io.github.tgkit.security.captcha.provider;
 
-import io.github.tgkit.internal.BotRequest;
+import io.github.tgkit.api.BotRequest;
 import io.github.tgkit.security.captcha.CaptchaProvider;
 import io.github.tgkit.security.captcha.InMemoryMathCaptchaProviderStore;
 import io.github.tgkit.security.captcha.MathCaptchaOperations;

--- a/security/src/main/java/io/github/tgkit/security/captcha/provider/RecaptchaWebProvider.java
+++ b/security/src/main/java/io/github/tgkit/security/captcha/provider/RecaptchaWebProvider.java
@@ -16,10 +16,10 @@
 package io.github.tgkit.security.captcha.provider;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.github.tgkit.internal.BotRequest;
+import io.github.tgkit.api.BotRequest;
 import io.github.tgkit.internal.config.BotGlobalConfig;
-import io.github.tgkit.internal.dsl.Button;
-import io.github.tgkit.internal.exception.BotApiException;
+import io.github.tgkit.api.dsl.Button;
+import io.github.tgkit.api.exception.BotApiException;
 import io.github.tgkit.security.captcha.CaptchaProvider;
 import io.github.tgkit.security.secret.SecretStore;
 import java.net.URI;

--- a/security/src/main/java/io/github/tgkit/security/captcha/provider/SliderCaptchaProvider.java
+++ b/security/src/main/java/io/github/tgkit/security/captcha/provider/SliderCaptchaProvider.java
@@ -17,9 +17,9 @@ package io.github.tgkit.security.captcha.provider;
 
 import static java.util.Collections.synchronizedMap;
 
-import io.github.tgkit.internal.BotRequest;
-import io.github.tgkit.internal.dsl.Button;
-import io.github.tgkit.internal.exception.BotApiException;
+import io.github.tgkit.api.BotRequest;
+import io.github.tgkit.api.dsl.Button;
+import io.github.tgkit.api.exception.BotApiException;
 import io.github.tgkit.security.captcha.CaptchaProvider;
 import java.awt.AlphaComposite;
 import java.awt.Graphics2D;

--- a/security/src/main/java/io/github/tgkit/security/event/SecurityBotEvent.java
+++ b/security/src/main/java/io/github/tgkit/security/event/SecurityBotEvent.java
@@ -15,10 +15,10 @@
  */
 package io.github.tgkit.security.event;
 
-import io.github.tgkit.internal.BotRequest;
+import io.github.tgkit.api.BotRequest;
 import io.github.tgkit.internal.bot.BotRegistryImpl;
 import io.github.tgkit.internal.event.TelegramBotEvent;
-import io.github.tgkit.internal.exception.BotApiException;
+import io.github.tgkit.api.exception.BotApiException;
 import java.time.Instant;
 import org.checkerframework.checker.nullness.qual.NonNull;
 

--- a/security/src/main/java/io/github/tgkit/security/ratelimit/RateLimitBotCommandFactory.java
+++ b/security/src/main/java/io/github/tgkit/security/ratelimit/RateLimitBotCommandFactory.java
@@ -15,8 +15,8 @@
  */
 package io.github.tgkit.security.ratelimit;
 
-import io.github.tgkit.internal.BotCommand;
-import io.github.tgkit.internal.loader.BotCommandFactory;
+import io.github.tgkit.api.BotCommand;
+import io.github.tgkit.api.loader.BotCommandFactory;
 import io.github.tgkit.security.config.BotSecurityGlobalConfig;
 import java.lang.reflect.Method;
 import java.util.ArrayList;

--- a/security/src/main/java/io/github/tgkit/security/ratelimit/RateLimitInterceptor.java
+++ b/security/src/main/java/io/github/tgkit/security/ratelimit/RateLimitInterceptor.java
@@ -15,9 +15,9 @@
  */
 package io.github.tgkit.security.ratelimit;
 
-import io.github.tgkit.internal.BotRequest;
+import io.github.tgkit.api.BotRequest;
 import io.github.tgkit.internal.BotResponse;
-import io.github.tgkit.internal.interceptor.BotInterceptor;
+import io.github.tgkit.api.interceptor.BotInterceptor;
 import io.github.tgkit.internal.update.UpdateUtils;
 import java.util.List;
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/security/src/main/java/io/github/tgkit/security/rbac/RoleBotCommandFactory.java
+++ b/security/src/main/java/io/github/tgkit/security/rbac/RoleBotCommandFactory.java
@@ -15,8 +15,8 @@
  */
 package io.github.tgkit.security.rbac;
 
-import io.github.tgkit.internal.BotCommand;
-import io.github.tgkit.internal.loader.BotCommandFactory;
+import io.github.tgkit.api.BotCommand;
+import io.github.tgkit.api.loader.BotCommandFactory;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.stream.Collectors;

--- a/security/src/main/java/io/github/tgkit/security/rbac/RoleInterceptor.java
+++ b/security/src/main/java/io/github/tgkit/security/rbac/RoleInterceptor.java
@@ -15,10 +15,10 @@
  */
 package io.github.tgkit.security.rbac;
 
-import io.github.tgkit.internal.BotRequest;
+import io.github.tgkit.api.BotRequest;
 import io.github.tgkit.internal.BotResponse;
-import io.github.tgkit.internal.interceptor.BotInterceptor;
-import io.github.tgkit.internal.user.BotUserInfo;
+import io.github.tgkit.api.interceptor.BotInterceptor;
+import io.github.tgkit.api.user.BotUserInfo;
 import java.util.Set;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;

--- a/security/src/test/java/io/github/tgkit/security/antispam/AntiSpamInterceptorTest.java
+++ b/security/src/test/java/io/github/tgkit/security/antispam/AntiSpamInterceptorTest.java
@@ -19,8 +19,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
-import io.github.tgkit.internal.BotRequest;
-import io.github.tgkit.internal.BotService;
+import io.github.tgkit.api.BotRequest;
+import io.github.tgkit.api.BotService;
 import io.github.tgkit.internal.i18n.MessageLocalizerImpl;
 import io.github.tgkit.security.captcha.CaptchaProvider;
 import io.github.tgkit.security.init.BotSecurityInitializer;

--- a/security/src/test/java/io/github/tgkit/security/captcha/MathCaptchaProviderServiceTest.java
+++ b/security/src/test/java/io/github/tgkit/security/captcha/MathCaptchaProviderServiceTest.java
@@ -18,12 +18,12 @@ package io.github.tgkit.security.captcha;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
-import io.github.tgkit.internal.BotRequest;
-import io.github.tgkit.internal.BotService;
+import io.github.tgkit.api.BotRequest;
+import io.github.tgkit.api.BotService;
 import io.github.tgkit.internal.i18n.MessageLocalizer;
 import io.github.tgkit.internal.i18n.MessageLocalizerImpl;
-import io.github.tgkit.internal.user.BotUserInfo;
-import io.github.tgkit.internal.user.store.UserKVStore;
+import io.github.tgkit.api.user.BotUserInfo;
+import io.github.tgkit.api.user.store.UserKVStore;
 import io.github.tgkit.security.TestUtils;
 import io.github.tgkit.security.captcha.provider.MathCaptchaProvider;
 import io.github.tgkit.security.init.BotSecurityInitializer;

--- a/security/src/test/java/io/github/tgkit/security/limiter/TelegramSenderRateLimiterTest.java
+++ b/security/src/test/java/io/github/tgkit/security/limiter/TelegramSenderRateLimiterTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
-import io.github.tgkit.internal.interceptor.BotInterceptor;
+import io.github.tgkit.api.interceptor.BotInterceptor;
 import io.github.tgkit.security.*;
 import io.github.tgkit.security.init.BotSecurityInitializer;
 import io.github.tgkit.security.ratelimit.*;

--- a/security/src/test/java/io/github/tgkit/security/rbac/RoleSecurityTest.java
+++ b/security/src/test/java/io/github/tgkit/security/rbac/RoleSecurityTest.java
@@ -19,9 +19,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
-import io.github.tgkit.internal.BotRequest;
-import io.github.tgkit.internal.interceptor.BotInterceptor;
-import io.github.tgkit.internal.loader.BotCommandFactory;
+import io.github.tgkit.api.BotRequest;
+import io.github.tgkit.api.interceptor.BotInterceptor;
+import io.github.tgkit.api.loader.BotCommandFactory;
 import io.github.tgkit.security.init.BotSecurityInitializer;
 import io.github.tgkit.testkit.TestBotBootstrap;
 import java.lang.reflect.Method;

--- a/security/src/test/java/io/github/tgkit/security/rbac/SimpleUser.java
+++ b/security/src/test/java/io/github/tgkit/security/rbac/SimpleUser.java
@@ -15,7 +15,7 @@
  */
 package io.github.tgkit.security.rbac;
 
-import io.github.tgkit.internal.user.BotUserInfo;
+import io.github.tgkit.api.user.BotUserInfo;
 import java.util.Set;
 import org.checkerframework.checker.nullness.qual.Nullable;
 


### PR DESCRIPTION
## Summary
- update `security` module imports to use `io.github.tgkit.api` classes
- adjust tests accordingly

## Testing
- `mvn -q verify -pl security -am` *(fails: module not found 'webhook')*

------
https://chatgpt.com/codex/tasks/task_e_6856a934bc7c8325ad17b2eaced53bcf