### PR TITLE
Refactor observability imports to public API

### DIFF
--- a/observability/src/main/java/io/github/observability/ObservabilityInterceptor.java
+++ b/observability/src/main/java/io/github/observability/ObservabilityInterceptor.java
@@ -18,7 +18,7 @@ package io.github.observability;
 import io.github.tgkit.api.BotRequest;
 import io.github.tgkit.api.BotResponse;
 import io.github.tgkit.api.interceptor.BotInterceptor;
-import io.github.tgkit.internal.update.UpdateUtils;
+import io.github.tgkit.api.update.UpdateUtils;
 import io.github.tgkit.observability.Span;
 import io.github.tgkit.observability.Tag;
 import io.github.tgkit.observability.Tags;

--- a/tgkit-api/src/main/java/io/github/tgkit/api/BotRequestType.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/BotRequestType.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api;
+
+import io.github.tgkit.api.exception.BotApiException;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
+import org.telegram.telegrambots.meta.api.objects.ChatJoinRequest;
+import org.telegram.telegrambots.meta.api.objects.ChatMemberUpdated;
+import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.boost.ChatBoostUpdated;
+import org.telegram.telegrambots.meta.api.objects.inlinequery.ChosenInlineQuery;
+import org.telegram.telegrambots.meta.api.objects.inlinequery.InlineQuery;
+import org.telegram.telegrambots.meta.api.objects.payments.PreCheckoutQuery;
+import org.telegram.telegrambots.meta.api.objects.payments.ShippingQuery;
+import org.telegram.telegrambots.meta.api.objects.polls.Poll;
+import org.telegram.telegrambots.meta.api.objects.polls.PollAnswer;
+import org.telegram.telegrambots.meta.api.objects.reactions.MessageReactionCountUpdated;
+import org.telegram.telegrambots.meta.api.objects.reactions.MessageReactionUpdated;
+
+/**
+ * Перечень поддерживаемых типов обновлений Telegram + сведения, обязателен ли userId / chatId для
+ * данного события.
+ */
+public enum BotRequestType {
+
+  /* Update на вход */
+  // user  chat
+  ANY(Update.class, false, false),
+
+  /* Сообщения в чатах */
+  MESSAGE(Message.class, true, true),
+  EDITED_MESSAGE(Message.class, true, true),
+
+  /* Публикации в каналах */
+  CHANNEL_POST(Message.class, false, true),
+  EDITED_CHANNEL_POST(Message.class, false, true),
+
+  /* Inline-клавиатура */
+  CALLBACK_QUERY(CallbackQuery.class, true, false),
+
+  /* Инлайновые запросы */
+  INLINE_QUERY(InlineQuery.class, true, false),
+  CHOSEN_INLINE_QUERY(ChosenInlineQuery.class, true, false),
+
+  /* Платёжные события */
+  SHIPPING_QUERY(ShippingQuery.class, true, false),
+  PRE_CHECKOUT_QUERY(PreCheckoutQuery.class, true, false),
+
+  /* Опросы */
+  POLL(Poll.class, false, false),
+  POLL_ANSWER(PollAnswer.class, true, false),
+
+  /* Изменения статусов участников */
+  CHAT_MEMBER(ChatMemberUpdated.class, true, true),
+  MY_CHAT_MEMBER(ChatMemberUpdated.class, true, true),
+  CHAT_JOIN_REQUEST(ChatJoinRequest.class, true, true),
+
+  /* Реакции */
+  MESSAGE_REACTION(MessageReactionUpdated.class, true, true),
+  MESSAGE_REACTION_COUNT(MessageReactionCountUpdated.class, false, true),
+
+  /* Boost’ы (premium) */
+  CHAT_BOOST(ChatBoostUpdated.class, true, true),
+  REMOVED_CHAT_BOOST(ChatBoostUpdated.class, true, true);
+
+  /** Класс Telegram API, соответствующий типу запроса. */
+  private final @NonNull Class<?> type;
+
+  /** Может ли объект содержать User-ID? */
+  private final boolean hasUserId;
+
+  /** Может ли объект содержать Chat-ID? */
+  private final boolean hasChatId;
+
+  BotRequestType(@NonNull Class<?> type, boolean hasUserId, boolean hasChatId) {
+    this.type = type;
+    this.hasUserId = hasUserId;
+    this.hasChatId = hasChatId;
+  }
+
+  /**
+   * @return true, если userId гарантированно присутствует
+   */
+  public boolean requiresUserId() {
+    return hasUserId;
+  }
+
+  /**
+   * @return true, если chatId гарантированно присутствует
+   */
+  public boolean requiresChatId() {
+    return hasChatId;
+  }
+
+  /**
+   * Проверяет, что переданный тип совместим с данным BotRequestType.
+   *
+   * @param clazz класс для проверки
+   * @throws BotApiException если тип не совместим
+   */
+  @SuppressWarnings("argument")
+  public void checkType(@NonNull Class<?> clazz) {
+    if (!this.type.isAssignableFrom(clazz)) {
+      throw new BotApiException(
+          "%s is not a %s".formatted(clazz.getCanonicalName(), this.type.getSimpleName()));
+    }
+  }
+
+  public @NonNull Class<?> getType() {
+    return type;
+  }
+
+  public boolean isHasUserId() {
+    return hasUserId;
+  }
+
+  public boolean isHasChatId() {
+    return hasChatId;
+  }
+}

--- a/tgkit-api/src/main/java/io/github/tgkit/api/exception/BotApiException.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/exception/BotApiException.java
@@ -13,18 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-module io.github.tgkit.observability {
-  requires io.github.tgkit.core;
-  requires io.github.tgkit.api;
-  requires io.micrometer.core;
-  requires io.opentelemetry.api;
-  requires io.opentelemetry.sdk;
-  requires io.opentelemetry.exporter.logging;
-  requires ch.qos.logback.classic;
-  requires io.micrometer.registry.prometheus;
-  requires io.prometheus.simpleclient_httpserver;
+package io.github.tgkit.api.exception;
 
-  exports io.github.observability;
-  exports io.github.observability.impl to
-      io.github.tgkit.plugin;
+/** Базовый класс исключений, возникающих при обращении к API Telegram. */
+public class BotApiException extends RuntimeException {
+
+  public BotApiException(String message) {
+    super(message);
+  }
+
+  public BotApiException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public BotApiException(Throwable cause) {
+    super(cause);
+  }
 }

--- a/tgkit-api/src/main/java/io/github/tgkit/api/update/UpdateUtils.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/update/UpdateUtils.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.api.update;
+
+import io.github.tgkit.api.BotRequestType;
+import io.github.tgkit.api.exception.BotApiException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.User;
+import org.telegram.telegrambots.meta.api.objects.boost.ChatBoostUpdated;
+
+@SuppressWarnings({"method.invocation", "argument", "type.anno.before.modifier", "return"})
+public final class UpdateUtils {
+  /** Таблица, сопоставляющая условие из Update типу запроса. */
+  private static final Map<Predicate<Update>, BotRequestType> TYPE_MAP =
+      new LinkedHashMap<>() {
+        {
+          put(u -> u.getMessage() != null, BotRequestType.MESSAGE);
+          put(u -> u.getEditedMessage() != null, BotRequestType.EDITED_MESSAGE);
+          put(u -> u.getChannelPost() != null, BotRequestType.CHANNEL_POST);
+          put(u -> u.getEditedChannelPost() != null, BotRequestType.EDITED_CHANNEL_POST);
+          put(u -> u.getShippingQuery() != null, BotRequestType.SHIPPING_QUERY);
+          put(u -> u.getPreCheckoutQuery() != null, BotRequestType.PRE_CHECKOUT_QUERY);
+          put(u -> u.getPoll() != null, BotRequestType.POLL);
+          put(u -> u.getPollAnswer() != null, BotRequestType.POLL_ANSWER);
+          put(u -> u.getChatMember() != null, BotRequestType.CHAT_MEMBER);
+          put(u -> u.getMyChatMember() != null, BotRequestType.MY_CHAT_MEMBER);
+          put(u -> u.getChatJoinRequest() != null, BotRequestType.CHAT_JOIN_REQUEST);
+          put(u -> u.getCallbackQuery() != null, BotRequestType.CALLBACK_QUERY);
+          put(u -> u.getInlineQuery() != null, BotRequestType.INLINE_QUERY);
+          put(u -> u.getChosenInlineQuery() != null, BotRequestType.CHOSEN_INLINE_QUERY);
+          put(u -> u.getMessageReaction() != null, BotRequestType.MESSAGE_REACTION);
+          put(u -> u.getMessageReactionCount() != null, BotRequestType.MESSAGE_REACTION_COUNT);
+          put(u -> u.getChatBoost() != null, BotRequestType.CHAT_BOOST);
+          put(u -> u.getRemovedChatBoost() != null, BotRequestType.REMOVED_CHAT_BOOST);
+        }
+      };
+
+  /** Функции, извлекающие пользователя из update. */
+  private static final List<Function<Update, User>> USER_EXTRACTORS =
+      List.of(
+          u -> u.getMessage() != null ? u.getMessage().getFrom() : null,
+          u -> u.getEditedMessage() != null ? u.getEditedMessage().getFrom() : null,
+          u -> u.getChannelPost() != null ? u.getChannelPost().getFrom() : null,
+          u -> u.getEditedChannelPost() != null ? u.getEditedChannelPost().getFrom() : null,
+          u -> u.getCallbackQuery() != null ? u.getCallbackQuery().getFrom() : null,
+          u -> u.getInlineQuery() != null ? u.getInlineQuery().getFrom() : null,
+          u -> u.getChosenInlineQuery() != null ? u.getChosenInlineQuery().getFrom() : null,
+          u -> u.getShippingQuery() != null ? u.getShippingQuery().getFrom() : null,
+          u -> u.getPreCheckoutQuery() != null ? u.getPreCheckoutQuery().getFrom() : null,
+          u -> u.getPollAnswer() != null ? u.getPollAnswer().getUser() : null,
+          u -> u.getChatMember() != null ? u.getChatMember().getFrom() : null,
+          u -> u.getMyChatMember() != null ? u.getMyChatMember().getFrom() : null,
+          u -> u.getChatJoinRequest() != null ? u.getChatJoinRequest().getUser() : null);
+
+  private UpdateUtils() {}
+
+  /** Определяет тип входящего update, используя таблицу соответствия предикатов и типов запроса. */
+  public static @NonNull BotRequestType getType(@NonNull Update update) {
+    return TYPE_MAP.entrySet().stream()
+        .filter(e -> e.getKey().test(update))
+        .findFirst()
+        .map(Map.Entry::getValue)
+        .orElseThrow(() -> new BotApiException("Unknown update type"));
+  }
+
+  /**
+   * Attempts to extract {@link org.telegram.telegrambots.meta.api.objects.User} from update.
+   *
+   * @throws BotApiException when no user information can be resolved
+   */
+  public static @NonNull User getUser(@NonNull Update update) {
+    return USER_EXTRACTORS.stream()
+        .map(f -> f.apply(update))
+        .filter(Objects::nonNull)
+        .findFirst()
+        .orElseThrow(() -> new BotApiException("User not found in update: " + update));
+  }
+
+  /** Извлекает chat_id из {@link Update}. */
+  public static @Nullable Long resolveChatId(@NonNull Update u) {
+    if (u.getMessage() != null) {
+      return u.getMessage().getChatId();
+    }
+    if (u.getEditedMessage() != null) {
+      return u.getEditedMessage().getChatId();
+    }
+    if (u.getChannelPost() != null) {
+      return u.getChannelPost().getChatId();
+    }
+    if (u.getEditedChannelPost() != null) {
+      return u.getEditedChannelPost().getChatId();
+    }
+    if (u.getCallbackQuery() != null && u.getCallbackQuery().getMessage() != null) {
+      return u.getCallbackQuery().getMessage().getChatId();
+    }
+    if (u.getChatMember() != null) {
+      return u.getChatMember().getChat().getId();
+    }
+    if (u.getMyChatMember() != null) {
+      return u.getMyChatMember().getChat().getId();
+    }
+    if (u.getChatJoinRequest() != null) {
+      return u.getChatJoinRequest().getChat().getId();
+    }
+    if (u.getChatBoost() != null) {
+      var boost = u.getChatBoost();
+      return boost != null && boost.getChat() != null ? boost.getChat().getId() : null;
+    }
+    if (u.getRemovedChatBoost() != null) {
+      var boost = u.getRemovedChatBoost();
+      return boost != null && boost.getChat() != null ? boost.getChat().getId() : null;
+    }
+    // InlineQuery, PreCheckoutQuery, ShippingQuery и другие события не содержат chat_id.
+    return null;
+  }
+
+  /** messageId или {@code null}. */
+  public static @Nullable Integer resolveMessageId(@NonNull Update u) {
+    if (u.getMessage() != null) {
+      return u.getMessage().getMessageId();
+    }
+    if (u.getEditedMessage() != null) {
+      return u.getEditedMessage().getMessageId();
+    }
+    if (u.getChannelPost() != null) {
+      return u.getChannelPost().getMessageId();
+    }
+    if (u.getEditedChannelPost() != null) {
+      return u.getEditedChannelPost().getMessageId();
+    }
+    if (u.getMessageReaction() != null) {
+      return u.getMessageReaction().getMessageId();
+    }
+    if (u.getMessageReactionCount() != null) {
+      return u.getMessageReactionCount().getMessageId();
+    }
+    if (u.getCallbackQuery() != null && u.getCallbackQuery().getMessage() != null) {
+      return u.getCallbackQuery().getMessage().getMessageId();
+    }
+    /* Poll, PollAnswer, InlineQuery, ShippingQuery, Pre-Checkout и др. без messageId */
+    return null;
+  }
+
+  /** userId или {@code null}, если не применимо (анонимные реакции и т.д.). */
+  public @Nullable Long resolveUserId(@NonNull Update update) {
+    User u = getUserQuiet(update);
+    return u != null ? u.getId() : null;
+  }
+
+  /**
+   * Возвращает username пользователя (без @) или {@code null}, если он отсутствует / событие
+   * анонимно.
+   */
+  public @Nullable String resolveUsername(@NonNull Update u) {
+    User user = getUserQuiet(u);
+    return user != null ? user.getUserName() : null;
+  }
+
+  /**
+   * Пытается извлечь «основной» текст из Update. Это может быть: • text обычного сообщения / поста
+   * <br>
+   * • data коллбэка (Inline-кнопка)<br>
+   * • query из InlineQuery / ChosenInlineQuery<br>
+   * • question опроса / викторины<br>
+   * • payload платёжного события (Invoice payload) Если текст отсутствует — возвращает {@code
+   * null}.
+   */
+  public @Nullable String resolveText(@NonNull Update u) {
+    if (u.getMessage() != null) {
+      return u.getMessage().getText();
+    }
+    if (u.getEditedMessage() != null) {
+      return u.getEditedMessage().getText();
+    }
+    if (u.getChannelPost() != null) {
+      return u.getChannelPost().getText();
+    }
+    if (u.getEditedChannelPost() != null) {
+      return u.getEditedChannelPost().getText();
+    }
+
+    if (u.getCallbackQuery() != null) {
+      return u.getCallbackQuery().getData();
+    }
+    if (u.getInlineQuery() != null) {
+      return u.getInlineQuery().getQuery();
+    }
+    if (u.getChosenInlineQuery() != null) {
+      return u.getChosenInlineQuery().getQuery();
+    }
+
+    if (u.getPoll() != null) {
+      return u.getPoll().getQuestion();
+    }
+    if (u.getShippingQuery() != null) {
+      return u.getShippingQuery().getInvoicePayload();
+    }
+    if (u.getPreCheckoutQuery() != null) {
+      return u.getPreCheckoutQuery().getInvoicePayload();
+    }
+
+    /* Boost / Reaction / Member updates не содержат текстового поля */
+    return null;
+  }
+
+  private @Nullable User getUserQuiet(@NonNull Update u) {
+    for (Function<Update, User> f : USER_EXTRACTORS) {
+      User r = f.apply(u);
+      if (r != null) {
+        return r;
+      }
+    }
+    return null;
+  }
+
+  private @Nullable Long chatId(@Nullable ChatBoostUpdated boost) {
+    return boost != null && boost.getChat() != null ? boost.getChat().getId() : null;
+  }
+}


### PR DESCRIPTION
## Summary
- switch ObservabilityInterceptor to use public UpdateUtils
- export BotRequestType and BotApiException in the API module
- add new public UpdateUtils delegating Telegram Update helpers
- require `io.github.tgkit.api` in observability module

## Testing
- `mvn verify` *(fails: project cycle prevents building)*

------
https://chatgpt.com/codex/tasks/task_e_6856b9fe87ac8325b76460cd70ad46b3