### PR TITLE
Fix plugin imports

### DIFF
--- a/plugin/src/main/java/io/github/tgkit/plugin/BotPluginManager.java
+++ b/plugin/src/main/java/io/github/tgkit/plugin/BotPluginManager.java
@@ -20,7 +20,7 @@ import static io.github.tgkit.plugin.internal.BotPluginConstants.CURRENT_VERSION
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.github.zafarkhaja.semver.Version;
-import io.github.tgkit.internal.exception.BotApiException;
+import io.github.tgkit.api.exception.BotApiException;
 import io.github.tgkit.plugin.internal.BotPluginContainer;
 import io.github.tgkit.plugin.internal.BotPluginContextDefault;
 import io.github.tgkit.plugin.internal.BotPluginDescriptor;

--- a/plugin/src/main/java/io/github/tgkit/plugin/internal/BotPluginContextDefault.java
+++ b/plugin/src/main/java/io/github/tgkit/plugin/internal/BotPluginContextDefault.java
@@ -15,12 +15,12 @@
  */
 package io.github.tgkit.plugin;
 
-import io.github.tgkit.internal.bot.BotRegistry;
+import io.github.tgkit.api.bot.BotRegistry;
+import io.github.tgkit.api.config.BotGlobalConfig;
+import io.github.tgkit.api.dsl.feature_flags.FeatureFlags;
+import io.github.tgkit.api.event.BotEventBus;
+import io.github.tgkit.api.ttl.TtlScheduler;
 import io.github.tgkit.internal.bot.BotRegistryImpl;
-import io.github.tgkit.internal.config.BotGlobalConfig;
-import io.github.tgkit.internal.dsl.feature_flags.FeatureFlags;
-import io.github.tgkit.internal.event.BotEventBus;
-import io.github.tgkit.internal.ttl.TtlScheduler;
 import io.github.tgkit.security.audit.AuditBus;
 import io.github.tgkit.security.config.BotSecurityGlobalConfig;
 import io.github.tgkit.security.secret.SecretStore;


### PR DESCRIPTION
## Summary
- update plugin module to use tgkit-api packages instead of internal ones

## Testing
- `mvn -q verify` *(fails: module not found webhook)*

------
https://chatgpt.com/codex/tasks/task_e_6856a9352a448325b2273f0e485d5e30