### PR TITLE
Add feature flag test utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,14 +113,14 @@ testImplementation("io.github.tgkit:tgkit-testkit-core")
 ```xml
 <dependency>
     <groupId>io.github.tgkit</groupId>
-    <artifactId>tgkit-flag-test</artifactId>
+    <artifactId>flag-test</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <scope>test</scope>
 </dependency>
 ```
 
 ```kotlin
-testImplementation("io.github.tgkit:tgkit-flag-test:0.0.1-SNAPSHOT")
+testImplementation("io.github.tgkit:flag-test:0.0.1-SNAPSHOT")
 ```
 
 </details>

--- a/docs/TESTKIT_README.md
+++ b/docs/TESTKIT_README.md
@@ -63,7 +63,7 @@ Bot bot = BotBuilder.builder()
 
 ## Фич-флаги в тестах
 
-Модуль `tgkit-flag-test` содержит расширение `FlagOverrideExtension`.
+Модуль `flag-test` содержит расширение `FlagOverrideExtension`.
 Оно позволяет включать или выключать флаги прямо в тестовом методе.
 
 ```java

--- a/examples/testkit-demo/pom.xml
+++ b/examples/testkit-demo/pom.xml
@@ -33,5 +33,11 @@
             <artifactId>tgkit-testkit-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.github.tgkit</groupId>
+            <artifactId>flag-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/flag-test/pom.xml
+++ b/flag-test/pom.xml
@@ -1,0 +1,49 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.github.tgkit</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>flag-test</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.github.tgkit</groupId>
+            <artifactId>api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/flag-test/src/main/java/io/github/tgkit/flag/test/FlagOverrideExtension.java
+++ b/flag-test/src/main/java/io/github/tgkit/flag/test/FlagOverrideExtension.java
@@ -1,0 +1,44 @@
+package io.github.tgkit.flag.test;
+
+import io.github.tgkit.internal.config.BotGlobalConfig;
+import io.github.tgkit.internal.dsl.feature_flags.FeatureFlags;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+/** JUnit extension that installs {@link FlagOverrideRegistry}. */
+public final class FlagOverrideExtension
+    implements BeforeEachCallback, AfterEachCallback, ParameterResolver {
+  private static final ExtensionContext.Namespace NS =
+      ExtensionContext.Namespace.create(FlagOverrideExtension.class);
+  private static final String KEY = "registry";
+
+  @Override
+  public void beforeEach(ExtensionContext context) {
+    FeatureFlags original = BotGlobalConfig.INSTANCE.dsl().getFeatureFlags();
+    FlagOverrideRegistry registry = new FlagOverrideRegistry(original);
+    BotGlobalConfig.INSTANCE.dsl().featureFlags(registry);
+    context.getStore(NS).put(KEY, registry);
+  }
+
+  @Override
+  public void afterEach(ExtensionContext context) {
+    FlagOverrideRegistry registry = context.getStore(NS).remove(KEY, FlagOverrideRegistry.class);
+    if (registry != null) {
+      BotGlobalConfig.INSTANCE.dsl().featureFlags(registry.original());
+    }
+  }
+
+  @Override
+  public boolean supportsParameter(ParameterContext pc, ExtensionContext ec) {
+    Class<?> type = pc.getParameter().getType();
+    return type == Flags.class || type == FlagOverrideRegistry.class;
+  }
+
+  @Override
+  public Object resolveParameter(ParameterContext pc, ExtensionContext ec) {
+    return ec.getStore(NS).get(KEY, FlagOverrideRegistry.class);
+  }
+}

--- a/flag-test/src/main/java/io/github/tgkit/flag/test/FlagOverrideRegistry.java
+++ b/flag-test/src/main/java/io/github/tgkit/flag/test/FlagOverrideRegistry.java
@@ -1,0 +1,134 @@
+package io.github.tgkit.flag.test;
+
+import io.github.tgkit.internal.dsl.feature_flags.FeatureFlags;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Feature flag implementation for tests. Supports overriding flag values and
+ * collecting branch coverage.
+ */
+public final class FlagOverrideRegistry implements FeatureFlags, Flags {
+  private final FeatureFlags delegate;
+  private final Map<String, Boolean> overrides = new ConcurrentHashMap<>();
+  private final Map<String, BranchCounter> coverage = new ConcurrentHashMap<>();
+
+  /**
+   * Wraps the given {@link FeatureFlags} instance.
+   *
+   * @param delegate real flags store
+   */
+  public FlagOverrideRegistry(@NonNull FeatureFlags delegate) {
+    this.delegate = delegate;
+  }
+
+  /** Returns collected coverage counters. */
+  public @NonNull Map<String, BranchCounter> coverage() {
+    return coverage;
+  }
+
+  /** Clears all overrides and counters. */
+  public void reset() {
+    overrides.clear();
+    coverage.clear();
+  }
+
+  FeatureFlags original() {
+    return delegate;
+  }
+
+  @Override
+  public void enable(String key) {
+    overrides.put(key, Boolean.TRUE);
+  }
+
+  @Override
+  public void disable(String key) {
+    overrides.put(key, Boolean.FALSE);
+  }
+
+  private boolean resolve(String key, boolean actual) {
+    Boolean override = overrides.get(key);
+    boolean result = override != null ? override : actual;
+    coverage.computeIfAbsent(key, k -> new BranchCounter()).hit(result);
+    return result;
+  }
+
+  @Override
+  public boolean isEnabled(@NonNull String key, long chatId) {
+    return resolve(key, delegate.isEnabled(key, chatId));
+  }
+
+  @Override
+  public boolean isEnabledForUser(@NonNull String key, long userId) {
+    return resolve(key, delegate.isEnabledForUser(key, userId));
+  }
+
+  @Override
+  public @NonNull Variant variant(@NonNull String abKey, long entityId) {
+    Variant v = delegate.variant(abKey, entityId);
+    boolean res = v == Variant.VARIANT;
+    coverage.computeIfAbsent(abKey, k -> new BranchCounter()).hit(res);
+    return v;
+  }
+
+  // Delegated modification methods -----------------------------------------
+  @Override
+  public void enableChat(@NonNull String key, long chatId) {
+    delegate.enableChat(key, chatId);
+  }
+
+  @Override
+  public void enableUser(@NonNull String key, long userId) {
+    delegate.enableUser(key, userId);
+  }
+
+  @Override
+  public void disableChat(@NonNull String key, long chatId) {
+    delegate.disableChat(key, chatId);
+  }
+
+  @Override
+  public void disableUser(@NonNull String key, long userId) {
+    delegate.disableUser(key, userId);
+  }
+
+  @Override
+  public void rollout(@NonNull String key, int percent) {
+    delegate.rollout(key, percent);
+  }
+
+  @Override
+  public void disable(@NonNull String key) {
+    delegate.disable(key);
+  }
+
+  @Override
+  public void enable(@NonNull String key) {
+    delegate.enable(key);
+  }
+
+  /** Counter for taken/not-taken branches. */
+  public static final class BranchCounter {
+    private final AtomicInteger taken = new AtomicInteger();
+    private final AtomicInteger skipped = new AtomicInteger();
+
+    void hit(boolean takenBranch) {
+      if (takenBranch) {
+        taken.incrementAndGet();
+      } else {
+        skipped.incrementAndGet();
+      }
+    }
+
+    public int taken() {
+      return taken.get();
+    }
+
+    public int skipped() {
+      return skipped.get();
+    }
+  }
+}

--- a/flag-test/src/main/java/io/github/tgkit/flag/test/Flags.java
+++ b/flag-test/src/main/java/io/github/tgkit/flag/test/Flags.java
@@ -1,0 +1,10 @@
+package io.github.tgkit.flag.test;
+
+/** Simple API to override feature flags in tests. */
+public interface Flags {
+  /** Enable feature flag temporarily. */
+  void enable(String key);
+
+  /** Disable feature flag temporarily. */
+  void disable(String key);
+}

--- a/flag-test/src/test/java/io/github/tgkit/flag/test/FlagOverrideExtensionTest.java
+++ b/flag-test/src/test/java/io/github/tgkit/flag/test/FlagOverrideExtensionTest.java
@@ -1,0 +1,20 @@
+package io.github.tgkit.flag.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.tgkit.internal.config.BotGlobalConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/** Integration test for {@link FlagOverrideExtension}. */
+@ExtendWith(FlagOverrideExtension.class)
+class FlagOverrideExtensionTest {
+
+  @Test
+  void extensionOverridesFlags(Flags flags) {
+    flags.enable("X");
+    boolean enabled =
+        BotGlobalConfig.INSTANCE.dsl().getFeatureFlags().isEnabled("X", 1L);
+    assertThat(enabled).isTrue();
+  }
+}

--- a/flag-test/src/test/java/io/github/tgkit/flag/test/FlagOverrideRegistryTest.java
+++ b/flag-test/src/test/java/io/github/tgkit/flag/test/FlagOverrideRegistryTest.java
@@ -1,0 +1,44 @@
+package io.github.tgkit.flag.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.tgkit.internal.dsl.feature_flags.FeatureFlags;
+import io.github.tgkit.internal.dsl.feature_flags.InMemoryFeatureFlags;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link FlagOverrideRegistry}. */
+class FlagOverrideRegistryTest {
+
+  @Test
+  void overrideTakesPrecedenceAndCountsBranches() {
+    InMemoryFeatureFlags base = new InMemoryFeatureFlags();
+    base.disable("A");
+    FlagOverrideRegistry registry = new FlagOverrideRegistry(base);
+
+    // override to enabled
+    registry.enable("A");
+    boolean first = registry.isEnabled("A", 1L);
+    registry.disable("A");
+    boolean second = registry.isEnabled("A", 1L);
+
+    assertThat(first).isTrue();
+    assertThat(second).isFalse();
+    FlagOverrideRegistry.BranchCounter counter = registry.coverage().get("A");
+    assertThat(counter.taken()).isEqualTo(1);
+    assertThat(counter.skipped()).isEqualTo(1);
+  }
+
+  @Test
+  void delegatesVariantCheck() {
+    InMemoryFeatureFlags base = new InMemoryFeatureFlags();
+    base.rollout("B", 100); // always variant
+    FlagOverrideRegistry registry = new FlagOverrideRegistry(base);
+
+    FeatureFlags.Variant v = registry.variant("B", 1L);
+
+    assertThat(v).isEqualTo(FeatureFlags.Variant.VARIANT);
+    FlagOverrideRegistry.BranchCounter counter = registry.coverage().get("B");
+    assertThat(counter.taken()).isEqualTo(1);
+    assertThat(counter.skipped()).isZero();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <module>doc2oas</module>
         <module>experiment</module>
         <module>flag</module>
+        <module>flag-test</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
## Summary
- add new module `flag-test` with JUnit extension to override feature flags
- expose `FlagOverrideRegistry` for coverage tracking
- update documentation and example to reference the module

## Testing
- `mvn -q -pl flag-test -am test` *(fails: ProjectCycleException)*

------
https://chatgpt.com/codex/tasks/task_e_6856d45730788325a0466147d5b0a94a