### PR TITLE
Add descriptor validation

### DIFF
--- a/plugin/src/main/java/io/github/tgkit/plugin/internal/BotPluginDescriptor.java
+++ b/plugin/src/main/java/io/github/tgkit/plugin/internal/BotPluginDescriptor.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 
 /** Описатель плагина, маппится из plugin.yml и обратно. */
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
@@ -199,6 +200,21 @@ public final class BotPluginDescriptor {
     }
 
     public BotPluginDescriptor build() {
+      if (StringUtils.isBlank(id)) {
+        throw new IllegalStateException("id must not be null or empty");
+      }
+      if (StringUtils.isBlank(version)) {
+        throw new IllegalStateException("version must not be null or empty");
+      }
+      if (StringUtils.isBlank(api)) {
+        throw new IllegalStateException("api must not be null or empty");
+      }
+      if (StringUtils.isBlank(mainClass)) {
+        throw new IllegalStateException("mainClass must not be null or empty");
+      }
+      if (StringUtils.isBlank(minCoreVersion)) {
+        throw new IllegalStateException("minCoreVersion must not be null or empty");
+      }
       return new BotPluginDescriptor(
           id,
           name,

--- a/plugin/src/test/java/io/github/tgkit/plugin/BotPluginManagerTest.java
+++ b/plugin/src/test/java/io/github/tgkit/plugin/BotPluginManagerTest.java
@@ -311,6 +311,20 @@ public class BotPluginManagerTest {
     verify(auditBus).publish(argThat(evt -> evt.getAction().contains("plugin.yml missing")));
   }
 
+  @Test
+  void testDescriptorBuilderMissingRequiredField() {
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            BotPluginDescriptor.builder()
+                .id("test")
+                .version("1.0")
+                // api not set
+                .mainClass("main")
+                .minCoreVersion("1.0")
+                .build());
+  }
+
   public static class TestPlugin implements BotPlugin {
     @Override
     public void onLoad(@NonNull BotPluginContext context) {}


### PR DESCRIPTION
## Summary
- add null/empty checks to `BotPluginDescriptor.Builder.build`
- cover error branch with unit test

## Testing
- `mvn -q -pl plugin -am verify` *(fails: cannot find symbol: BufferedSink)*

------
https://chatgpt.com/codex/tasks/task_e_6856fbc966a48325b5ed2be93fadaec7