### PR TITLE
Update CONTRIBUTING with proxy details

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,3 +18,24 @@ mvn test
 ```
 
 Перед отправкой изменений убедитесь, что тесты выполняются без ошибок.
+
+## Настройка Maven и прокси
+
+Для сборки требуется установленный Maven. В среде Codex перед запуском
+не забудьте задать переменные окружения для работы через прокси:
+
+```bash
+export http_proxy=http://proxy:8080
+export https_proxy=http://proxy:8080
+export MAVEN_OPTS="-Dhttps.proxyHost=proxy -Dhttps.proxyPort=8080 \
+-Dhttp.proxyHost=proxy -Dhttp.proxyPort=8080 \
+-Djava.net.preferIPv4Stack=true -Dfile.encoding=UTF-8"
+```
+
+После изменений обязательно выполните:
+
+```bash
+mvn verify
+```
+
+и только затем отправляйте коммит.


### PR DESCRIPTION
## Summary
- document proxy variables for Maven usage
- remind contributors to run `mvn verify` before committing

## Testing
- `mvn verify` *(fails: cannot find symbol BufferedSink)*

------
https://chatgpt.com/codex/tasks/task_e_6856fbba284c8325aaa888d9dfc6acde