### PR TITLE
Add property-based testing with jqwik

### DIFF
--- a/flag/pom.xml
+++ b/flag/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.github.tgkit</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>flag</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.github.tgkit</groupId>
+            <artifactId>api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- TEST -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.jqwik</groupId>
+            <artifactId>jqwik</artifactId>
+            <version>1.8.4</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/flag/src/test/java/io/github/tgkit/flag/TgJqwik.java
+++ b/flag/src/test/java/io/github/tgkit/flag/TgJqwik.java
@@ -1,0 +1,66 @@
+package io.github.tgkit.flag;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.github.tgkit.internal.BotInfo;
+import io.github.tgkit.internal.BotService;
+import io.github.tgkit.internal.bot.TelegramSender;
+import io.github.tgkit.internal.dsl.MessageBuilder;
+import io.github.tgkit.internal.dsl.context.DSLContext;
+import io.github.tgkit.internal.i18n.MessageLocalizer;
+import io.github.tgkit.internal.user.BotUserInfo;
+import java.util.Set;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Provide;
+import net.jqwik.api.Property;
+
+/**
+ * Property-based tests for message generation.
+ */
+class TgJqwik {
+
+  /** Provides random {@link DSLContext} instances. */
+  @Provide
+  Arbitrary<DSLContext> contexts() {
+    Arbitrary<Long> chatId = Arbitraries.longs().between(1L, 100_000L);
+    Arbitrary<Long> userId = Arbitraries.longs().between(1L, 100_000L);
+    return Combinators.combine(chatId, userId)
+        .as(
+            (c, u) -> {
+              BotService service = mock(BotService.class);
+              when(service.sender()).thenReturn(mock(TelegramSender.class));
+              when(service.localizer()).thenReturn(mock(MessageLocalizer.class));
+              when(service.userKVStore()).thenReturn(null);
+              when(service.store()).thenReturn(null);
+              BotUserInfo user = mock(BotUserInfo.class);
+              when(user.chatId()).thenReturn(c);
+              when(user.userId()).thenReturn(u);
+              when(user.roles()).thenReturn(Set.of("ADMIN"));
+              return new DSLContext.SimpleDSLContext(service, new BotInfo(1L), user);
+            });
+  }
+
+  /** Provides short random text messages. */
+  @Provide
+  Arbitrary<String> messages() {
+    return Arbitraries.strings().withCharRange(' ', '~').ofMinLength(1).ofMaxLength(100);
+  }
+
+  /**
+   * Builds messages with random inputs and expects no exceptions.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * jqwik.api.Property property = new TgJqwik().messagesDoNotThrow();
+   * }</pre>
+   */
+  @Property(tries = 50)
+  void messagesDoNotThrow(@ForAll("contexts") DSLContext ctx, @ForAll("messages") String text) {
+    new MessageBuilder(ctx, text).build();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <module>benchmarks</module>
         <module>doc2oas</module>
         <module>experiment</module>
+        <module>flag</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
## Summary
- introduce `flag` module with jqwik for property tests
- create `TgJqwik` example generating messages and DSL contexts
- register new module in parent POM

## Testing
- `mvn -q verify` *(fails: cycle in project dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6856cd34d1d4832585fcf451f2e9eddd