### PR TITLE
Fix pre-commit hook instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,8 @@ Apache License 2.0 © 2025 TgKit Team
 Для автоматического форматирования и проверки стиля перед коммитом подключите локальный хук:
 
 ```bash
-ln -s ../../githooks/pre-commit .git/hooks/pre-commit
+# Выполняйте команду из корня проекта
+ln -s ../githooks/pre-commit .git/hooks/pre-commit
 ```
 
 Коммит будет прерван, если `mvn -q checkstyle:check` обнаружит нарушения.


### PR DESCRIPTION
## Summary
- correct relative path for pre-commit hook
- advise running command from repo root

## Testing
- `mvn -q verify` *(fails: cannot find symbol BufferedSink)*

------
https://chatgpt.com/codex/tasks/task_e_6856f471cde48325ac092222e2ca70c7