### PR TITLE
Add Javadocs for doc2oas CLI

### DIFF
--- a/doc2oas/src/main/java/io/github/tgkit/doc/cli/DocCli.java
+++ b/doc2oas/src/main/java/io/github/tgkit/doc/cli/DocCli.java
@@ -43,6 +43,16 @@ public class DocCli implements Runnable {
   }
 
   @Override
+  /**
+   * Запускает конвертацию документации в спецификацию OpenAPI.
+   *
+   * <p>Если указан {@code --api}, документ загружается с официального сайта. Иначе используется
+   * локальный файл из опции {@code --input}. Результат сохраняется в путь из опции {@code
+   * --output}.
+   *
+   * @throws CommandLine.ParameterException если не задан входной файл и не передан флаг {@code
+   *     --api}
+   */
   public void run() {
     DocumentationService service = new DocumentationService();
     if (fromApi) {

--- a/doc2oas/src/main/java/io/github/tgkit/doc/generator/GeneratorCli.java
+++ b/doc2oas/src/main/java/io/github/tgkit/doc/generator/GeneratorCli.java
@@ -41,6 +41,14 @@ public class GeneratorCli implements Runnable {
   }
 
   @Override
+  /**
+   * Генерирует исходный код SDK из спецификации OpenAPI.
+   *
+   * <p>Параметры командной строки задают путь к YAML-файлу спецификации ({@code --spec}), каталог
+   * для исходников ({@code --target}) и язык генерации ({@code --language}).
+   *
+   * @throws IllegalStateException при ошибке генерации
+   */
   public void run() {
     CodegenConfigurator cfg =
         new CodegenConfigurator()


### PR DESCRIPTION
## Summary
- document behaviour of `DocCli.run()`
- document behaviour of `GeneratorCli.run()`

## Testing
- `mvn -DskipTests=true verify` *(fails: `doc-to-openapi` requires input or `--api`)*

------
https://chatgpt.com/codex/tasks/task_e_6856bbd42f4c832593bc826b8ba0082b