### PR TITLE
Add tests and Jacoco profile

### DIFF
--- a/testkit/pom.xml
+++ b/testkit/pom.xml
@@ -28,4 +28,48 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>strict</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>prepare-agent-strict</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>report-strict</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                    <goal>check</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <rule>
+                                            <element>BUNDLE</element>
+                                            <limits>
+                                                <limit>
+                                                    <counter>LINE</counter>
+                                                    <value>COVEREDRATIO</value>
+                                                    <minimum>0.90</minimum>
+                                                </limit>
+                                            </limits>
+                                        </rule>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/testkit/src/test/java/io/github/tgkit/testkit/BotTestExtensionTest.java
+++ b/testkit/src/test/java/io/github/tgkit/testkit/BotTestExtensionTest.java
@@ -1,0 +1,46 @@
+package io.github.tgkit.testkit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.tgkit.api.BotCommand;
+import io.github.tgkit.api.BotRequest;
+import io.github.tgkit.api.BotRequestType;
+import io.github.tgkit.api.BotResponse;
+import io.github.tgkit.api.matching.CommandMatch;
+import io.github.tgkit.internal.bot.BotAdapterImpl;
+import java.util.concurrent.TimeUnit;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.junit.jupiter.api.Test;
+
+@TelegramBotTest
+class BotTestExtensionTest {
+
+  @Test
+  void extensionInjectsDependencies(
+      UpdateInjector injector, TelegramMockServer server, BotAdapterImpl adapter)
+      throws Exception {
+    adapter.registry().add(new PingCommand());
+    injector.text("/ping").from(1L).dispatch();
+    RecordedRequest req = server.takeRequest(1, TimeUnit.SECONDS);
+    assertThat(req).isNotNull();
+    assertThat(req.path()).endsWith("/sendMessage");
+    assertThat(req.body()).contains("pong");
+  }
+
+  private static class PingCommand implements BotCommand<org.telegram.telegrambots.meta.api.objects.Message> {
+    @Override
+    public BotResponse handle(@NonNull BotRequest<org.telegram.telegrambots.meta.api.objects.Message> request) {
+      return BotResponse.builder().method(request.msg("pong").build()).build();
+    }
+
+    @Override
+    public @NonNull BotRequestType type() {
+      return BotRequestType.MESSAGE;
+    }
+
+    @Override
+    public @NonNull CommandMatch<org.telegram.telegrambots.meta.api.objects.Message> matcher() {
+      return msg -> "/ping".equals(msg.getText());
+    }
+  }
+}

--- a/testkit/src/test/java/io/github/tgkit/testkit/TelegramMockServerTest.java
+++ b/testkit/src/test/java/io/github/tgkit/testkit/TelegramMockServerTest.java
@@ -61,4 +61,26 @@ class TelegramMockServerTest {
       assertThat(recorded.body()).isEmpty();
     }
   }
+
+  @Test
+  void defaultResponseWhenQueueEmpty() throws Exception {
+    try (TelegramMockServer server = new TelegramMockServer()) {
+      var client = java.net.http.HttpClient.newHttpClient();
+      var request =
+          java.net.http.HttpRequest.newBuilder()
+              .uri(java.net.URI.create(server.baseUrl() + "TEST/getMe"))
+              .GET()
+              .build();
+      var response = client.send(request, java.net.http.HttpResponse.BodyHandlers.ofString());
+      assertThat(response.body()).contains("\"ok\":true");
+    }
+  }
+
+  @Test
+  void takeRequestReturnsNullOnTimeout() throws Exception {
+    try (TelegramMockServer server = new TelegramMockServer()) {
+      RecordedRequest req = server.takeRequest(100, java.util.concurrent.TimeUnit.MILLISECONDS);
+      assertThat(req).isNull();
+    }
+  }
 }

--- a/testkit/src/test/java/io/github/tgkit/testkit/UpdateInjectorTest.java
+++ b/testkit/src/test/java/io/github/tgkit/testkit/UpdateInjectorTest.java
@@ -1,0 +1,54 @@
+package io.github.tgkit.testkit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.tgkit.api.BotAdapter;
+import io.github.tgkit.internal.bot.BotConfig;
+import io.github.tgkit.internal.bot.TelegramSender;
+import java.io.Serializable;
+import java.util.concurrent.atomic.AtomicReference;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+class UpdateInjectorTest {
+
+  static class CaptureAdapter implements BotAdapter {
+    final AtomicReference<Update> last = new AtomicReference<>();
+
+    @Override
+    public BotApiMethod<?> handle(@NonNull Update update) {
+      last.set(update);
+      return null;
+    }
+  }
+
+  static class NoopSender extends TelegramSender {
+    NoopSender() {
+      super(BotConfig.builder().build(), "T");
+    }
+
+    @Override
+    public <T extends Serializable, Method extends BotApiMethod<T>> @NonNull T execute(
+        @NonNull Method method) {
+      return null;
+    }
+  }
+
+  @Test
+  void dispatchBuildsUpdateSequentialIds() {
+    CaptureAdapter adapter = new CaptureAdapter();
+    NoopSender sender = new NoopSender();
+    UpdateInjector injector = new UpdateInjector(adapter, sender);
+
+    injector.text("hi").from(10L).dispatch();
+    Update first = adapter.last.get();
+    assertThat(first.getUpdateId()).isEqualTo(1);
+    assertThat(first.getMessage().getChatId()).isEqualTo(10L);
+
+    injector.text("again").from(10L).dispatch();
+    Update second = adapter.last.get();
+    assertThat(second.getUpdateId()).isEqualTo(2);
+  }
+}


### PR DESCRIPTION
## Summary
- add jacoco `strict` profile in `testkit` module
- add tests for `BotTestExtension` and `UpdateInjector`
- extend `TelegramMockServerTest` cases

## Testing
- `mvn verify -q -pl testkit -am` *(fails: ProjectCycleException)*

------
https://chatgpt.com/codex/tasks/task_e_6856d456cf408325bde0dd6fd739e6f7