### PR TITLE
Implement reactive testkit transport

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -19,7 +19,7 @@
         </dependency>
         <dependency>
             <groupId>io.github.tgkit</groupId>
-            <artifactId>testkit</artifactId>
+            <artifactId>tgkit-testkit-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <!-- JMH -->

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <picocli.version>4.7.5</picocli.version>
         <openapi-parser.version>2.2.2</openapi-parser.version>
         <openapi-generator.version>7.13.0</openapi-generator.version>
+        <reactor.version>3.6.6</reactor.version>
 
         <!-- PLUGINS -->
         <checkerframework.version>3.49.4</checkerframework.version>
@@ -244,6 +245,17 @@
                 <groupId>info.picocli</groupId>
                 <artifactId>picocli</artifactId>
                 <version>${picocli.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.projectreactor</groupId>
+                <artifactId>reactor-core</artifactId>
+                <version>${reactor.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.tgkit</groupId>
+                <artifactId>tgkit-testkit-core</artifactId>
+                <version>${project.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/testkit/pom.xml
+++ b/testkit/pom.xml
@@ -9,7 +9,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>testkit</artifactId>
+    <artifactId>tgkit-testkit-core</artifactId>
 
     <dependencies>
         <dependency>
@@ -26,6 +26,25 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/testkit/src/main/java/io/github/tgkit/testkit/core/BotMethod.java
+++ b/testkit/src/main/java/io/github/tgkit/testkit/core/BotMethod.java
@@ -1,0 +1,7 @@
+package io.github.tgkit.testkit.core;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+
+/** Обертка над {@link BotApiMethod}, используемая в тестовой транспортной системе. */
+public record BotMethod<T>(@NonNull BotApiMethod<T> method) {}

--- a/testkit/src/main/java/io/github/tgkit/testkit/core/FakeTransport.java
+++ b/testkit/src/main/java/io/github/tgkit/testkit/core/FakeTransport.java
@@ -1,0 +1,42 @@
+package io.github.tgkit.testkit.core;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.reactivestreams.Publisher;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
+
+/**
+ * Простая транспортная прослойка для тестов. Позволяет отправлять {@link Update}
+ * и отслеживать вызовы к Telegram API.
+ */
+public final class FakeTransport {
+
+  private final Sinks.Many<Update> updateSink = Sinks.many().unicast().onBackpressureBuffer();
+  private final Sinks.Many<BotMethod<?>> methodSink = Sinks.many().unicast().onBackpressureBuffer();
+
+  /** Получает поток входящих обновлений. */
+  public @NonNull Flux<Update> updates() {
+    return updateSink.asFlux();
+  }
+
+  /** Получает поток отправляемых методов. */
+  public @NonNull Flux<BotMethod<?>> methods() {
+    return methodSink.asFlux();
+  }
+
+  /** Публикует новое обновление. */
+  public void emit(@NonNull Update update) {
+    updateSink.tryEmitNext(update);
+  }
+
+  /** Записывает вызов Telegram API. */
+  public void record(@NonNull BotMethod<?> method) {
+    methodSink.tryEmitNext(method);
+  }
+
+  void complete() {
+    updateSink.tryEmitComplete();
+    methodSink.tryEmitComplete();
+  }
+}

--- a/testkit/src/main/java/io/github/tgkit/testkit/core/TgTestKit.java
+++ b/testkit/src/main/java/io/github/tgkit/testkit/core/TgTestKit.java
@@ -1,0 +1,86 @@
+package io.github.tgkit.testkit.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.tgkit.api.BotAdapter;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Objects;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.junit.jupiter.api.Assertions;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Chat;
+import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import reactor.core.Disposable;
+
+/**
+ * DSL для удобного тестирования ботов. Использует {@link FakeTransport} как ис
+ * точник данных.
+ */
+public final class TgTestKit {
+
+  private final FakeTransport transport = new FakeTransport();
+  private final Disposable subscription;
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  public TgTestKit(@NonNull BotAdapter adapter) {
+    subscription =
+        transport
+            .updates()
+            .concatMap(
+                u ->
+                    reactor.core.publisher.Mono.fromCallable(
+                            () -> adapter.handle(u))
+                        .doOnNext(
+                            m -> {
+                              if (m != null) {
+                                transport.record(new BotMethod<>(m));
+                              }
+                            }))
+            .subscribe();
+  }
+
+  /** Отправляет текстовое сообщение от указанного пользователя. */
+  public @NonNull TgTestKit sendText(long chatId, @NonNull String text) {
+    Message msg = new Message();
+    msg.setText(text);
+    Chat chat = new Chat();
+    chat.setId(chatId);
+    msg.setChat(chat);
+    Update update = new Update();
+    update.setMessage(msg);
+    transport.emit(update);
+    return this;
+  }
+
+  /** Проверяет текст ответа. */
+  public @NonNull TgTestKit expectReply(@NonNull String text) {
+    BotMethod<?> method =
+        transport.methods().blockFirst(Duration.ofSeconds(1));
+    Assertions.assertNotNull(method, "No reply emitted");
+    BotApiMethod<?> raw = method.method();
+    Assertions.assertTrue(raw instanceof SendMessage, "Unexpected method " + raw.getClass());
+    Assertions.assertEquals(text, ((SendMessage) raw).getText());
+    return this;
+  }
+
+  /** Сравнивает сериализованный ответ с JSON из ресурсов. */
+  public @NonNull TgTestKit expectJsonSnapshot(@NonNull String resourcePath) throws Exception {
+    BotMethod<?> method =
+        transport.methods().blockFirst(Duration.ofSeconds(1));
+    Assertions.assertNotNull(method, "No reply emitted");
+    String actual = mapper.writeValueAsString(method.method());
+    var is = TgTestKit.class.getClassLoader().getResourceAsStream(resourcePath);
+    Objects.requireNonNull(is, "Snapshot " + resourcePath + " not found");
+    String expected = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+    Assertions.assertEquals(expected.trim(), actual);
+    return this;
+  }
+
+  /** Завершает работу тестового конвейера. */
+  public void end() {
+    transport.complete();
+    subscription.dispose();
+  }
+}

--- a/testkit/src/test/java/io/github/tgkit/testkit/core/FakeTransportTest.java
+++ b/testkit/src/test/java/io/github/tgkit/testkit/core/FakeTransportTest.java
@@ -1,0 +1,19 @@
+package io.github.tgkit.testkit.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+class FakeTransportTest {
+
+  @Test
+  void emitsUpdates() {
+    FakeTransport transport = new FakeTransport();
+    Update u = new Update();
+    transport.emit(u);
+    Update received = transport.updates().blockFirst(Duration.ofSeconds(1));
+    assertThat(received).isSameAs(u);
+  }
+}

--- a/testkit/src/test/java/io/github/tgkit/testkit/core/TgTestKitTest.java
+++ b/testkit/src/test/java/io/github/tgkit/testkit/core/TgTestKitTest.java
@@ -1,0 +1,30 @@
+package io.github.tgkit.testkit.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.tgkit.api.BotAdapter;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+class TgTestKitTest {
+
+  @Test
+  void sendAndExpect() {
+    BotAdapter adapter =
+        update -> new SendMessage(update.getMessage().getChatId().toString(), "pong");
+
+    TgTestKit kit = new TgTestKit(adapter);
+    kit.sendText(1L, "ping").expectReply("pong").end();
+  }
+
+  @Test
+  void jsonSnapshot() throws Exception {
+    BotAdapter adapter =
+        update -> new SendMessage(update.getMessage().getChatId().toString(), "pong");
+    TgTestKit kit = new TgTestKit(adapter);
+    kit.sendText(1L, "ping").expectJsonSnapshot("snapshot.json").end();
+  }
+}

--- a/testkit/src/test/resources/snapshot.json
+++ b/testkit/src/test/resources/snapshot.json
@@ -1,0 +1,1 @@
+{"chat_id":"1","text":"pong"}

--- a/webhook/pom.xml
+++ b/webhook/pom.xml
@@ -46,7 +46,7 @@
         <!-- TEST -->
         <dependency>
             <groupId>io.github.tgkit</groupId>
-            <artifactId>testkit</artifactId>
+            <artifactId>tgkit-testkit-core</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
## Summary
- add Reactor to BOM
- build testkit as test-jar
- introduce FakeTransport and TgTestKit DSL
- update modules to use new artifact

## Testing
- `mvn -q -pl testkit -DskipTests=true verify` *(fails: ProjectCycleException)*

------
https://chatgpt.com/codex/tasks/task_e_6856d4566f748325aa768f982ac49aa9