### PR TITLE
Fix ChildFirstURLClassLoader package

### DIFF
--- a/plugin/src/main/java/io/github/tgkit/plugin/BotPluginManager.java
+++ b/plugin/src/main/java/io/github/tgkit/plugin/BotPluginManager.java
@@ -24,6 +24,7 @@ import io.github.tgkit.api.exception.BotApiException;
 import io.github.tgkit.plugin.internal.BotPluginContainer;
 import io.github.tgkit.plugin.internal.BotPluginContextDefault;
 import io.github.tgkit.plugin.internal.BotPluginDescriptor;
+import io.github.tgkit.plugin.internal.ChildFirstURLClassLoader;
 import io.github.tgkit.plugin.internal.sort.TopoSorter;
 import io.github.tgkit.security.audit.AuditBus;
 import io.github.tgkit.security.audit.AuditEvent;

--- a/plugin/src/main/java/io/github/tgkit/plugin/internal/ChildFirstURLClassLoader.java
+++ b/plugin/src/main/java/io/github/tgkit/plugin/internal/ChildFirstURLClassLoader.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.tgkit.plugin;
+package io.github.tgkit.plugin.internal;
 
 import java.net.URL;
 import java.net.URLClassLoader;


### PR DESCRIPTION
## Summary
- put `ChildFirstURLClassLoader` into `io.github.tgkit.plugin.internal`
- update BotPluginManager import

## Testing
- `mvn -pl plugin spotless:apply`
- `mvn -pl plugin -am test` *(fails: Could not find symbol okhttp3)*

------
https://chatgpt.com/codex/tasks/task_e_6856e817e158832591928ad472ebc953