### PR TITLE
Fix TelegramMockServer exception handling

### DIFF
--- a/testkit/src/main/java/io/github/tgkit/testkit/TelegramMockServer.java
+++ b/testkit/src/main/java/io/github/tgkit/testkit/TelegramMockServer.java
@@ -19,6 +19,7 @@ import io.undertow.Undertow;
 import io.undertow.util.Headers;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.Queue;
@@ -66,7 +67,7 @@ public final class TelegramMockServer implements AutoCloseable {
     try (ServerSocket socket = new ServerSocket()) {
       socket.bind(new InetSocketAddress(0));
       return socket.getLocalPort();
-    } catch (Exception e) {
+    } catch (IOException e) {
       throw new IllegalStateException("Failed to allocate port", e);
     }
   }


### PR DESCRIPTION
## Summary
- narrow TelegramMockServer `findFreePort` catch from `Exception` to `IOException`
- adjust imports accordingly

## Testing
- `mvn -pl testkit -am test` *(fails: reactor cyclic reference)*

------
https://chatgpt.com/codex/tasks/task_e_6856cd2ec4d88325a8ba681a40d73ee9