### PR TITLE
Implement Expectation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ class PingCommandTest {
 
     @Test
     void pingPong(UpdateInjector inject, Expectation expect) {
-        inject.text("/ping").from(42L);
+        inject.text("/ping").from(42L).dispatch();
         expect.api("sendMessage").jsonPath("$.text", "pong");
     }
 }
@@ -230,7 +230,7 @@ class AbFlowTest {
     @Test
     void variant(UpdateInjector inject, Expectation expect, Flags flags) {
         flags.enable("NEW_FLOW");
-        inject.text("/start").from(1L);
+        inject.text("/start").from(1L).dispatch();
         expect.api("sendMessage").jsonPath("$.text", "new");
     }
 }

--- a/docs/TESTKIT_README.md
+++ b/docs/TESTKIT_README.md
@@ -46,7 +46,7 @@ class EchoBotTest {
 
     @Test
     void echo(UpdateInjector inject, Expectation expect) {
-        inject.text("/echo hello").from(1L);
+        inject.text("/echo hello").from(1L).dispatch();
         expect.api("sendMessage").jsonPath("$.text", "hello");
     }
 }
@@ -73,7 +73,7 @@ class AbTest {
     @Test
     void variant(UpdateInjector inject, Expectation expect, Flags flags) {
         flags.enable("NEW_FLOW");
-        inject.text("/start").from(1L);
+        inject.text("/start").from(1L).dispatch();
         expect.api("sendMessage").jsonPath("$.text", "new");
     }
 }

--- a/examples/testkit-demo/src/test/java/io/github/examples/testkitdemo/PingCommandTest.java
+++ b/examples/testkit-demo/src/test/java/io/github/examples/testkitdemo/PingCommandTest.java
@@ -20,7 +20,7 @@ class PingCommandTest {
   @Test
   void pingPong(UpdateInjector inject, Expectation expect, Flags flags) {
     flags.enable("PING_CMD");
-    inject.text("/ping").from(42L);
+    inject.text("/ping").from(42L).dispatch();
     expect.api("sendMessage").jsonPath("$.text", "pong");
   }
 }

--- a/testkit/pom.xml
+++ b/testkit/pom.xml
@@ -22,6 +22,10 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/testkit/src/main/java/io/github/tgkit/testkit/BotTestExtension.java
+++ b/testkit/src/main/java/io/github/tgkit/testkit/BotTestExtension.java
@@ -33,6 +33,7 @@ public final class BotTestExtension
   private TelegramSender sender;
   private UpdateInjector injector;
   private BotAdapterImpl adapter;
+  private Expectation expectation;
 
   @Override
   public void beforeEach(ExtensionContext context) {
@@ -42,6 +43,7 @@ public final class BotTestExtension
     sender = new TelegramSender(config, "TEST_TOKEN");
     adapter = BotAdapterImpl.builder().internalId(1L).sender(sender).config(config).build();
     injector = new UpdateInjector(adapter, sender);
+    expectation = new Expectation(server);
     // ответ для getMe
     server.enqueue("{\"ok\":true,\"result\":{\"id\":1,\"is_bot\":true,\"username\":\"bot\"}}");
   }
@@ -65,7 +67,8 @@ public final class BotTestExtension
     Class<?> type = parameterContext.getParameter().getType();
     return type == TelegramMockServer.class
         || type == UpdateInjector.class
-        || type == BotAdapterImpl.class;
+        || type == BotAdapterImpl.class
+        || type == Expectation.class;
   }
 
   @Override
@@ -76,6 +79,8 @@ public final class BotTestExtension
       return server;
     } else if (type == UpdateInjector.class) {
       return injector;
+    } else if (type == Expectation.class) {
+      return expectation;
     } else {
       return adapter;
     }

--- a/testkit/src/main/java/io/github/tgkit/testkit/Expectation.java
+++ b/testkit/src/main/java/io/github/tgkit/testkit/Expectation.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 TgKit Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.tgkit.testkit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.tgkit.internal.config.BotGlobalConfig;
+import java.util.concurrent.TimeUnit;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.junit.jupiter.api.Assertions;
+
+/**
+ * Utility for verifying calls to Telegram API in tests.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * inject.text("/ping").from(1L).dispatch();
+ * expect.api("sendMessage").jsonPath("$.text", "pong");
+ * }</pre>
+ */
+public final class Expectation {
+
+  private final TelegramMockServer server;
+  private final ObjectMapper mapper = BotGlobalConfig.INSTANCE.http().getMapper();
+
+  Expectation(@NonNull TelegramMockServer server) {
+    this.server = server;
+  }
+
+  /** Returns expectation for the next API call with given method name. */
+  public ApiExpectation api(@NonNull String method) {
+    return new ApiExpectation(method);
+  }
+
+  /** Checks JSON body of the recorded request. */
+  public final class ApiExpectation {
+    private final String method;
+
+    ApiExpectation(String method) {
+      this.method = method;
+    }
+
+    /** Asserts that JSON at {@code path} equals {@code expected}. */
+    public void jsonPath(@NonNull String path, @NonNull String expected) {
+      try {
+        RecordedRequest req = server.takeRequest(1, TimeUnit.SECONDS);
+        Assertions.assertNotNull(req, "No request captured");
+        Assertions.assertTrue(
+            req.path().endsWith("/" + method),
+            "Expected method " + method + " but was " + req.path());
+        JsonNode body = mapper.readTree(req.body());
+        JsonNode node = body.at(toPointer(path));
+        Assertions.assertFalse(
+            node.isMissingNode(), "Path " + path + " not found in " + req.body());
+        Assertions.assertEquals(expected, node.asText());
+      } catch (Exception e) {
+        throw new AssertionError("Failed to check request", e);
+      }
+    }
+
+    private String toPointer(String jsonPath) {
+      if (jsonPath.startsWith("$")) {
+        String p = jsonPath.substring(1);
+        if (p.startsWith(".")) {
+          p = p.substring(1);
+        }
+        return "/" + p.replace(".", "/");
+      }
+      return jsonPath;
+    }
+  }
+}

--- a/testkit/src/test/java/io/github/tgkit/testkit/ExpectationTest.java
+++ b/testkit/src/test/java/io/github/tgkit/testkit/ExpectationTest.java
@@ -1,0 +1,44 @@
+package io.github.tgkit.testkit;
+
+
+import io.github.tgkit.api.BotCommand;
+import io.github.tgkit.api.BotRequest;
+import io.github.tgkit.api.BotRequestType;
+import io.github.tgkit.api.BotResponse;
+import io.github.tgkit.api.matching.CommandMatch;
+import io.github.tgkit.internal.bot.BotAdapterImpl;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.junit.jupiter.api.Test;
+
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Message;
+
+@TelegramBotTest
+class ExpectationTest {
+
+  @Test
+  void verifiesApiRequest(
+      UpdateInjector inject, Expectation expect, BotAdapterImpl adapter) {
+    adapter.registry().add(new PingCommand());
+    inject.text("/ping").from(1L).dispatch();
+    expect.api("sendMessage").jsonPath("$.text", "pong");
+  }
+
+  private static class PingCommand implements BotCommand<Message> {
+    @Override
+    public BotResponse handle(@NonNull BotRequest<Message> request) {
+      SendMessage msg = new SendMessage(request.msg().getChatId().toString(), "pong");
+      return BotResponse.builder().method(msg).build();
+    }
+
+    @Override
+    public @NonNull BotRequestType type() {
+      return BotRequestType.MESSAGE;
+    }
+
+    @Override
+    public @NonNull CommandMatch<Message> matcher() {
+      return m -> "/ping".equals(m.getText());
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `Expectation` class for convenient API assertions in tests
- inject Expectation via BotTestExtension
- update demo and docs with dispatch usage
- provide unit test for the new helper
- add jackson dependency to testkit module

## Testing
- `mvn -q -pl testkit -am test` *(fails: project has cyclic references)*

------
https://chatgpt.com/codex/tasks/task_e_6856d4562f008325a5ec0dd441697d40