### PR TITLE
Update plugin API version constant

### DIFF
--- a/plugin/src/main/java/io/github/tgkit/plugin/BotPluginManager.java
+++ b/plugin/src/main/java/io/github/tgkit/plugin/BotPluginManager.java
@@ -65,7 +65,7 @@ public final class BotPluginManager implements AutoCloseable {
   private static final MessageDigest MESSAGE_DIGEST;
   private static final long SHUTDOWN_TIMEOUT_MS = 500;
   private static final Version SUPPORTED_API_VERSION =
-      Version.valueOf(String.format("%.1f.0", CURRENT_VERSION));
+      Version.valueOf(normalizeVersion(CURRENT_VERSION));
 
   static {
     try {

--- a/plugin/src/main/java/io/github/tgkit/plugin/internal/BotPluginConstants.java
+++ b/plugin/src/main/java/io/github/tgkit/plugin/internal/BotPluginConstants.java
@@ -21,14 +21,15 @@ package io.github.tgkit.plugin;
  * <p>Пример использования:
  *
  * <pre>{@code
- * if (descriptor.api() > BotPluginConstants.CURRENT_VERSION) {
+ * if (descriptor.api().compareTo(BotPluginConstants.CURRENT_VERSION) > 0) {
  *     throw new UnsupportedOperationException();
  * }
- * }</pre>
+ * }
+ * </pre>
  */
 public class BotPluginConstants {
   /** Текущая поддерживаемая версия API плагинов. */
-  public static final Double CURRENT_VERSION = 0.1;
+  public static final String CURRENT_VERSION = "0.1";
 
   private BotPluginConstants() {}
 }

--- a/plugin/src/test/java/io/github/tgkit/plugin/BotPluginManagerTest.java
+++ b/plugin/src/test/java/io/github/tgkit/plugin/BotPluginManagerTest.java
@@ -95,8 +95,8 @@ public class BotPluginManagerTest {
     createPluginJar(
         jar,
         "test-id",
-        String.valueOf(CURRENT_VERSION),
-        String.valueOf(CURRENT_VERSION),
+        CURRENT_VERSION,
+        CURRENT_VERSION,
         TestPlugin.class.getName(),
         null);
 
@@ -145,7 +145,7 @@ public class BotPluginManagerTest {
     // плагин требует более новую версию API
     Path jar = tempDir.resolve("ver.jar");
     createPluginJar(
-        jar, "id", String.valueOf(CURRENT_VERSION), "1.0.0", TestPlugin.class.getName(), null);
+        jar, "id", CURRENT_VERSION, "1.0.0", TestPlugin.class.getName(), null);
 
     manager.loadAll(tempDir);
 
@@ -164,8 +164,8 @@ public class BotPluginManagerTest {
     createPluginJar(
         jar,
         "id2",
-        String.valueOf(CURRENT_VERSION),
-        String.valueOf(CURRENT_VERSION),
+        CURRENT_VERSION,
+        CURRENT_VERSION,
         TestPlugin.class.getName(),
         "deadbeef");
 
@@ -183,7 +183,7 @@ public class BotPluginManagerTest {
   void testApiInvalidFormat() throws Exception {
     Path jar = tempDir.resolve("badapi.jar");
     createPluginJar(
-        jar, "bad", String.valueOf(CURRENT_VERSION), "one.two", TestPlugin.class.getName(), null);
+        jar, "bad", CURRENT_VERSION, "one.two", TestPlugin.class.getName(), null);
 
     manager.loadAll(tempDir);
 
@@ -201,8 +201,8 @@ public class BotPluginManagerTest {
     createPluginJar(
         jar,
         "thread",
-        String.valueOf(CURRENT_VERSION),
-        String.valueOf(CURRENT_VERSION),
+        CURRENT_VERSION,
+        CURRENT_VERSION,
         ThreadNamePlugin.class.getName(),
         null);
 
@@ -220,7 +220,7 @@ public class BotPluginManagerTest {
         jar,
         "reload",
         "1.0",
-        String.valueOf(CURRENT_VERSION),
+        CURRENT_VERSION,
         ReloadPluginV1.class.getName(),
         null);
 
@@ -232,7 +232,7 @@ public class BotPluginManagerTest {
         jar,
         "reload",
         "2.0",
-        String.valueOf(CURRENT_VERSION),
+        CURRENT_VERSION,
         ReloadPluginV2.class.getName(),
         null);
 
@@ -247,7 +247,7 @@ public class BotPluginManagerTest {
   void testHotReloadDescriptorFailure() throws Exception {
     Path jar = tempDir.resolve("fail.jar");
     createPluginJar(
-        jar, "fail", "1.0", String.valueOf(CURRENT_VERSION), ReloadPluginV1.class.getName(), null);
+        jar, "fail", "1.0", CURRENT_VERSION, ReloadPluginV1.class.getName(), null);
 
     manager.loadAll(tempDir);
     assertEquals("v1", System.getProperty("reload.phase"));
@@ -275,8 +275,8 @@ public class BotPluginManagerTest {
     createPluginJar(
         jar,
         "slow",
-        String.valueOf(CURRENT_VERSION),
-        String.valueOf(CURRENT_VERSION),
+        CURRENT_VERSION,
+        CURRENT_VERSION,
         SlowPlugin.class.getName(),
         null);
 


### PR DESCRIPTION
## Summary
- switch plugin API version constant from `Double` to `String`
- adjust `BotPluginManager` to parse the string API version
- fix tests to use the string constant

## Testing
- `mvn -q verify` *(fails: cannot find symbol javax.annotation, okhttp3, etc.)*
- `mvn -q -pl plugin -am verify` *(fails: cannot find symbol BufferedSink, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6856fbd3c6c883258fa1cb5d7d28abb6