### PR TITLE
Update docs for BOM usage and flag test example

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,16 +81,46 @@ implementation("io.github.tgkit:tgkit-api:0.0.1-SNAPSHOT")
 <summary>TestKit</summary>
 
 ```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>io.github.tgkit</groupId>
+            <artifactId>tgkit-bom</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+
 <dependency>
     <groupId>io.github.tgkit</groupId>
-    <artifactId>testkit</artifactId>
+    <artifactId>tgkit-testkit-core</artifactId>
+    <scope>test</scope>
+</dependency>
+```
+
+```kotlin
+implementation(platform("io.github.tgkit:tgkit-bom:0.0.1-SNAPSHOT"))
+testImplementation("io.github.tgkit:tgkit-testkit-core")
+```
+
+</details>
+
+<details>
+<summary>Flag Test</summary>
+
+```xml
+<dependency>
+    <groupId>io.github.tgkit</groupId>
+    <artifactId>tgkit-flag-test</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <scope>test</scope>
 </dependency>
 ```
 
 ```kotlin
-testImplementation("io.github.tgkit:testkit:0.0.1-SNAPSHOT")
+testImplementation("io.github.tgkit:tgkit-flag-test:0.0.1-SNAPSHOT")
 ```
 
 </details>
@@ -188,6 +218,20 @@ class PingCommandTest {
     void pingPong(UpdateInjector inject, Expectation expect) {
         inject.text("/ping").from(42L);
         expect.api("sendMessage").jsonPath("$.text", "pong");
+    }
+}
+```
+
+```java
+// A/B‑тест: включение флага прямо в тесте
+@ExtendWith(FlagOverrideExtension.class)
+class AbFlowTest {
+
+    @Test
+    void variant(UpdateInjector inject, Expectation expect, Flags flags) {
+        flags.enable("NEW_FLOW");
+        inject.text("/start").from(1L);
+        expect.api("sendMessage").jsonPath("$.text", "new");
     }
 }
 ```

--- a/docs/TESTKIT_README.md
+++ b/docs/TESTKIT_README.md
@@ -10,10 +10,21 @@
 <summary>Maven</summary>
 
 ```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>io.github.tgkit</groupId>
+            <artifactId>tgkit-bom</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+
 <dependency>
     <groupId>io.github.tgkit</groupId>
-    <artifactId>testkit</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <artifactId>tgkit-testkit-core</artifactId>
     <scope>test</scope>
 </dependency>
 ```
@@ -22,7 +33,8 @@
 <summary>Gradle Kotlin DSL</summary>
 
 ```kotlin
-testImplementation("io.github.tgkit:testkit:0.0.1-SNAPSHOT")
+implementation(platform("io.github.tgkit:tgkit-bom:0.0.1-SNAPSHOT"))
+testImplementation("io.github.tgkit:tgkit-testkit-core")
 ```
 </details>
 
@@ -47,4 +59,22 @@ Bot bot = BotBuilder.builder()
         .token("TOKEN")
         .addHandler(new EchoCommands())
         .build();
+```
+
+## Фич-флаги в тестах
+
+Модуль `tgkit-flag-test` содержит расширение `FlagOverrideExtension`.
+Оно позволяет включать или выключать флаги прямо в тестовом методе.
+
+```java
+@ExtendWith(FlagOverrideExtension.class)
+class AbTest {
+
+    @Test
+    void variant(UpdateInjector inject, Expectation expect, Flags flags) {
+        flags.enable("NEW_FLOW");
+        inject.text("/start").from(1L);
+        expect.api("sendMessage").jsonPath("$.text", "new");
+    }
+}
 ```

--- a/examples/testkit-demo/pom.xml
+++ b/examples/testkit-demo/pom.xml
@@ -11,16 +11,26 @@
 
     <artifactId>testkit-demo</artifactId>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.github.tgkit</groupId>
+                <artifactId>tgkit-bom</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>io.github.tgkit</groupId>
             <artifactId>core</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.github.tgkit</groupId>
-            <artifactId>testkit</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <artifactId>tgkit-testkit-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/testkit-demo/src/test/java/io/github/examples/testkitdemo/PingCommandTest.java
+++ b/examples/testkit-demo/src/test/java/io/github/examples/testkitdemo/PingCommandTest.java
@@ -3,13 +3,23 @@ package io.github.examples.testkitdemo;
 import io.github.tgkit.testkit.TelegramBotTest;
 import io.github.tgkit.testkit.UpdateInjector;
 import io.github.tgkit.testkit.Expectation;
+import io.github.tgkit.testkit.TestBotBootstrap;
+import io.github.tgkit.flag.test.FlagOverrideExtension;
+import io.github.tgkit.flag.test.Flags;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(FlagOverrideExtension.class)
 @TelegramBotTest
 class PingCommandTest {
 
+  static {
+    TestBotBootstrap.initOnce();
+  }
+
   @Test
-  void pingPong(UpdateInjector inject, Expectation expect) {
+  void pingPong(UpdateInjector inject, Expectation expect, Flags flags) {
+    flags.enable("PING_CMD");
     inject.text("/ping").from(42L);
     expect.api("sendMessage").jsonPath("$.text", "pong");
   }


### PR DESCRIPTION
## Summary
- document tgkit-bom and tgkit-testkit-core in README
- document same in TestKit README and describe FlagOverrideExtension
- update testkit-demo to use BOM and new artifact
- demo flag override in example test

## Testing
- `mvn verify` *(fails: ProjectCycleException)*

------
https://chatgpt.com/codex/tasks/task_e_6856cd30c01c83258da0e0435db830e0