### PR TITLE
Add russian javadocs for user API

### DIFF
--- a/tgkit-api/src/main/java/io/github/tgkit/api/BotCommand.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/BotCommand.java
@@ -60,10 +60,25 @@ public interface BotCommand<T> {
    */
   @NonNull List<BotInterceptor> interceptors();
 
+  /**
+   * Задаёт правило сопоставления команды.
+   *
+   * @param matcher правило сопоставления
+   */
   void setMatcher(@NonNull CommandMatch<T> matcher);
 
+  /**
+   * Устанавливает тип обрабатываемого запроса.
+   *
+   * @param type тип запроса
+   */
   void setType(@NonNull BotRequestType type);
 
+  /**
+   * Определяет группу команд, к которой относится обработчик.
+   *
+   * @param group название группы
+   */
   void setBotGroup(@NonNull String group);
 
   /**

--- a/tgkit-api/src/main/java/io/github/tgkit/api/user/BotUserInfo.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/user/BotUserInfo.java
@@ -20,16 +20,27 @@ import java.util.Set;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+/**
+ * Сводная информация о пользователе Telegram.
+ *
+ * <p>Используется при авторизации и персонализации, содержит основные идентификаторы и роли
+ * пользователя.
+ */
 public interface BotUserInfo {
 
+  /** Идентификатор чата, если известен. */
   @Nullable Long chatId();
 
+  /** Идентификатор пользователя Telegram. */
   @Nullable Long userId();
 
+  /** Внутренний идентификатор пользователя в системе. */
   @Nullable Long internalUserId();
 
+  /** Набор ролей пользователя. */
   @NonNull Set<String> roles();
 
+  /** Локаль пользователя для выбора языка сообщений. */
   default @Nullable Locale locale() {
     return null;
   }

--- a/tgkit-api/src/main/java/io/github/tgkit/api/user/BotUserProvider.java
+++ b/tgkit-api/src/main/java/io/github/tgkit/api/user/BotUserProvider.java
@@ -18,6 +18,19 @@ package io.github.tgkit.api.user;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.telegram.telegrambots.meta.api.objects.Update;
 
+/**
+ * Поставщик информации о пользователе.
+ *
+ * <p>Инкапсулирует логику извлечения {@link BotUserInfo} из обновлений Telegram или внешних
+ * источников данных.
+ */
 public interface BotUserProvider {
+
+  /**
+   * Получает сведения о пользователе на основе входящего {@link Update}.
+   *
+   * @param update обновление Telegram
+   * @return заполненная структура {@link BotUserInfo}
+   */
   @NonNull BotUserInfo resolve(@NonNull Update update);
 }


### PR DESCRIPTION
## Summary
- document `BotUserInfo` fields and default method
- document `BotUserProvider` and its `resolve` method
- add javadocs for setters in `BotCommand`

## Testing
- `mvn -q -pl tgkit-api spotless:apply`
- `mvn -q -pl tgkit-api spotless:check`
- `mvn -q -pl tgkit-api checkstyle:check`
- `mvn -q -pl tgkit-api verify` *(fails: cannot find symbol okhttp3)*
- `mvn -q javadoc:javadoc` *(fails: Aggregator report contains named and unnamed modules)*

------
https://chatgpt.com/codex/tasks/task_e_6856fbb627188325acace63e3c7ffb3a