### PR TITLE
Replace internal imports with api packages in boot

### DIFF
--- a/boot/src/main/java/io/github/tgkit/boot/BotAutoConfiguration.java
+++ b/boot/src/main/java/io/github/tgkit/boot/BotAutoConfiguration.java
@@ -19,6 +19,7 @@ import io.github.observability.BotObservability;
 import io.github.observability.MetricsCollector;
 import io.github.observability.impl.NoOpMetricsCollector;
 import io.github.tgkit.security.init.BotSecurityInitializer;
+import io.github.tgkit.api.config.BotGlobalConfig;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -59,16 +60,14 @@ public class BotAutoConfiguration {
     @Override
     public void afterPropertiesSet() {
       collector = BotObservability.micrometer(properties.getMetricsPort());
-      io.github.tgkit.internal.config.BotGlobalConfig.INSTANCE.observability().collector(collector);
+      BotGlobalConfig.INSTANCE.observability().collector(collector);
     }
 
     @Override
     public void destroy() throws Exception {
       if (collector != null) {
         collector.close();
-        io.github.tgkit.internal.config.BotGlobalConfig.INSTANCE
-            .observability()
-            .collector(new NoOpMetricsCollector());
+        BotGlobalConfig.INSTANCE.observability().collector(new NoOpMetricsCollector());
       }
     }
   }

--- a/boot/src/main/java/io/github/tgkit/boot/TelegramBotRunner.java
+++ b/boot/src/main/java/io/github/tgkit/boot/TelegramBotRunner.java
@@ -15,13 +15,13 @@
  */
 package io.github.tgkit.boot;
 
-import io.github.tgkit.internal.bot.Bot;
-import io.github.tgkit.internal.bot.BotAdapter;
-import io.github.tgkit.internal.bot.BotAdapterImpl;
-import io.github.tgkit.internal.bot.BotConfig;
-import io.github.tgkit.internal.bot.BotFactory;
-import io.github.tgkit.internal.bot.TelegramSender;
-import io.github.tgkit.internal.init.BotCoreInitializer;
+import io.github.tgkit.api.bot.Bot;
+import io.github.tgkit.api.BotAdapter;
+import io.github.tgkit.api.bot.BotAdapterImpl;
+import io.github.tgkit.api.bot.BotConfig;
+import io.github.tgkit.api.bot.BotFactory;
+import io.github.tgkit.api.bot.TelegramSender;
+import io.github.tgkit.api.init.BotCoreInitializer;
 import java.util.List;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.springframework.boot.ApplicationArguments;

--- a/boot/src/main/java/module-info.java
+++ b/boot/src/main/java/module-info.java
@@ -1,5 +1,6 @@
 module io.github.tgkit.boot {
   requires io.github.tgkit.core;
+  requires io.github.tgkit.api;
   requires spring.boot;
   requires spring.boot.autoconfigure;
   requires spring.context;

--- a/boot/src/test/java/io/github/tgkit/boot/TelegramBotRunnerTest.java
+++ b/boot/src/test/java/io/github/tgkit/boot/TelegramBotRunnerTest.java
@@ -17,8 +17,8 @@ package io.github.tgkit.boot;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.github.tgkit.internal.bot.Bot;
-import io.github.tgkit.internal.init.BotCoreInitializer;
+import io.github.tgkit.api.bot.Bot;
+import io.github.tgkit.api.init.BotCoreInitializer;
 import io.github.tgkit.testkit.TelegramMockServer;
 import java.util.List;
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
## Summary
- switch Boot module to use `io.github.tgkit.api.*` packages
- update module-info and tests accordingly

## Testing
- `mvn -q -pl boot -am test` *(fails: Spotless format violation)*
- `mvn -q package -DskipTests -Dspotless.check.skip=true` *(fails: module not found `webhook`)*

------
https://chatgpt.com/codex/tasks/task_e_6856a9378b2083258b36043757f1ca90