### PR TITLE
Remove webhook optional dependency

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -32,6 +32,11 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.github.tgkit</groupId>
+            <artifactId>webhook</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!-- CHECKS -->
         <dependency>

--- a/tgkit-api/pom.xml
+++ b/tgkit-api/pom.xml
@@ -32,12 +32,6 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.github.tgkit</groupId>
-            <artifactId>webhook</artifactId>
-            <version>${project.version}</version>
-            <optional>true</optional>
-        </dependency>
 
         <!-- CHECKS -->
         <dependency>

--- a/tgkit-api/src/main/java/module-info.java
+++ b/tgkit-api/src/main/java/module-info.java
@@ -20,7 +20,6 @@ module io.github.tgkit.api {
   requires transitive java.net.http;
   requires transitive org.apache.httpcomponents.httpclient;
   requires transitive org.apache.httpcomponents.httpcore;
-  requires static webhook;
   requires static com.fasterxml.jackson.annotation;
   requires static org.checkerframework.checker.qual;
 


### PR DESCRIPTION
## Summary
- clean tgkit-api module dependencies
- link webhook explicitly from api
- update module-info

## Testing
- `mvn -q verify` *(fails: package okhttp3 does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6856e34ce30483259401d2738c9d4c85